### PR TITLE
Issue #16 - split the UI into read-only and full admin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,5 +42,7 @@ frontend/.vite/
 .DS_Store
 
 # front-end build output:
+backend/src/main/resources/static/assets/
+backend/src/main/resources/static/index.html
 backend/src/main/resources/static/frontend
 frontend/node

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # MovieNight
 A media organizing and playing application
+
+## Interfaces
+- `/` provides the public read-only media browser.
+- `/admin` provides the localhost-only admin interface for create, edit, and delete actions.
+
+## Admin authentication
+- Admin access requires HTTP Basic authentication and must originate from localhost.
+- Override the default credentials with `MOVIENIGHT_ADMIN_USERNAME` and `MOVIENIGHT_ADMIN_PASSWORD`.

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -54,10 +54,21 @@
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
 
+        <!-- Security -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+
         <!-- Testing -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/backend/src/main/java/ca/corbett/movienight/config/SecurityConfig.java
+++ b/backend/src/main/java/ca/corbett/movienight/config/SecurityConfig.java
@@ -1,0 +1,89 @@
+package ca.corbett.movienight.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.authorization.AuthorizationDecision;
+import org.springframework.security.authorization.AuthorizationManager;
+import org.springframework.security.authorization.AuthorizationManagers;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.intercept.RequestAuthorizationContext;
+import org.springframework.security.config.http.SessionCreationPolicy;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import static org.springframework.security.authorization.AuthorityAuthorizationManager.hasRole;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(
+            HttpSecurity http,
+            AuthorizationManager<RequestAuthorizationContext> localhostOnlyAccess
+    ) throws Exception {
+        AuthorizationManager<RequestAuthorizationContext> adminAccess =
+                AuthorizationManagers.allOf(localhostOnlyAccess, hasRole("ADMIN"));
+
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(Customizer.withDefaults())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                        .requestMatchers("/", "/frontend/**", "/favicon.svg", "/error").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/**").permitAll()
+                        .requestMatchers("/admin", "/admin/**").access(adminAccess)
+                        .requestMatchers(HttpMethod.POST, "/api/**").access(adminAccess)
+                        .requestMatchers(HttpMethod.PUT, "/api/**").access(adminAccess)
+                        .requestMatchers(HttpMethod.DELETE, "/api/**").access(adminAccess)
+                        .anyRequest().denyAll()
+                );
+
+        return http.build();
+    }
+
+    @Bean
+    public AuthorizationManager<RequestAuthorizationContext> localhostOnlyAccess() {
+        return (authentication, context) ->
+                new AuthorizationDecision(isLoopbackAddress(context.getRequest().getRemoteAddr()));
+    }
+
+    @Bean
+    public UserDetailsService userDetailsService(
+            @Value("${movienight.admin.username}") String username,
+            @Value("${movienight.admin.password}") String password,
+            PasswordEncoder passwordEncoder
+    ) {
+        return new InMemoryUserDetailsManager(
+                User.withUsername(username)
+                        .password(passwordEncoder.encode(password))
+                        .roles("ADMIN")
+                        .build()
+        );
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    private boolean isLoopbackAddress(String remoteAddress) {
+        try {
+            return InetAddress.getByName(remoteAddress).isLoopbackAddress();
+        } catch (UnknownHostException e) {
+            return false;
+        }
+    }
+}

--- a/backend/src/main/java/ca/corbett/movienight/controller/SpaForwardController.java
+++ b/backend/src/main/java/ca/corbett/movienight/controller/SpaForwardController.java
@@ -1,0 +1,13 @@
+package ca.corbett.movienight.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class SpaForwardController {
+
+    @GetMapping({"/", "/admin", "/admin/{*path}"})
+    public String forwardToSpa() {
+        return "forward:/frontend/index.html";
+    }
+}

--- a/backend/src/main/resources/application-dev.properties
+++ b/backend/src/main/resources/application-dev.properties
@@ -5,3 +5,7 @@ spring.datasource.url=jdbc:sqlite:movienight.db
 
 # Thumbnail storage directory (leave empty to disable thumbnail support in dev)
 movienight.data-dir=
+
+# Credentials for basic auth access to the admin API in dev:
+movienight.admin.username=${MOVIENIGHT_ADMIN_USERNAME:admin}
+movienight.admin.password=${MOVIENIGHT_ADMIN_PASSWORD:password}

--- a/backend/src/main/resources/application-prod.properties
+++ b/backend/src/main/resources/application-prod.properties
@@ -1,7 +1,12 @@
 # Prod profile: environment-variable-backed values with sensible fallback defaults
 
-# SQLite database path – set MOVIENIGHT_DB_PATH to override
+# SQLite database path - set MOVIENIGHT_DB_PATH to override
 spring.datasource.url=jdbc:sqlite:${MOVIENIGHT_DB_PATH:/var/lib/movienight/movienight.db}
 
-# Thumbnail storage directory – set MOVIENIGHT_DATA_DIR to override
+# Thumbnail storage directory - set MOVIENIGHT_DATA_DIR to override
 movienight.data-dir=${MOVIENIGHT_DATA_DIR:/var/lib/movienight/data-dir}
+
+# Change these credentials in production! These defaults are just placeholders.
+# Alternatively, override with environment variables MOVIENIGHT_ADMIN_USERNAME and MOVIENIGHT_ADMIN_PASSWORD.
+movienight.admin.username=${MOVIENIGHT_ADMIN_USERNAME:admin}
+movienight.admin.password=${MOVIENIGHT_ADMIN_PASSWORD:change-me}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -15,3 +15,7 @@ spring.jpa.properties.hibernate.format_sql=true
 
 # Disable open-in-view warning
 spring.jpa.open-in-view=false
+
+# Admin credentials for the localhost-only admin interface
+movienight.admin.username=${MOVIENIGHT_ADMIN_USERNAME:admin}
+movienight.admin.password=${MOVIENIGHT_ADMIN_PASSWORD:change-me}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -15,7 +15,3 @@ spring.jpa.properties.hibernate.format_sql=true
 
 # Disable open-in-view warning
 spring.jpa.open-in-view=false
-
-# Admin credentials for the localhost-only admin interface
-movienight.admin.username=${MOVIENIGHT_ADMIN_USERNAME:admin}
-movienight.admin.password=${MOVIENIGHT_ADMIN_PASSWORD:change-me}

--- a/backend/src/test/java/ca/corbett/movienight/SecurityIntegrationTest.java
+++ b/backend/src/test/java/ca/corbett/movienight/SecurityIntegrationTest.java
@@ -1,0 +1,90 @@
+package ca.corbett.movienight;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:sqlite:file:security-tests?mode=memory&cache=shared",
+        "spring.datasource.driver-class-name=org.sqlite.JDBC",
+        "spring.jpa.database-platform=org.hibernate.community.dialect.SQLiteDialect",
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "movienight.data-dir=",
+        "movienight.admin.username=admin",
+        "movienight.admin.password=secret"
+})
+class SecurityIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void publicReadEndpointsRemainOpen() throws Exception {
+        mockMvc.perform(get("/api/movies"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void adminRouteRequiresBasicAuthFromLocalhost() throws Exception {
+        mockMvc.perform(get("/admin").with(remoteAddr("127.0.0.1")))
+                .andExpect(status().isUnauthorized());
+
+        mockMvc.perform(get("/admin")
+                        .with(remoteAddr("127.0.0.1"))
+                        .with(httpBasic("admin", "secret")))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void writeEndpointsRequireLocalhostAndAuth() throws Exception {
+        String movieJson = """
+                {
+                  "title": "Secured Movie",
+                  "year": 2024,
+                  "genre": "Drama",
+                  "description": "Created through the secured admin API.",
+                  "watched": false,
+                  "tags": ["security"]
+                }
+                """;
+
+        mockMvc.perform(post("/api/movies")
+                        .with(remoteAddr("127.0.0.1"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(movieJson))
+                .andExpect(status().isUnauthorized());
+
+        mockMvc.perform(post("/api/movies")
+                        .with(remoteAddr("192.168.1.50"))
+                        .with(httpBasic("admin", "secret"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(movieJson))
+                .andExpect(status().isForbidden());
+
+        mockMvc.perform(post("/api/movies")
+                        .with(remoteAddr("127.0.0.1"))
+                        .with(httpBasic("admin", "secret"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(movieJson))
+                .andExpect(status().isCreated());
+    }
+
+    private static RequestPostProcessor remoteAddr(String remoteAddress) {
+        return request -> {
+            request.setRemoteAddr(remoteAddress);
+            return request;
+        };
+    }
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.1",
       "dependencies": {
         "react": "^18.3.1",
-        "react-dom": "^18.3.1"
+        "react-dom": "^18.3.1",
+        "react-router-dom": "^7.9.4"
       },
       "devDependencies": {
         "@types/react": "^18.3.3",
@@ -1528,6 +1529,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -2288,6 +2302,44 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.2.tgz",
+      "integrity": "sha512-yCqNne6I8IB6rVCH7XUvlBK7/QKyqypBFGv+8dj4QBFJiiRX+FG7/nkdAvGElyvVZ/HQP5N19wzteuTARXi5Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.14.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.2.tgz",
+      "integrity": "sha512-YZcM5ES8jJSM+KrJ9BdvHHqlnGTg5tH3sC5ChFRj4inosKctdyzBDhOyyHdGk597q2OT6NTrCA1OvB/YDwfekQ==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.14.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -2431,6 +2483,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^7.9.4"
   },
   "devDependencies": {
     "@types/react": "^18.3.3",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,324 +1,49 @@
-import { useState, useEffect } from 'react'
-import MovieList from './components/MovieList'
-import MovieForm from './components/MovieForm'
-import EpisodeList from './components/EpisodeList'
-import EpisodeForm from './components/EpisodeForm'
+import { BrowserRouter, NavLink, Navigate, Route, Routes } from 'react-router-dom'
+import MediaLibraryPage from './pages/MediaLibraryPage'
 
-const MOVIES_API = '/api/movies'
-const EPISODES_API = '/api/episodes'
+function NavItem({ to, children }) {
+  return (
+    <NavLink
+      to={to}
+      className={({ isActive }) => `px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
+        isActive
+          ? 'bg-indigo-600 text-white'
+          : 'bg-gray-800 text-gray-300 hover:bg-gray-700 hover:text-white'
+      }`}
+    >
+      {children}
+    </NavLink>
+  )
+}
 
 export default function App() {
-  const [activeTab, setActiveTab] = useState('movies')
-
-  // Movies state
-  const [movies, setMovies] = useState([])
-  const [moviesLoading, setMoviesLoading] = useState(true)
-  const [moviesError, setMoviesError] = useState(null)
-  const [showMovieForm, setShowMovieForm] = useState(false)
-  const [editingMovie, setEditingMovie] = useState(null)
-  const [movieSearchQuery, setMovieSearchQuery] = useState('')
-  const [filterWatched, setFilterWatched] = useState('')
-
-  // Episodes state
-  const [episodes, setEpisodes] = useState([])
-  const [episodesLoading, setEpisodesLoading] = useState(true)
-  const [episodesError, setEpisodesError] = useState(null)
-  const [showEpisodeForm, setShowEpisodeForm] = useState(false)
-  const [editingEpisode, setEditingEpisode] = useState(null)
-  const [episodeSeriesQuery, setEpisodeSeriesQuery] = useState('')
-  const [episodeSeasonQuery, setEpisodeSeasonQuery] = useState('')
-  const [filterEpisodeWatched, setFilterEpisodeWatched] = useState('')
-
-  // --- Movies ---
-
-  const fetchMovies = async () => {
-    try {
-      setMoviesLoading(true)
-      const params = new URLSearchParams()
-      if (movieSearchQuery) params.append('title', movieSearchQuery)
-      if (filterWatched !== '') params.append('watched', filterWatched)
-      const res = await fetch(`${MOVIES_API}?${params}`)
-      if (!res.ok) throw new Error('Failed to fetch movies')
-      setMovies(await res.json())
-      setMoviesError(null)
-    } catch (err) {
-      setMoviesError(err.message)
-    } finally {
-      setMoviesLoading(false)
-    }
-  }
-
-  useEffect(() => { fetchMovies() }, [movieSearchQuery, filterWatched])
-
-  const handleSaveMovie = async (movieData) => {
-    try {
-      const { _thumbnail, _clearThumbnail, ...data } = movieData
-      const isEdit = data.id != null
-      const url = isEdit ? `${MOVIES_API}/${data.id}` : MOVIES_API
-      const res = await fetch(url, {
-        method: isEdit ? 'PUT' : 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(data),
-      })
-      if (!res.ok) throw new Error('Failed to save movie')
-      const saved = await res.json()
-      if (_clearThumbnail) {
-        const thumbnailRes = await fetch(`${MOVIES_API}/${saved.id}/thumbnail`, { method: 'DELETE' })
-        if (!thumbnailRes.ok) throw new Error('Failed to delete movie thumbnail')
-      } else if (_thumbnail) {
-        const formData = new FormData()
-        formData.append('file', _thumbnail)
-        const thumbnailRes = await fetch(`${MOVIES_API}/${saved.id}/thumbnail`, { method: 'POST', body: formData })
-        if (!thumbnailRes.ok) throw new Error('Failed to upload movie thumbnail')
-      }
-      setShowMovieForm(false)
-      setEditingMovie(null)
-      fetchMovies()
-    } catch (err) {
-      setMoviesError(err.message)
-    }
-  }
-
-  const handleDeleteMovie = async (id) => {
-    if (!confirm('Delete this movie?')) return
-    try {
-      const res = await fetch(`${MOVIES_API}/${id}`, { method: 'DELETE' })
-      if (!res.ok) throw new Error('Failed to delete movie')
-      fetchMovies()
-    } catch (err) {
-      setMoviesError(err.message)
-    }
-  }
-
-  // --- Episodes ---
-
-  const fetchEpisodes = async () => {
-    try {
-      setEpisodesLoading(true)
-      const params = new URLSearchParams()
-      if (episodeSeriesQuery) params.append('seriesName', episodeSeriesQuery)
-      if (episodeSeasonQuery !== '') params.append('season', episodeSeasonQuery)
-      if (filterEpisodeWatched !== '') params.append('watched', filterEpisodeWatched)
-      const res = await fetch(`${EPISODES_API}?${params}`)
-      if (!res.ok) throw new Error('Failed to fetch episodes')
-      setEpisodes(await res.json())
-      setEpisodesError(null)
-    } catch (err) {
-      setEpisodesError(err.message)
-    } finally {
-      setEpisodesLoading(false)
-    }
-  }
-
-  useEffect(() => {
-    if (activeTab !== 'episodes') return
-    fetchEpisodes()
-  }, [activeTab, episodeSeriesQuery, episodeSeasonQuery, filterEpisodeWatched])
-
-  const handleSaveEpisode = async (episodeData) => {
-    try {
-      const { _thumbnail, _clearThumbnail, ...data } = episodeData
-      const isEdit = data.id != null
-      const url = isEdit ? `${EPISODES_API}/${data.id}` : EPISODES_API
-      const res = await fetch(url, {
-        method: isEdit ? 'PUT' : 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(data),
-      })
-      if (!res.ok) throw new Error('Failed to save episode')
-      const saved = await res.json()
-      if (_clearThumbnail) {
-        const thumbnailRes = await fetch(`${EPISODES_API}/${saved.id}/thumbnail`, { method: 'DELETE' })
-        if (!thumbnailRes.ok) throw new Error('Failed to clear episode thumbnail')
-      } else if (_thumbnail) {
-        const formData = new FormData()
-        formData.append('file', _thumbnail)
-        const thumbnailRes = await fetch(`${EPISODES_API}/${saved.id}/thumbnail`, { method: 'POST', body: formData })
-        if (!thumbnailRes.ok) throw new Error('Failed to upload episode thumbnail')
-      }
-      setShowEpisodeForm(false)
-      setEditingEpisode(null)
-      fetchEpisodes()
-    } catch (err) {
-      setEpisodesError(err.message)
-    }
-  }
-
-  const handleDeleteEpisode = async (id) => {
-    if (!confirm('Delete this episode?')) return
-    try {
-      const res = await fetch(`${EPISODES_API}/${id}`, { method: 'DELETE' })
-      if (!res.ok) throw new Error('Failed to delete episode')
-      fetchEpisodes()
-    } catch (err) {
-      setEpisodesError(err.message)
-    }
-  }
-
   return (
-    <div className="min-h-screen bg-gray-950 text-gray-100">
-      {/* Header */}
-      <header className="bg-gray-900 border-b border-gray-800 shadow-lg">
-        <div className="max-w-6xl mx-auto px-4 py-4 flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <span className="text-3xl" aria-hidden="true">🎬</span>
-            <h1 className="text-2xl font-bold text-white tracking-tight">MovieNight</h1>
+    <BrowserRouter>
+      <div className="min-h-screen bg-gray-950 text-gray-100">
+        <header className="bg-gray-900 border-b border-gray-800 shadow-lg">
+          <div className="max-w-6xl mx-auto px-4 py-4 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex items-center gap-3">
+              <span className="text-3xl" aria-hidden="true">🎬</span>
+              <div>
+                <h1 className="text-2xl font-bold text-white tracking-tight">MovieNight</h1>
+                <p className="text-sm text-gray-400">Public browse UI with a localhost-only admin route.</p>
+              </div>
+            </div>
+            <nav className="flex items-center gap-2">
+              <NavItem to="/">Browse</NavItem>
+              <NavItem to="/admin">Admin</NavItem>
+            </nav>
           </div>
-          {activeTab === 'movies' ? (
-            <button
-              onClick={() => { setEditingMovie(null); setShowMovieForm(true) }}
-              className="bg-indigo-600 hover:bg-indigo-500 text-white px-4 py-2 rounded-lg font-medium transition-colors"
-            >
-              + Add Movie
-            </button>
-          ) : (
-            <button
-              onClick={() => { setEditingEpisode(null); setShowEpisodeForm(true) }}
-              className="bg-indigo-600 hover:bg-indigo-500 text-white px-4 py-2 rounded-lg font-medium transition-colors"
-            >
-              + Add Episode
-            </button>
-          )}
-        </div>
-      </header>
+        </header>
 
-      <main className="max-w-6xl mx-auto px-4 py-8">
-        {/* Tabs */}
-        <div className="flex gap-1 mb-6 bg-gray-900 border border-gray-800 rounded-lg p-1 w-fit">
-          <button
-            onClick={() => { setActiveTab('movies'); setShowEpisodeForm(false); setEditingEpisode(null) }}
-            className={`px-5 py-2 rounded-md text-sm font-medium transition-colors ${
-              activeTab === 'movies'
-                ? 'bg-indigo-600 text-white'
-                : 'text-gray-400 hover:text-gray-200'
-            }`}
-          >
-            🎬 Movies
-          </button>
-          <button
-            onClick={() => { setActiveTab('episodes'); setShowMovieForm(false); setEditingMovie(null) }}
-            className={`px-5 py-2 rounded-md text-sm font-medium transition-colors ${
-              activeTab === 'episodes'
-                ? 'bg-indigo-600 text-white'
-                : 'text-gray-400 hover:text-gray-200'
-            }`}
-          >
-            📺 Episodes
-          </button>
-        </div>
-
-        {activeTab === 'movies' && (
-          <>
-            {/* Movie Search & Filter */}
-            <div className="flex flex-col sm:flex-row gap-3 mb-6">
-              <input
-                type="text"
-                placeholder="Search by title…"
-                value={movieSearchQuery}
-                onChange={(e) => setMovieSearchQuery(e.target.value)}
-                className="flex-1 bg-gray-800 border border-gray-700 rounded-lg px-4 py-2 text-gray-100 placeholder-gray-500 focus:outline-none focus:border-indigo-500"
-              />
-              <select
-                value={filterWatched}
-                onChange={(e) => setFilterWatched(e.target.value)}
-                className="bg-gray-800 border border-gray-700 rounded-lg px-4 py-2 text-gray-100 focus:outline-none focus:border-indigo-500"
-              >
-                <option value="">All movies</option>
-                <option value="true">Watched</option>
-                <option value="false">Unwatched</option>
-              </select>
-            </div>
-
-            {moviesError && (
-              <div className="bg-red-900/50 border border-red-700 text-red-300 px-4 py-3 rounded-lg mb-6">
-                {moviesError}
-              </div>
-            )}
-
-            {showMovieForm && (
-              <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4">
-                <div className="bg-gray-900 border border-gray-700 rounded-xl shadow-2xl w-full max-w-lg">
-                  <MovieForm
-                    movie={editingMovie}
-                    onSave={handleSaveMovie}
-                    onCancel={() => { setShowMovieForm(false); setEditingMovie(null) }}
-                  />
-                </div>
-              </div>
-            )}
-
-            {moviesLoading ? (
-              <div className="text-center text-gray-400 py-16">Loading…</div>
-            ) : (
-              <MovieList
-                movies={movies}
-                onEdit={(m) => { setEditingMovie(m); setShowMovieForm(true) }}
-                onDelete={handleDeleteMovie}
-              />
-            )}
-          </>
-        )}
-
-        {activeTab === 'episodes' && (
-          <>
-            {/* Episode Search & Filter */}
-            <div className="flex flex-col sm:flex-row gap-3 mb-6">
-              <input
-                type="text"
-                placeholder="Search by series name…"
-                value={episodeSeriesQuery}
-                onChange={(e) => setEpisodeSeriesQuery(e.target.value)}
-                className="flex-1 bg-gray-800 border border-gray-700 rounded-lg px-4 py-2 text-gray-100 placeholder-gray-500 focus:outline-none focus:border-indigo-500"
-              />
-              <input
-                type="number"
-                placeholder="Season"
-                value={episodeSeasonQuery}
-                onChange={(e) => setEpisodeSeasonQuery(e.target.value)}
-                min="1"
-                className="w-28 bg-gray-800 border border-gray-700 rounded-lg px-4 py-2 text-gray-100 placeholder-gray-500 focus:outline-none focus:border-indigo-500"
-              />
-              <select
-                value={filterEpisodeWatched}
-                onChange={(e) => setFilterEpisodeWatched(e.target.value)}
-                className="bg-gray-800 border border-gray-700 rounded-lg px-4 py-2 text-gray-100 focus:outline-none focus:border-indigo-500"
-              >
-                <option value="">All episodes</option>
-                <option value="true">Watched</option>
-                <option value="false">Unwatched</option>
-              </select>
-            </div>
-
-            {episodesError && (
-              <div className="bg-red-900/50 border border-red-700 text-red-300 px-4 py-3 rounded-lg mb-6">
-                {episodesError}
-              </div>
-            )}
-
-            {showEpisodeForm && (
-              <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4">
-                <div className="bg-gray-900 border border-gray-700 rounded-xl shadow-2xl w-full max-w-lg overflow-y-auto max-h-[90vh]">
-                  <EpisodeForm
-                    episode={editingEpisode}
-                    onSave={handleSaveEpisode}
-                    onCancel={() => { setShowEpisodeForm(false); setEditingEpisode(null) }}
-                  />
-                </div>
-              </div>
-            )}
-
-            {episodesLoading ? (
-              <div className="text-center text-gray-400 py-16">Loading…</div>
-            ) : (
-              <EpisodeList
-                episodes={episodes}
-                onEdit={(ep) => { setEditingEpisode(ep); setShowEpisodeForm(true) }}
-                onDelete={handleDeleteEpisode}
-              />
-            )}
-          </>
-        )}
-      </main>
-    </div>
+        <main className="max-w-6xl mx-auto px-4 py-8">
+          <Routes>
+            <Route path="/" element={<MediaLibraryPage mode="user" />} />
+            <Route path="/admin" element={<MediaLibraryPage mode="admin" />} />
+            <Route path="*" element={<Navigate to="/" replace />} />
+          </Routes>
+        </main>
+      </div>
+    </BrowserRouter>
   )
 }

--- a/frontend/src/components/EpisodeList.jsx
+++ b/frontend/src/components/EpisodeList.jsx
@@ -1,12 +1,14 @@
 const EPISODES_API = '/api/episodes'
 
-export default function EpisodeList({ episodes, onEdit, onDelete }) {
+export default function EpisodeList({ episodes, onEdit, onDelete, readOnly = false }) {
   if (episodes.length === 0) {
     return (
       <div className="text-center text-gray-500 py-16">
         <p className="text-5xl mb-4" aria-hidden="true">📺</p>
         <p className="text-xl">No episodes found.</p>
-        <p className="text-sm mt-2">Add an episode to get started!</p>
+        <p className="text-sm mt-2">
+          {readOnly ? 'Try adjusting your filters.' : 'Add an episode to get started!'}
+        </p>
       </div>
     )
   }
@@ -14,13 +16,19 @@ export default function EpisodeList({ episodes, onEdit, onDelete }) {
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
       {episodes.map((episode) => (
-        <EpisodeCard key={episode.id} episode={episode} onEdit={onEdit} onDelete={onDelete} />
+        <EpisodeCard
+          key={episode.id}
+          episode={episode}
+          onEdit={onEdit}
+          onDelete={onDelete}
+          readOnly={readOnly}
+        />
       ))}
     </div>
   )
 }
 
-function EpisodeCard({ episode, onEdit, onDelete }) {
+function EpisodeCard({ episode, onEdit, onDelete, readOnly }) {
   const seasonEpisodeLabel = [
     episode.season != null ? `S${episode.season}` : null,
     episode.episode != null ? `E${episode.episode}` : null,
@@ -70,20 +78,22 @@ function EpisodeCard({ episode, onEdit, onDelete }) {
         </div>
       )}
 
-      <div className="flex gap-2 mt-auto pt-2">
-        <button
-          onClick={() => onEdit(episode)}
-          className="flex-1 bg-gray-800 hover:bg-gray-700 text-gray-200 text-sm px-3 py-1.5 rounded-lg transition-colors"
-        >
-          Edit
-        </button>
-        <button
-          onClick={() => onDelete(episode.id)}
-          className="flex-1 bg-red-900/40 hover:bg-red-800/60 text-red-300 text-sm px-3 py-1.5 rounded-lg transition-colors"
-        >
-          Delete
-        </button>
-      </div>
+      {!readOnly && (
+        <div className="flex gap-2 mt-auto pt-2">
+          <button
+            onClick={() => onEdit(episode)}
+            className="flex-1 bg-gray-800 hover:bg-gray-700 text-gray-200 text-sm px-3 py-1.5 rounded-lg transition-colors"
+          >
+            Edit
+          </button>
+          <button
+            onClick={() => onDelete(episode.id)}
+            className="flex-1 bg-red-900/40 hover:bg-red-800/60 text-red-300 text-sm px-3 py-1.5 rounded-lg transition-colors"
+          >
+            Delete
+          </button>
+        </div>
+      )}
       </div>
     </div>
   )

--- a/frontend/src/components/MovieList.jsx
+++ b/frontend/src/components/MovieList.jsx
@@ -1,12 +1,14 @@
 const MOVIES_API = '/api/movies'
 
-export default function MovieList({ movies, onEdit, onDelete }) {
+export default function MovieList({ movies, onEdit, onDelete, readOnly = false }) {
   if (movies.length === 0) {
     return (
       <div className="text-center text-gray-500 py-16">
         <p className="text-5xl mb-4" aria-hidden="true">🎥</p>
         <p className="text-xl">No movies found.</p>
-        <p className="text-sm mt-2">Add a movie to get started!</p>
+        <p className="text-sm mt-2">
+          {readOnly ? 'Try adjusting your filters.' : 'Add a movie to get started!'}
+        </p>
       </div>
     )
   }
@@ -14,13 +16,13 @@ export default function MovieList({ movies, onEdit, onDelete }) {
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
       {movies.map((movie) => (
-        <MovieCard key={movie.id} movie={movie} onEdit={onEdit} onDelete={onDelete} />
+        <MovieCard key={movie.id} movie={movie} onEdit={onEdit} onDelete={onDelete} readOnly={readOnly} />
       ))}
     </div>
   )
 }
 
-function MovieCard({ movie, onEdit, onDelete }) {
+function MovieCard({ movie, onEdit, onDelete, readOnly }) {
   return (
     <div className="bg-gray-900 border border-gray-800 rounded-xl overflow-hidden flex flex-col hover:border-gray-600 transition-colors">
       {movie.hasThumbnail && (
@@ -59,20 +61,22 @@ function MovieCard({ movie, onEdit, onDelete }) {
         </div>
       )}
 
-      <div className="flex gap-2 mt-auto pt-2">
-        <button
-          onClick={() => onEdit(movie)}
-          className="flex-1 bg-gray-800 hover:bg-gray-700 text-gray-200 text-sm px-3 py-1.5 rounded-lg transition-colors"
-        >
-          Edit
-        </button>
-        <button
-          onClick={() => onDelete(movie.id)}
-          className="flex-1 bg-red-900/40 hover:bg-red-800/60 text-red-300 text-sm px-3 py-1.5 rounded-lg transition-colors"
-        >
-          Delete
-        </button>
-      </div>
+      {!readOnly && (
+        <div className="flex gap-2 mt-auto pt-2">
+          <button
+            onClick={() => onEdit(movie)}
+            className="flex-1 bg-gray-800 hover:bg-gray-700 text-gray-200 text-sm px-3 py-1.5 rounded-lg transition-colors"
+          >
+            Edit
+          </button>
+          <button
+            onClick={() => onDelete(movie.id)}
+            className="flex-1 bg-red-900/40 hover:bg-red-800/60 text-red-300 text-sm px-3 py-1.5 rounded-lg transition-colors"
+          >
+            Delete
+          </button>
+        </div>
+      )}
       </div>
     </div>
   )

--- a/frontend/src/pages/MediaLibraryPage.jsx
+++ b/frontend/src/pages/MediaLibraryPage.jsx
@@ -1,0 +1,349 @@
+import { useEffect, useState } from 'react'
+import MovieList from '../components/MovieList'
+import MovieForm from '../components/MovieForm'
+import EpisodeList from '../components/EpisodeList'
+import EpisodeForm from '../components/EpisodeForm'
+
+const MOVIES_API = '/api/movies'
+const EPISODES_API = '/api/episodes'
+
+export default function MediaLibraryPage({ mode }) {
+  const isAdmin = mode === 'admin'
+  const [activeTab, setActiveTab] = useState('movies')
+
+  const [movies, setMovies] = useState([])
+  const [moviesLoading, setMoviesLoading] = useState(true)
+  const [moviesError, setMoviesError] = useState(null)
+  const [showMovieForm, setShowMovieForm] = useState(false)
+  const [editingMovie, setEditingMovie] = useState(null)
+  const [movieSearchQuery, setMovieSearchQuery] = useState('')
+  const [filterWatched, setFilterWatched] = useState('')
+
+  const [episodes, setEpisodes] = useState([])
+  const [episodesLoading, setEpisodesLoading] = useState(true)
+  const [episodesError, setEpisodesError] = useState(null)
+  const [showEpisodeForm, setShowEpisodeForm] = useState(false)
+  const [editingEpisode, setEditingEpisode] = useState(null)
+  const [episodeSeriesQuery, setEpisodeSeriesQuery] = useState('')
+  const [episodeSeasonQuery, setEpisodeSeasonQuery] = useState('')
+  const [filterEpisodeWatched, setFilterEpisodeWatched] = useState('')
+
+  const fetchMovies = async () => {
+    try {
+      setMoviesLoading(true)
+      const params = new URLSearchParams()
+      if (movieSearchQuery) params.append('title', movieSearchQuery)
+      if (filterWatched !== '') params.append('watched', filterWatched)
+      const res = await fetch(`${MOVIES_API}?${params}`)
+      if (!res.ok) throw new Error('Failed to fetch movies')
+      setMovies(await res.json())
+      setMoviesError(null)
+    } catch (err) {
+      setMoviesError(err.message)
+    } finally {
+      setMoviesLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    fetchMovies()
+  }, [movieSearchQuery, filterWatched])
+
+  const fetchEpisodes = async () => {
+    try {
+      setEpisodesLoading(true)
+      const params = new URLSearchParams()
+      if (episodeSeriesQuery) params.append('seriesName', episodeSeriesQuery)
+      if (episodeSeasonQuery !== '') params.append('season', episodeSeasonQuery)
+      if (filterEpisodeWatched !== '') params.append('watched', filterEpisodeWatched)
+      const res = await fetch(`${EPISODES_API}?${params}`)
+      if (!res.ok) throw new Error('Failed to fetch episodes')
+      setEpisodes(await res.json())
+      setEpisodesError(null)
+    } catch (err) {
+      setEpisodesError(err.message)
+    } finally {
+      setEpisodesLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    if (activeTab !== 'episodes') return
+    fetchEpisodes()
+  }, [activeTab, episodeSeriesQuery, episodeSeasonQuery, filterEpisodeWatched])
+
+  const handleSaveMovie = async (movieData) => {
+    try {
+      const { _thumbnail, _clearThumbnail, ...data } = movieData
+      const isEdit = data.id != null
+      const url = isEdit ? `${MOVIES_API}/${data.id}` : MOVIES_API
+      const res = await fetch(url, {
+        method: isEdit ? 'PUT' : 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      })
+      if (!res.ok) throw new Error('Failed to save movie')
+      const saved = await res.json()
+      if (_clearThumbnail) {
+        const thumbnailRes = await fetch(`${MOVIES_API}/${saved.id}/thumbnail`, { method: 'DELETE' })
+        if (!thumbnailRes.ok) throw new Error('Failed to delete movie thumbnail')
+      } else if (_thumbnail) {
+        const formData = new FormData()
+        formData.append('file', _thumbnail)
+        const thumbnailRes = await fetch(`${MOVIES_API}/${saved.id}/thumbnail`, { method: 'POST', body: formData })
+        if (!thumbnailRes.ok) throw new Error('Failed to upload movie thumbnail')
+      }
+      setShowMovieForm(false)
+      setEditingMovie(null)
+      fetchMovies()
+    } catch (err) {
+      setMoviesError(err.message)
+    }
+  }
+
+  const handleDeleteMovie = async (id) => {
+    if (!confirm('Delete this movie?')) return
+    try {
+      const res = await fetch(`${MOVIES_API}/${id}`, { method: 'DELETE' })
+      if (!res.ok) throw new Error('Failed to delete movie')
+      fetchMovies()
+    } catch (err) {
+      setMoviesError(err.message)
+    }
+  }
+
+  const handleSaveEpisode = async (episodeData) => {
+    try {
+      const { _thumbnail, _clearThumbnail, ...data } = episodeData
+      const isEdit = data.id != null
+      const url = isEdit ? `${EPISODES_API}/${data.id}` : EPISODES_API
+      const res = await fetch(url, {
+        method: isEdit ? 'PUT' : 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      })
+      if (!res.ok) throw new Error('Failed to save episode')
+      const saved = await res.json()
+      if (_clearThumbnail) {
+        const thumbnailRes = await fetch(`${EPISODES_API}/${saved.id}/thumbnail`, { method: 'DELETE' })
+        if (!thumbnailRes.ok) throw new Error('Failed to clear episode thumbnail')
+      } else if (_thumbnail) {
+        const formData = new FormData()
+        formData.append('file', _thumbnail)
+        const thumbnailRes = await fetch(`${EPISODES_API}/${saved.id}/thumbnail`, { method: 'POST', body: formData })
+        if (!thumbnailRes.ok) throw new Error('Failed to upload episode thumbnail')
+      }
+      setShowEpisodeForm(false)
+      setEditingEpisode(null)
+      fetchEpisodes()
+    } catch (err) {
+      setEpisodesError(err.message)
+    }
+  }
+
+  const handleDeleteEpisode = async (id) => {
+    if (!confirm('Delete this episode?')) return
+    try {
+      const res = await fetch(`${EPISODES_API}/${id}`, { method: 'DELETE' })
+      if (!res.ok) throw new Error('Failed to delete episode')
+      fetchEpisodes()
+    } catch (err) {
+      setEpisodesError(err.message)
+    }
+  }
+
+  const adminActionLabel = activeTab === 'movies' ? '+ Add Movie' : '+ Add Episode'
+
+  return (
+    <>
+      <section className="mb-6 rounded-xl border border-gray-800 bg-gray-900 px-5 py-4">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.2em] text-indigo-300">
+              {isAdmin ? 'Admin interface' : 'Read-only interface'}
+            </p>
+            <h2 className="mt-1 text-xl font-semibold text-white">
+              {isAdmin ? 'Manage your media library' : 'Browse your media library'}
+            </h2>
+            <p className="mt-1 text-sm text-gray-400">
+              {isAdmin
+                ? 'Create, edit, and delete entries from this machine only. Basic auth is required for admin access.'
+                : 'Browse movies and episodes without any write controls.'}
+            </p>
+          </div>
+          {isAdmin && (
+            <button
+              onClick={() => {
+                if (activeTab === 'movies') {
+                  setEditingMovie(null)
+                  setShowMovieForm(true)
+                } else {
+                  setEditingEpisode(null)
+                  setShowEpisodeForm(true)
+                }
+              }}
+              className="bg-indigo-600 hover:bg-indigo-500 text-white px-4 py-2 rounded-lg font-medium transition-colors"
+            >
+              {adminActionLabel}
+            </button>
+          )}
+        </div>
+      </section>
+
+      <div className="flex gap-1 mb-6 bg-gray-900 border border-gray-800 rounded-lg p-1 w-fit">
+        <button
+          onClick={() => {
+            setActiveTab('movies')
+            setShowEpisodeForm(false)
+            setEditingEpisode(null)
+          }}
+          className={`px-5 py-2 rounded-md text-sm font-medium transition-colors ${
+            activeTab === 'movies'
+              ? 'bg-indigo-600 text-white'
+              : 'text-gray-400 hover:text-gray-200'
+          }`}
+        >
+          🎬 Movies
+        </button>
+        <button
+          onClick={() => {
+            setActiveTab('episodes')
+            setShowMovieForm(false)
+            setEditingMovie(null)
+          }}
+          className={`px-5 py-2 rounded-md text-sm font-medium transition-colors ${
+            activeTab === 'episodes'
+              ? 'bg-indigo-600 text-white'
+              : 'text-gray-400 hover:text-gray-200'
+          }`}
+        >
+          📺 Episodes
+        </button>
+      </div>
+
+      {activeTab === 'movies' && (
+        <>
+          <div className="flex flex-col sm:flex-row gap-3 mb-6">
+            <input
+              type="text"
+              placeholder="Search by title…"
+              value={movieSearchQuery}
+              onChange={(e) => setMovieSearchQuery(e.target.value)}
+              className="flex-1 bg-gray-800 border border-gray-700 rounded-lg px-4 py-2 text-gray-100 placeholder-gray-500 focus:outline-none focus:border-indigo-500"
+            />
+            <select
+              value={filterWatched}
+              onChange={(e) => setFilterWatched(e.target.value)}
+              className="bg-gray-800 border border-gray-700 rounded-lg px-4 py-2 text-gray-100 focus:outline-none focus:border-indigo-500"
+            >
+              <option value="">All movies</option>
+              <option value="true">Watched</option>
+              <option value="false">Unwatched</option>
+            </select>
+          </div>
+
+          {moviesError && (
+            <div className="bg-red-900/50 border border-red-700 text-red-300 px-4 py-3 rounded-lg mb-6">
+              {moviesError}
+            </div>
+          )}
+
+          {isAdmin && showMovieForm && (
+            <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4">
+              <div className="bg-gray-900 border border-gray-700 rounded-xl shadow-2xl w-full max-w-lg">
+                <MovieForm
+                  movie={editingMovie}
+                  onSave={handleSaveMovie}
+                  onCancel={() => {
+                    setShowMovieForm(false)
+                    setEditingMovie(null)
+                  }}
+                />
+              </div>
+            </div>
+          )}
+
+          {moviesLoading ? (
+            <div className="text-center text-gray-400 py-16">Loading…</div>
+          ) : (
+            <MovieList
+              movies={movies}
+              onEdit={(movie) => {
+                setEditingMovie(movie)
+                setShowMovieForm(true)
+              }}
+              onDelete={handleDeleteMovie}
+              readOnly={!isAdmin}
+            />
+          )}
+        </>
+      )}
+
+      {activeTab === 'episodes' && (
+        <>
+          <div className="flex flex-col sm:flex-row gap-3 mb-6">
+            <input
+              type="text"
+              placeholder="Search by series name…"
+              value={episodeSeriesQuery}
+              onChange={(e) => setEpisodeSeriesQuery(e.target.value)}
+              className="flex-1 bg-gray-800 border border-gray-700 rounded-lg px-4 py-2 text-gray-100 placeholder-gray-500 focus:outline-none focus:border-indigo-500"
+            />
+            <input
+              type="number"
+              placeholder="Season"
+              value={episodeSeasonQuery}
+              onChange={(e) => setEpisodeSeasonQuery(e.target.value)}
+              min="1"
+              className="w-28 bg-gray-800 border border-gray-700 rounded-lg px-4 py-2 text-gray-100 placeholder-gray-500 focus:outline-none focus:border-indigo-500"
+            />
+            <select
+              value={filterEpisodeWatched}
+              onChange={(e) => setFilterEpisodeWatched(e.target.value)}
+              className="bg-gray-800 border border-gray-700 rounded-lg px-4 py-2 text-gray-100 focus:outline-none focus:border-indigo-500"
+            >
+              <option value="">All episodes</option>
+              <option value="true">Watched</option>
+              <option value="false">Unwatched</option>
+            </select>
+          </div>
+
+          {episodesError && (
+            <div className="bg-red-900/50 border border-red-700 text-red-300 px-4 py-3 rounded-lg mb-6">
+              {episodesError}
+            </div>
+          )}
+
+          {isAdmin && showEpisodeForm && (
+            <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4">
+              <div className="bg-gray-900 border border-gray-700 rounded-xl shadow-2xl w-full max-w-lg overflow-y-auto max-h-[90vh]">
+                <EpisodeForm
+                  episode={editingEpisode}
+                  onSave={handleSaveEpisode}
+                  onCancel={() => {
+                    setShowEpisodeForm(false)
+                    setEditingEpisode(null)
+                  }}
+                />
+              </div>
+            </div>
+          )}
+
+          {episodesLoading ? (
+            <div className="text-center text-gray-400 py-16">Loading…</div>
+          ) : (
+            <EpisodeList
+              episodes={episodes}
+              onEdit={(episode) => {
+                setEditingEpisode(episode)
+                setShowEpisodeForm(true)
+              }}
+              onDelete={handleDeleteEpisode}
+              readOnly={!isAdmin}
+            />
+          )}
+        </>
+      )}
+    </>
+  )
+}

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,7 +1,8 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
-export default defineConfig({
+export default defineConfig(({ command }) => ({
+  base: command === 'build' ? '/frontend/' : '/',
   plugins: [react()],
   build: {
     outDir: '../backend/src/main/resources/static/frontend',
@@ -16,4 +17,4 @@ export default defineConfig({
       },
     },
   },
-})
+}))


### PR DESCRIPTION
This PR addresses issue #16 by splitting the current UI into two: a read-only UI designed for regular users, and a full admin UI for managing the collection. The admin UI is locked down with basic authentication on the API endpoints, combined with localhost-only filtering, so that it can only be accessed from a web browser running on the same machine. There is no remote admin access planned for V1.

Closes #16 