### PR TITLE
Issue #29 - promote Series to model object

### DIFF
--- a/backend/src/main/java/ca/corbett/movienight/controller/EpisodeController.java
+++ b/backend/src/main/java/ca/corbett/movienight/controller/EpisodeController.java
@@ -9,11 +9,21 @@ import org.springframework.core.io.Resource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
+
 import java.nio.file.Path;
 import java.util.List;
-import org.springframework.web.server.ResponseStatusException;
 
 @RestController
 @RequestMapping("/api/episodes")
@@ -29,12 +39,12 @@ public class EpisodeController {
     }
 
     @GetMapping
-    public List<Episode> getAllEpisodes(@RequestParam(required = false) String seriesName,
+    public List<Episode> getAllEpisodes(@RequestParam(required = false) Long seriesId,
                                         @RequestParam(required = false) Integer season,
                                         @RequestParam(required = false) Integer episode,
                                         @RequestParam(required = false) Boolean watched,
                                         @RequestParam(required = false) String tag) {
-        return episodeService.searchEpisodes(seriesName, season, episode, watched, tag);
+        return episodeService.searchEpisodes(seriesId, season, episode, watched, tag);
     }
 
     @GetMapping("/{id}")

--- a/backend/src/main/java/ca/corbett/movienight/controller/SeriesController.java
+++ b/backend/src/main/java/ca/corbett/movienight/controller/SeriesController.java
@@ -1,0 +1,100 @@
+package ca.corbett.movienight.controller;
+
+import ca.corbett.movienight.model.Series;
+import ca.corbett.movienight.service.SeriesService;
+import ca.corbett.movienight.service.ThumbnailService;
+import jakarta.validation.Valid;
+import org.springframework.core.io.PathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.nio.file.Path;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/series")
+@CrossOrigin(origins = "http://localhost:5173")
+public class SeriesController {
+    private final SeriesService seriesService;
+    private final ThumbnailService thumbnailService;
+
+    public SeriesController(SeriesService seriesService, ThumbnailService thumbnailService) {
+        this.seriesService = seriesService;
+        this.thumbnailService = thumbnailService;
+    }
+
+    @GetMapping
+    public List<Series> getAllSeries() {
+        return seriesService.getAllSeries();
+    }
+
+    @GetMapping("/{id}")
+    public Series getSeriesById(@PathVariable Long id) {
+        return seriesService.getSeriesById(id)
+                            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                                                                           "Series not found with id: " + id));
+    }
+
+    @PostMapping
+    public ResponseEntity<Series> createSeries(@Valid @RequestBody Series series) {
+        Series saved = seriesService.saveSeries(series);
+        return ResponseEntity.status(HttpStatus.CREATED).body(saved);
+    }
+
+    @PutMapping("/{id}")
+    public Series updateSeries(@PathVariable Long id,
+                               @Valid @RequestBody Series series) {
+        return seriesService.updateSeries(id, series);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteSeries(@PathVariable Long id) {
+        seriesService.deleteSeries(id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/{id}/thumbnail")
+    public ResponseEntity<Void> uploadSeriesThumbnail(@PathVariable Long id,
+                                                      @RequestParam("file") MultipartFile file) {
+        seriesService.requireSeries(id);
+        thumbnailService.saveThumbnail(file, "series", id);
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/{id}/thumbnail")
+    public ResponseEntity<Resource> getSeriesThumbnail(@PathVariable Long id) {
+        seriesService.requireSeries(id);
+        Path thumbnailPath = thumbnailService.getThumbnailPath("series", id);
+        if (thumbnailPath == null) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND,
+                                              "Series thumbnail not found for id: " + id);
+        }
+        String filename = thumbnailPath.getFileName().toString().toLowerCase();
+        MediaType mediaType = filename.endsWith(".png") ? MediaType.IMAGE_PNG : MediaType.IMAGE_JPEG;
+        return ResponseEntity.ok()
+                             .contentType(mediaType)
+                             .body(new PathResource(thumbnailPath));
+    }
+
+    @DeleteMapping("/{id}/thumbnail")
+    public ResponseEntity<Void> deleteSeriesThumbnail(@PathVariable Long id) {
+        seriesService.requireSeries(id);
+        thumbnailService.deleteThumbnail("series", id);
+        return ResponseEntity.noContent().build();
+    }
+
+}

--- a/backend/src/main/java/ca/corbett/movienight/model/Episode.java
+++ b/backend/src/main/java/ca/corbett/movienight/model/Episode.java
@@ -1,7 +1,18 @@
 package ca.corbett.movienight.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import jakarta.persistence.*;
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
@@ -9,6 +20,16 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+/**
+ * Represents a single episode of a TV series (or web series, or any kind of episodic content).
+ * An Episode has a mandatory title, and a mandatory Series association. It can optionally
+ * have a season and episode number, and a description. For additional metadata, use the
+ * tags list, and attach any arbitrary string tags to describe the episode.
+ * <p>
+ * If a data directory is set, a thumbnail image can be associated with an episode.
+ * This is optional. If present, the thumbnail will be presented in the UI.
+ * </p>
+ */
 @Entity
 @Table(name = "episodes")
 public class Episode {
@@ -17,10 +38,9 @@ public class Episode {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @NotBlank
-    @Size(max = 255)
-    @Column(nullable = false)
-    private String seriesName;
+    @ManyToOne(fetch = FetchType.EAGER)
+    @JoinColumn(name = "series_id", nullable = false)
+    private Series series;
 
     @Size(max = 255)
     @Column
@@ -52,11 +72,12 @@ public class Episode {
     @JsonProperty(value = "hasThumbnail", access = JsonProperty.Access.READ_ONLY)
     private boolean hasThumbnail = false;
 
-    public Episode() {}
+    public Episode() {
+    }
 
-    public Episode(String seriesName, String episodeTitle, Integer season, Integer episode,
+    public Episode(Series series, String episodeTitle, Integer season, Integer episode,
                    String description, Boolean watched) {
-        this.seriesName = seriesName;
+        this.series = series;
         this.episodeTitle = episodeTitle;
         this.season = season;
         this.episode = episode;
@@ -66,43 +87,92 @@ public class Episode {
 
     // Getters and setters
 
-    public Long getId() { return id; }
-    public void setId(Long id) { this.id = id; }
+    public Long getId() {
+        return id;
+    }
 
-    public String getSeriesName() { return seriesName; }
-    public void setSeriesName(String seriesName) { this.seriesName = seriesName; }
+    public void setId(Long id) {
+        this.id = id;
+    }
 
-    public String getEpisodeTitle() { return episodeTitle; }
-    public void setEpisodeTitle(String episodeTitle) { this.episodeTitle = episodeTitle; }
+    public Series getSeries() {
+        return series;
+    }
 
-    public Integer getSeason() { return season; }
-    public void setSeason(Integer season) { this.season = season; }
+    public void setSeries(Series series) {
+        this.series = series;
+    }
 
-    public Integer getEpisode() { return episode; }
-    public void setEpisode(Integer episode) { this.episode = episode; }
+    public String getEpisodeTitle() {
+        return episodeTitle;
+    }
 
-    public String getDescription() { return description; }
-    public void setDescription(String description) { this.description = description; }
+    public void setEpisodeTitle(String episodeTitle) {
+        this.episodeTitle = episodeTitle;
+    }
 
-    public Boolean getWatched() { return watched; }
-    public void setWatched(Boolean watched) { this.watched = watched; }
+    public Integer getSeason() {
+        return season;
+    }
 
-    public List<String> getTags() { return tags; }
+    public void setSeason(Integer season) {
+        this.season = season;
+    }
+
+    public Integer getEpisode() {
+        return episode;
+    }
+
+    public void setEpisode(Integer episode) {
+        this.episode = episode;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public Boolean getWatched() {
+        return watched;
+    }
+
+    public void setWatched(Boolean watched) {
+        this.watched = watched;
+    }
+
+    public List<String> getTags() {
+        return tags;
+    }
+
     public void setTags(List<String> tags) {
         if (tags == null) {
             this.tags = new ArrayList<>();
-        } else {
+        }
+        else {
             this.tags = tags.stream()
-                    .filter(t -> t != null && !t.isBlank())
-                    .map(t -> t.trim().toLowerCase())
-                    .distinct()
-                    .collect(Collectors.toCollection(ArrayList::new));
+                            .filter(t -> t != null && !t.isBlank())
+                            .map(t -> t.trim().toLowerCase())
+                            .distinct()
+                            .collect(Collectors.toCollection(ArrayList::new));
         }
     }
 
-    public boolean isHasThumbnail() { return hasThumbnail; }
-    public void setHasThumbnail(boolean hasThumbnail) { this.hasThumbnail = hasThumbnail; }
+    public boolean isHasThumbnail() {
+        return hasThumbnail;
+    }
 
-    public String getVideoFilePath() { return videoFilePath; }
-    public void setVideoFilePath(String videoFilePath) { this.videoFilePath = videoFilePath; }
+    public void setHasThumbnail(boolean hasThumbnail) {
+        this.hasThumbnail = hasThumbnail;
+    }
+
+    public String getVideoFilePath() {
+        return videoFilePath;
+    }
+
+    public void setVideoFilePath(String videoFilePath) {
+        this.videoFilePath = videoFilePath;
+    }
 }

--- a/backend/src/main/java/ca/corbett/movienight/model/Movie.java
+++ b/backend/src/main/java/ca/corbett/movienight/model/Movie.java
@@ -1,7 +1,18 @@
 package ca.corbett.movienight.model;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import jakarta.persistence.*;
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
@@ -9,6 +20,16 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+/**
+ * Represents a single movie (or any standalone long-form video content really).
+ * A Movie has a mandatory title, and a mandatory Genre association.
+ * It can optionally have a release year, and a description. For additional metadata,
+ * use the tags list, and attach any arbitrary string tags to describe the movie.
+ * <p>
+ * If a data directory is set, a thumbnail image can be associated with a movie.
+ * This is optional. If present, the thumbnail will be presented in the UI.
+ * </p>
+ */
 @Entity
 @Table(name = "movies")
 public class Movie {
@@ -49,7 +70,8 @@ public class Movie {
     @JsonProperty(value = "hasThumbnail", access = JsonProperty.Access.READ_ONLY)
     private boolean hasThumbnail = false;
 
-    public Movie() {}
+    public Movie() {
+    }
 
     public Movie(String title, Integer year, Genre genre,
                  String description, Boolean watched) {
@@ -62,14 +84,29 @@ public class Movie {
 
     // Getters and setters
 
-    public Long getId() { return id; }
-    public void setId(Long id) { this.id = id; }
+    public Long getId() {
+        return id;
+    }
 
-    public String getTitle() { return title; }
-    public void setTitle(String title) { this.title = title; }
+    public void setId(Long id) {
+        this.id = id;
+    }
 
-    public Integer getYear() { return year; }
-    public void setYear(Integer year) { this.year = year; }
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public Integer getYear() {
+        return year;
+    }
+
+    public void setYear(Integer year) {
+        this.year = year;
+    }
 
     public Genre getGenre() {
         return genre;
@@ -79,28 +116,52 @@ public class Movie {
         this.genre = genre;
     }
 
-    public String getDescription() { return description; }
-    public void setDescription(String description) { this.description = description; }
+    public String getDescription() {
+        return description;
+    }
 
-    public Boolean getWatched() { return watched; }
-    public void setWatched(Boolean watched) { this.watched = watched; }
+    public void setDescription(String description) {
+        this.description = description;
+    }
 
-    public List<String> getTags() { return tags; }
+    public Boolean getWatched() {
+        return watched;
+    }
+
+    public void setWatched(Boolean watched) {
+        this.watched = watched;
+    }
+
+    public List<String> getTags() {
+        return tags;
+    }
+
     public void setTags(List<String> tags) {
         if (tags == null) {
             this.tags = new ArrayList<>();
-        } else {
+        }
+        else {
             this.tags = tags.stream()
-                    .filter(t -> t != null && !t.isBlank())
-                    .map(t -> t.trim().toLowerCase())
-                    .distinct()
-                    .collect(Collectors.toCollection(ArrayList::new));
+                            .filter(t -> t != null && !t.isBlank())
+                            .map(t -> t.trim().toLowerCase())
+                            .distinct()
+                            .collect(Collectors.toCollection(ArrayList::new));
         }
     }
 
-    public boolean isHasThumbnail() { return hasThumbnail; }
-    public void setHasThumbnail(boolean hasThumbnail) { this.hasThumbnail = hasThumbnail; }
+    public boolean isHasThumbnail() {
+        return hasThumbnail;
+    }
 
-    public String getVideoFilePath() { return videoFilePath; }
-    public void setVideoFilePath(String videoFilePath) { this.videoFilePath = videoFilePath; }
+    public void setHasThumbnail(boolean hasThumbnail) {
+        this.hasThumbnail = hasThumbnail;
+    }
+
+    public String getVideoFilePath() {
+        return videoFilePath;
+    }
+
+    public void setVideoFilePath(String videoFilePath) {
+        this.videoFilePath = videoFilePath;
+    }
 }

--- a/backend/src/main/java/ca/corbett/movienight/model/Series.java
+++ b/backend/src/main/java/ca/corbett/movienight/model/Series.java
@@ -11,20 +11,20 @@ import jakarta.persistence.Transient;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
-import java.util.Locale;
-
 /**
- * Each Movie has a mandatory Genre association. A Genre has a mandatory name, and an optional description.
- * The main Movies tab in the UI starts with a list of Genres, and clicking on a Genre shows the movies in that genre.
+ * An Episode has a mandatory Series association.
+ * A Series has a mandatory name, and an optional description.
+ * The main TV Series tab in the UI starts with a list of Series,
+ * and clicking on a Series shows the episodes in that series.
+ * A Series can optionally have a year associated with it.
  * <p>
- * If a data directory is set, a thumbnail image can be associated with a genre. This is optional.
+ * If a data directory is set, a thumbnail image can be associated with a series. This is optional.
  * If present, the thumbnail will be presented in the UI.
  * </p>
  */
 @Entity
-@Table(name = "genres")
-public class Genre {
-
+@Table(name = "series")
+public class Series {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -38,22 +38,25 @@ public class Genre {
     @Column(length = 2000)
     private String description;
 
+    @Column
+    private Integer year;
+
     @Transient
     @JsonProperty(value = "hasThumbnail", access = JsonProperty.Access.READ_ONLY)
     private boolean hasThumbnail = false;
 
     @Transient
-    @JsonProperty(value = "movieCount", access = JsonProperty.Access.READ_ONLY)
-    private long movieCount = 0;
+    @JsonProperty(value = "episodeCount", access = JsonProperty.Access.READ_ONLY)
+    private long episodeCount = 0;
 
-    public Genre() {
+    public Series() {
     }
 
-    public Genre(String name) {
+    public Series(String name) {
         this(name, null);
     }
 
-    public Genre(String name, String description) {
+    public Series(String name, String description) {
         setName(name);
         this.description = description;
     }
@@ -66,13 +69,20 @@ public class Genre {
         this.id = id;
     }
 
+    public int getYear() {
+        return year;
+    }
+
+    public void setYear(int year) {
+        this.year = year;
+    }
+
     public String getName() {
         return name;
     }
 
     public void setName(String name) {
-        // Normalize:
-        this.name = name == null ? null : name.trim().toLowerCase(Locale.ROOT);
+        this.name = name;
     }
 
     public String getDescription() {
@@ -91,12 +101,11 @@ public class Genre {
         this.hasThumbnail = hasThumbnail;
     }
 
-    public long getMovieCount() {
-        return movieCount;
+    public long getEpisodeCount() {
+        return episodeCount;
     }
 
-    public void setMovieCount(long movieCount) {
-        this.movieCount = movieCount;
+    public void setEpisodeCount(long movieCount) {
+        this.episodeCount = movieCount;
     }
-
 }

--- a/backend/src/main/java/ca/corbett/movienight/model/Series.java
+++ b/backend/src/main/java/ca/corbett/movienight/model/Series.java
@@ -69,11 +69,11 @@ public class Series {
         this.id = id;
     }
 
-    public int getYear() {
+    public Integer getYear() {
         return year;
     }
 
-    public void setYear(int year) {
+    public void setYear(Integer year) {
         this.year = year;
     }
 

--- a/backend/src/main/java/ca/corbett/movienight/model/Series.java
+++ b/backend/src/main/java/ca/corbett/movienight/model/Series.java
@@ -105,7 +105,7 @@ public class Series {
         return episodeCount;
     }
 
-    public void setEpisodeCount(long movieCount) {
-        this.episodeCount = movieCount;
+    public void setEpisodeCount(long episodeCount) {
+        this.episodeCount = episodeCount;
     }
 }

--- a/backend/src/main/java/ca/corbett/movienight/repository/EpisodeRepository.java
+++ b/backend/src/main/java/ca/corbett/movienight/repository/EpisodeRepository.java
@@ -1,6 +1,7 @@
 package ca.corbett.movienight.repository;
 
 import ca.corbett.movienight.model.Episode;
+import ca.corbett.movienight.model.Series;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
@@ -10,11 +11,11 @@ import java.util.List;
 @Repository
 public interface EpisodeRepository extends JpaRepository<Episode, Long>, JpaSpecificationExecutor<Episode> {
 
-    List<Episode> findBySeriesNameContainingIgnoreCaseOrderBySeasonAscEpisodeAsc(String seriesName);
+    List<Episode> findBySeriesOrderBySeasonAscEpisodeAsc(Series series);
 
-    List<Episode> findBySeriesNameIgnoreCaseAndSeasonOrderByEpisodeAsc(String seriesName, Integer season);
-
-    List<Episode> findByWatched(Boolean watched);
+    List<Episode> findByEpisodeTitleContainingIgnoreCase(String episodeTitle);
 
     List<Episode> findByTagsContainingIgnoreCase(String tag);
+
+    long countBySeries(Series series);
 }

--- a/backend/src/main/java/ca/corbett/movienight/repository/SeriesRepository.java
+++ b/backend/src/main/java/ca/corbett/movienight/repository/SeriesRepository.java
@@ -1,0 +1,13 @@
+package ca.corbett.movienight.repository;
+
+import ca.corbett.movienight.model.Series;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface SeriesRepository extends JpaRepository<Series, Long> {
+
+    Optional<Series> findByNameIgnoreCase(String name);
+
+    boolean existsByNameIgnoreCase(String name);
+}

--- a/backend/src/main/java/ca/corbett/movienight/service/EpisodeService.java
+++ b/backend/src/main/java/ca/corbett/movienight/service/EpisodeService.java
@@ -33,8 +33,13 @@ public class EpisodeService {
     }
 
     public Episode updateEpisode(Long id, Episode updatedEpisode) {
+        // Reject request if the episode's series is null:
+        if (updatedEpisode.getSeries() == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Episode series is required.");
+        }
+
         return episodeRepository.findById(id).map(ep -> {
-            ep.setSeriesName(updatedEpisode.getSeriesName());
+            ep.setSeries(updatedEpisode.getSeries());
             ep.setEpisodeTitle(updatedEpisode.getEpisodeTitle());
             ep.setSeason(updatedEpisode.getSeason());
             ep.setEpisode(updatedEpisode.getEpisode());

--- a/backend/src/main/java/ca/corbett/movienight/service/EpisodeService.java
+++ b/backend/src/main/java/ca/corbett/movienight/service/EpisodeService.java
@@ -60,19 +60,17 @@ public class EpisodeService {
     public Episode requireEpisode(Long id) {
         return getEpisodeById(id)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
-                        "Episode not found with id: " + id));
+                                                               "Episode not found with id: " + id));
     }
 
-    public List<Episode> searchEpisodes(String seriesName, Integer season, Integer episode,
+    public List<Episode> searchEpisodes(Long seriesId, Integer season, Integer episode,
                                         Boolean watched, String tag) {
-        Specification<Episode> spec = Specification.where(seriesNameContains(seriesName))
-                .and(seasonEquals(season))
-                .and(episodeEquals(episode))
-                .and(watchedEquals(watched))
-                .and(tagContains(tag));
+        Specification<Episode> spec = Specification.where(seasonEquals(season)).and(episodeEquals(episode))
+                                                   .and(watchedEquals(watched)).and(tagContains(tag))
+                                                   .and(seriesEquals(seriesId));
         Sort sort = Sort.by(
-                Sort.Order.asc("seriesName").ignoreCase(),
-                Sort.Order.asc("season"),
+                Sort.Order.asc("series.name"),
+                Sort.Order.asc("season").nullsLast(),
                 Sort.Order.asc("episode")
         );
         return populateHasThumbnail(episodeRepository.findAll(spec, sort));
@@ -88,15 +86,12 @@ public class EpisodeService {
         return episodes;
     }
 
-    private static Specification<Episode> seriesNameContains(String seriesName) {
-        return (root, query, cb) -> {
-            if (seriesName == null || seriesName.isBlank()) return null;
-            return cb.like(cb.lower(root.get("seriesName")), "%" + seriesName.trim().toLowerCase() + "%");
-        };
-    }
-
     private static Specification<Episode> seasonEquals(Integer season) {
         return (root, query, cb) -> season == null ? null : cb.equal(root.get("season"), season);
+    }
+
+    private static Specification<Episode> seriesEquals(Long seriesId) {
+        return (root, query, cb) -> seriesId == null ? null : cb.equal(root.get("series").get("id"), seriesId);
     }
 
     private static Specification<Episode> episodeEquals(Integer episode) {
@@ -109,7 +104,7 @@ public class EpisodeService {
 
     private static Specification<Episode> tagContains(String tag) {
         return (root, query, cb) -> {
-            if (tag == null || tag.isBlank()) return null;
+            if (tag == null || tag.isBlank()) { return null; }
             query.distinct(true);
             Join<Episode, String> tagsJoin = root.join("tags", JoinType.INNER);
             return cb.like(cb.lower(tagsJoin.as(String.class)), "%" + tag.trim().toLowerCase() + "%");

--- a/backend/src/main/java/ca/corbett/movienight/service/GenreService.java
+++ b/backend/src/main/java/ca/corbett/movienight/service/GenreService.java
@@ -1,7 +1,6 @@
 package ca.corbett.movienight.service;
 
 import ca.corbett.movienight.model.Genre;
-import ca.corbett.movienight.model.Movie;
 import ca.corbett.movienight.repository.GenreRepository;
 import ca.corbett.movienight.repository.MovieRepository;
 import org.springframework.http.HttpStatus;

--- a/backend/src/main/java/ca/corbett/movienight/service/SeriesService.java
+++ b/backend/src/main/java/ca/corbett/movienight/service/SeriesService.java
@@ -1,0 +1,90 @@
+package ca.corbett.movienight.service;
+
+import ca.corbett.movienight.model.Series;
+import ca.corbett.movienight.repository.EpisodeRepository;
+import ca.corbett.movienight.repository.SeriesRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class SeriesService {
+    private final EpisodeRepository episodeRepository;
+    private final SeriesRepository seriesRepository;
+    private final ThumbnailService thumbnailService;
+
+    public SeriesService(EpisodeRepository episodeRepository,
+                         SeriesRepository seriesRepository,
+                         ThumbnailService thumbnailService) {
+        this.thumbnailService = thumbnailService;
+        this.episodeRepository = episodeRepository;
+        this.seriesRepository = seriesRepository;
+    }
+
+    public List<Series> getAllSeries() {
+        return populateTransientFields(seriesRepository.findAll());
+    }
+
+    public Optional<Series> getSeriesById(Long id) {
+        return seriesRepository.findById(id).map(this::populateTransientFields);
+    }
+
+    public Series requireSeries(Long id) {
+        return getSeriesById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                                                               "Series not found with id: " + id));
+    }
+
+    public Series saveSeries(Series series) {
+        return populateTransientFields(seriesRepository.save(series));
+    }
+
+    public void deleteSeries(Long id) {
+        // Throw a 404 if the Genre doesn't exist:
+        if (!seriesRepository.existsById(id)) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Series not found with id: " + id);
+        }
+
+        // Throw a 409 if any Episode currently references this Series:
+        if (episodeRepository.countBySeries(requireSeries(id)) > 0) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                                              "Cannot delete series with id: " + id
+                                                      + " because it is referenced by existing episodes.");
+        }
+
+        thumbnailService.deleteThumbnail("genres", id);
+        seriesRepository.deleteById(id);
+    }
+
+    public Series updateSeries(Long id, Series updatedSeries) {
+        Series existingSeries = requireSeries(id);
+        existingSeries.setName(updatedSeries.getName());
+        existingSeries.setDescription(updatedSeries.getDescription());
+        return populateTransientFields(seriesRepository.save(existingSeries));
+    }
+
+    private Series populateHasThumbnail(Series series) {
+        series.setHasThumbnail(thumbnailService.hasThumbnail("series", series.getId()));
+        return series;
+    }
+
+    private Series populateEpisodeCount(Series series) {
+        series.setEpisodeCount(episodeRepository.countBySeries(series));
+        return series;
+    }
+
+    private Series populateTransientFields(Series series) {
+        populateHasThumbnail(series);
+        populateEpisodeCount(series);
+        return series;
+    }
+
+    private List<Series> populateTransientFields(List<Series> series) {
+        series.forEach(this::populateTransientFields);
+        return series;
+    }
+
+}

--- a/backend/src/main/java/ca/corbett/movienight/service/SeriesService.java
+++ b/backend/src/main/java/ca/corbett/movienight/service/SeriesService.java
@@ -55,7 +55,7 @@ public class SeriesService {
                                                       + " because it is referenced by existing episodes.");
         }
 
-        thumbnailService.deleteThumbnail("genres", id);
+        thumbnailService.deleteThumbnail("series", id);
         seriesRepository.deleteById(id);
     }
 

--- a/backend/src/main/java/ca/corbett/movienight/service/SeriesService.java
+++ b/backend/src/main/java/ca/corbett/movienight/service/SeriesService.java
@@ -65,8 +65,18 @@ public class SeriesService {
 
     public Series updateSeries(Long id, Series updatedSeries) {
         Series existingSeries = requireSeries(id);
+
+        seriesRepository.findByNameIgnoreCase(updatedSeries.getName())
+                .filter(series -> !series.getId().equals(id))
+                .ifPresent(series -> {
+                    throw new ResponseStatusException(HttpStatus.CONFLICT,
+                                                      "Series already exists with name: "
+                                                              + updatedSeries.getName());
+                });
+
         existingSeries.setName(updatedSeries.getName());
         existingSeries.setDescription(updatedSeries.getDescription());
+        existingSeries.setYear(updatedSeries.getYear());
         return populateTransientFields(seriesRepository.save(existingSeries));
     }
 

--- a/backend/src/main/java/ca/corbett/movienight/service/SeriesService.java
+++ b/backend/src/main/java/ca/corbett/movienight/service/SeriesService.java
@@ -39,6 +39,10 @@ public class SeriesService {
     }
 
     public Series saveSeries(Series series) {
+        if (seriesRepository.existsByNameIgnoreCase(series.getName())) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                                              "Series already exists with name: " + series.getName());
+        }
         return populateTransientFields(seriesRepository.save(series));
     }
 

--- a/backend/src/main/java/ca/corbett/movienight/service/ThumbnailService.java
+++ b/backend/src/main/java/ca/corbett/movienight/service/ThumbnailService.java
@@ -1,13 +1,13 @@
 package ca.corbett.movienight.service;
 
 import jakarta.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.imageio.ImageIO;
 import javax.imageio.ImageReader;
@@ -51,6 +51,7 @@ public class ThumbnailService {
             Files.createDirectories(dir.resolve("movies"));
             Files.createDirectories(dir.resolve("episodes"));
             Files.createDirectories(dir.resolve("genres"));
+            Files.createDirectories(dir.resolve("series"));
             enabled = true;
             logger.info("Thumbnail support enabled using {}", dir);
         } catch (IOException e) {

--- a/backend/src/test/java/ca/corbett/movienight/EpisodeRepositoryTest.java
+++ b/backend/src/test/java/ca/corbett/movienight/EpisodeRepositoryTest.java
@@ -1,7 +1,9 @@
 package ca.corbett.movienight;
 
 import ca.corbett.movienight.model.Episode;
+import ca.corbett.movienight.model.Series;
 import ca.corbett.movienight.repository.EpisodeRepository;
+import ca.corbett.movienight.repository.SeriesRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
@@ -27,72 +29,28 @@ class EpisodeRepositoryTest {
     @Autowired
     private EpisodeRepository episodeRepository;
 
+    @Autowired
+    private SeriesRepository seriesRepository;
+
     @Test
     void saveAndFindEpisode() {
-        Episode ep = new Episode("Dexter", "Hungry Man", 4, 9, "Thanksgiving.", false);
+        Series dexter = new Series("Dexter", "A blood spatter analyst leads a secret life as a vigilante.");
+        seriesRepository.save(dexter);
+        Episode ep = new Episode(dexter, "Hungry Man", 4, 9, "Thanksgiving.", false);
         ep.setVideoFilePath("/shows/dexter/s04e09.mkv");
         episodeRepository.save(ep);
 
         List<Episode> all = episodeRepository.findAll();
         assertThat(all).hasSize(1);
-        assertThat(all.get(0).getSeriesName()).isEqualTo("Dexter");
-    }
-
-    @Test
-    void findBySeriesNameContainingIgnoreCase() {
-        Episode dexterPilot = new Episode("Dexter", "Pilot", 1, 1, "Dexter pilot.", false);
-        dexterPilot.setVideoFilePath("/shows/dexter/s01e01.mkv");
-        episodeRepository.save(dexterPilot);
-        Episode bbPilot = new Episode("Breaking Bad", "Pilot", 1, 1, "BB pilot.", false);
-        bbPilot.setVideoFilePath("/shows/breakingbad/s01e01.mkv");
-        episodeRepository.save(bbPilot);
-
-        List<Episode> results = episodeRepository
-                .findBySeriesNameContainingIgnoreCaseOrderBySeasonAscEpisodeAsc("dexter");
-        assertThat(results).hasSize(1);
-        assertThat(results.get(0).getSeriesName()).isEqualTo("Dexter");
-    }
-
-    @Test
-    void findBySeriesNameAndSeasonOrderedByEpisode() {
-        Episode ep3 = new Episode("Dexter", "Ep 3", 4, 3, null, false);
-        ep3.setVideoFilePath("/shows/dexter/s04e03.mkv");
-        episodeRepository.save(ep3);
-        Episode ep1 = new Episode("Dexter", "Ep 1", 4, 1, null, false);
-        ep1.setVideoFilePath("/shows/dexter/s04e01.mkv");
-        episodeRepository.save(ep1);
-        Episode ep2 = new Episode("Dexter", "Ep 2", 4, 2, null, false);
-        ep2.setVideoFilePath("/shows/dexter/s04e02.mkv");
-        episodeRepository.save(ep2);
-        Episode s3ep1 = new Episode("Dexter", "S3Ep1", 3, 1, null, false);
-        s3ep1.setVideoFilePath("/shows/dexter/s03e01.mkv");
-        episodeRepository.save(s3ep1);
-
-        List<Episode> results = episodeRepository
-                .findBySeriesNameIgnoreCaseAndSeasonOrderByEpisodeAsc("Dexter", 4);
-        assertThat(results).hasSize(3);
-        assertThat(results.get(0).getEpisode()).isEqualTo(1);
-        assertThat(results.get(1).getEpisode()).isEqualTo(2);
-        assertThat(results.get(2).getEpisode()).isEqualTo(3);
-    }
-
-    @Test
-    void findByWatched() {
-        Episode watchedEp = new Episode("Dexter", "Watched Ep", 1, 1, null, true);
-        watchedEp.setVideoFilePath("/shows/dexter/s01e01.mkv");
-        episodeRepository.save(watchedEp);
-        Episode unwatchedEp = new Episode("Dexter", "Unwatched Ep", 1, 2, null, false);
-        unwatchedEp.setVideoFilePath("/shows/dexter/s01e02.mkv");
-        episodeRepository.save(unwatchedEp);
-
-        List<Episode> watched = episodeRepository.findByWatched(true);
-        assertThat(watched).hasSize(1);
-        assertThat(watched.get(0).getEpisodeTitle()).isEqualTo("Watched Ep");
+        assertThat(all.get(0).getSeries().getName()).isEqualTo("Dexter");
+        assertThat(all.get(0).getSeries().getDescription()).contains("vigilante");
     }
 
     @Test
     void saveAndFindEpisodeWithTags() {
-        Episode ep = new Episode("Dexter", "Hungry Man", 4, 9, "Thanksgiving.", false);
+        Series dexter = new Series("Dexter");
+        seriesRepository.save(dexter);
+        Episode ep = new Episode(dexter, "Hungry Man", 4, 9, "Thanksgiving.", false);
         ep.setVideoFilePath("/shows/dexter/s04e09.mkv");
         ep.setTags(List.of("Drama", "Thriller", "Must-See"));
         episodeRepository.save(ep);
@@ -104,7 +62,9 @@ class EpisodeRepositoryTest {
 
     @Test
     void tagsAreNormalizedToLowercase() {
-        Episode ep = new Episode("Show", "Ep", 1, 1, null, false);
+        Series dexter = new Series("Dexter");
+        seriesRepository.save(dexter);
+        Episode ep = new Episode(dexter, "Ep", 1, 1, null, false);
         ep.setVideoFilePath("/shows/show/s01e01.mkv");
         ep.setTags(List.of("Drama", "DRAMA", "drama", "  Drama  "));
         episodeRepository.save(ep);
@@ -115,11 +75,15 @@ class EpisodeRepositoryTest {
 
     @Test
     void findByTagsContainingIgnoreCase() {
-        Episode ep1 = new Episode("Show A", "Ep1", 1, 1, null, false);
+        Series showA = new Series("Show A");
+        seriesRepository.save(showA);
+        Episode ep1 = new Episode(showA, "Ep1", 1, 1, null, false);
         ep1.setVideoFilePath("/shows/showa/s01e01.mkv");
         ep1.setTags(List.of("drama", "award-winner"));
 
-        Episode ep2 = new Episode("Show B", "Ep1", 1, 1, null, false);
+        Series showB = new Series("Show B");
+        seriesRepository.save(showB);
+        Episode ep2 = new Episode(showB, "Ep1", 1, 1, null, false);
         ep2.setVideoFilePath("/shows/showb/s01e01.mkv");
         ep2.setTags(List.of("comedy", "family"));
 
@@ -127,26 +91,28 @@ class EpisodeRepositoryTest {
 
         List<Episode> results = episodeRepository.findByTagsContainingIgnoreCase("drama");
         assertThat(results).hasSize(1);
-        assertThat(results.get(0).getSeriesName()).isEqualTo("Show A");
+        assertThat(results.get(0).getSeries().getName()).isEqualTo("Show A");
     }
 
     @Test
     void searchOrderedBySeasonThenEpisode() {
-        Episode s4e3 = new Episode("Dexter", "S4E3", 4, 3, null, false);
+        Series dexter = new Series("Dexter");
+        seriesRepository.save(dexter);
+        Episode s4e3 = new Episode(dexter, "S4E3", 4, 3, null, false);
         s4e3.setVideoFilePath("/shows/dexter/s04e03.mkv");
         episodeRepository.save(s4e3);
-        Episode s2e1 = new Episode("Dexter", "S2E1", 2, 1, null, false);
+        Episode s2e1 = new Episode(dexter, "S2E1", 2, 1, null, false);
         s2e1.setVideoFilePath("/shows/dexter/s02e01.mkv");
         episodeRepository.save(s2e1);
-        Episode s4e1 = new Episode("Dexter", "S4E1", 4, 1, null, false);
+        Episode s4e1 = new Episode(dexter, "S4E1", 4, 1, null, false);
         s4e1.setVideoFilePath("/shows/dexter/s04e01.mkv");
         episodeRepository.save(s4e1);
-        Episode s1e1 = new Episode("Dexter", "S1E1", 1, 1, null, false);
+        Episode s1e1 = new Episode(dexter, "S1E1", 1, 1, null, false);
         s1e1.setVideoFilePath("/shows/dexter/s01e01.mkv");
         episodeRepository.save(s1e1);
 
         Specification<Episode> spec = (root, query, cb) ->
-                cb.like(cb.lower(root.get("seriesName")), "%dexter%");
+                cb.equal(root.get("series"), dexter);
         Sort sort = Sort.by(Sort.Direction.ASC, "season")
                 .and(Sort.by(Sort.Direction.ASC, "episode"));
 

--- a/backend/src/test/java/ca/corbett/movienight/MediaServiceTest.java
+++ b/backend/src/test/java/ca/corbett/movienight/MediaServiceTest.java
@@ -3,8 +3,8 @@ package ca.corbett.movienight;
 import ca.corbett.movienight.model.Episode;
 import ca.corbett.movienight.model.Genre;
 import ca.corbett.movienight.model.Movie;
+import ca.corbett.movienight.model.Series;
 import ca.corbett.movienight.service.EpisodeService;
-import ca.corbett.movienight.service.GenreService;
 import ca.corbett.movienight.service.MediaService;
 import ca.corbett.movienight.service.MovieService;
 import org.junit.jupiter.api.BeforeEach;
@@ -44,7 +44,8 @@ class MediaServiceTest {
 
     @Test
     void resolvesEpisodeId() {
-        Episode episode = new Episode("Test Series", "Pilot", 1, 1, "First episode.", false);
+        Series series = new Series("Test Series", "A test series.");
+        Episode episode = new Episode(series, "Pilot", 1, 1, "First episode.", false);
         episode.setVideoFilePath("/episodes/s01e01.mp4");
         when(episodeService.requireEpisode(7L)).thenReturn(episode);
 

--- a/frontend/src/components/EpisodeForm.jsx
+++ b/frontend/src/components/EpisodeForm.jsx
@@ -4,7 +4,7 @@ import FileBrowserModal from './FileBrowserModal'
 const EPISODES_API = '/api/episodes'
 
 const EMPTY_FORM = {
-  seriesName: '',
+  seriesId: '',
   episodeTitle: '',
   season: '',
   episode: '',
@@ -16,6 +16,9 @@ const EMPTY_FORM = {
 
 export default function EpisodeForm({ episode, onSave, onCancel }) {
   const [form, setForm] = useState(EMPTY_FORM)
+  const [series, setSeries] = useState([])
+  const [seriesLoading, setSeriesLoading] = useState(true)
+  const [seriesError, setSeriesError] = useState(null)
   const [errors, setErrors] = useState({})
   const [tagInput, setTagInput] = useState('')
   const [thumbnailFile, setThumbnailFile] = useState(null)
@@ -35,6 +38,36 @@ export default function EpisodeForm({ episode, onSave, onCancel }) {
   }, [])
 
   useEffect(() => {
+    let ignore = false
+
+    const fetchSeries = async () => {
+      try {
+        setSeriesLoading(true)
+        const res = await fetch(SERIES_API)
+        if (!res.ok) throw new Error('Failed to fetch series')
+        const data = await res.json()
+        if (!ignore) {
+          const sortedSeries = Array.isArray(data)
+            ? [...data].sort((a, b) => a.name.localeCompare(b.name))
+            : []
+          setSeries(sortedSeries)
+          setSeriesError(null)
+        }
+      } catch {
+        if (!ignore) setSeriesError('Failed to load series.')
+      } finally {
+        if (!ignore) setSeriesLoading(false)
+      }
+    }
+
+    fetchSeries()
+
+    return () => {
+      ignore = true
+    }
+  }, [])
+
+  useEffect(() => {
     // Revoke any existing object URL when the episode prop changes (form reset)
     if (objectUrlRef.current) {
       URL.revokeObjectURL(objectUrlRef.current)
@@ -42,7 +75,12 @@ export default function EpisodeForm({ episode, onSave, onCancel }) {
     }
     if (episode) {
       setForm({
-        ...episode,
+        id: episode.id,
+        episodeTitle: episode.episodeTitle ?? '',
+        description: episode.description ?? '',
+        videoFilePath: episode.videoFilePath ?? '',
+        watched: episode.watched ?? false,
+        seriesId: episode.series?.id != null ? String(episode.series.id) : '',
         season: episode.season ?? '',
         episode: episode.episode ?? '',
         tags: episode.tags ?? [],
@@ -60,7 +98,7 @@ export default function EpisodeForm({ episode, onSave, onCancel }) {
 
   const validate = () => {
     const errs = {}
-    if (!form.seriesName.trim()) errs.seriesName = 'Series name is required.'
+    if (!form.seriesId) errs.seriesId = 'Series is required.'
     if (!form.videoFilePath || !form.videoFilePath.trim()) errs.videoFilePath = 'Video file path is required.'
     return errs
   }
@@ -71,6 +109,9 @@ export default function EpisodeForm({ episode, onSave, onCancel }) {
       ...prev,
       [name]: type === 'checkbox' ? checked : value,
     }))
+    if (errors[name]) {
+      setErrors((prev) => ({ ...prev, [name]: undefined }))
+    }
   }
 
   const handleSubmit = (e) => {
@@ -84,7 +125,12 @@ export default function EpisodeForm({ episode, onSave, onCancel }) {
       ? [...form.tags, ...tagInput.split(',').map(t => t.trim()).filter(Boolean)]
       : form.tags
     onSave({
-      ...form,
+        id: form.id,
+        seriesId: { id: Number(form.seriesId) },
+        episodeTitle: form.episodeTitle.trim() || null,
+        description: form.description.trim() || null,
+        videoFilePath: form.videoFilePath.trim(),
+        watched: form.watched,
       season: form.season !== '' ? Number(form.season) : null,
       episode: form.episode !== '' ? Number(form.episode) : null,
       tags: pendingTags,
@@ -94,6 +140,8 @@ export default function EpisodeForm({ episode, onSave, onCancel }) {
   }
 
   const isEditing = episode != null
+  const hasMissingSelectedSeries = form.seriesId && !series.some((g) => String(g.id) === String(form.seriesId))
+  const noSeriesAvailable = !seriesLoading && series.length === 0
 
   return (
     <>
@@ -102,15 +150,29 @@ export default function EpisodeForm({ episode, onSave, onCancel }) {
 
       {/* Series Name */}
       <div>
-        <label className="block text-sm text-gray-400 mb-1">Series Name *</label>
-        <input
-          name="seriesName"
-          value={form.seriesName}
+        <label className="block text-sm text-gray-400 mb-1">Series *</label>
+        <select
+          name="seriesId"
+          value={form.seriesId}
           onChange={handleChange}
-          placeholder="e.g. Dexter"
-          className={`w-full bg-gray-800 border rounded-lg px-3 py-2 text-gray-100 focus:outline-none focus:border-indigo-500 ${errors.seriesName ? 'border-red-500' : 'border-gray-700'}`}
-        />
-        {errors.seriesName && <p className="text-red-400 text-xs mt-1">{errors.seriesName}</p>}
+          disabled={seriesLoading || series.length === 0}
+          className={`w-full bg-gray-800 border rounded-lg px-3 py-2 text-gray-100 focus:outline-none focus:border-indigo-500 ${errors.seriesId ? 'border-red-500' : 'border-gray-700'}`}
+         >
+              <option value="">{seriesLoading ? 'Loading series…' : 'Select a series'}</option>
+              {series.map((series) => (
+                <option key={series.id} value={String(series.id)}>
+                  {series.name}
+                </option>
+              ))}
+            </select>
+            {errors.seriesId && <p className="text-red-400 text-xs mt-1">{errors.seriesId}</p>}
+            {hasMissingSelectedSeries && (
+              <p className="text-red-400 text-xs mt-1">The previously selected series no longer exists. Please select a valid series.</p>
+            )}
+            {seriesError && <p className="text-red-400 text-xs mt-1">{seriesError}</p>}
+            {noSeriesAvailable && !seriesError && (
+              <p className="text-amber-300 text-xs mt-1">No series exist yet. Create one first, then add episodes.</p>
+            )}
       </div>
 
       {/* Episode Title */}
@@ -307,7 +369,8 @@ export default function EpisodeForm({ episode, onSave, onCancel }) {
       <div className="flex gap-3 pt-2">
         <button
           type="submit"
-          className="flex-1 bg-indigo-600 hover:bg-indigo-500 text-white font-medium py-2 rounded-lg transition-colors"
+            disabled={noSeriesAvailable || seriesLoading || Boolean(seriesError) || Boolean(hasMissingSelectedSeries)}
+          className="flex-1 bg-indigo-600 hover:bg-indigo-500 disabled:bg-gray-700 disabled:text-gray-400 disabled:cursor-not-allowed text-white font-medium py-2 rounded-lg transition-colors"
         >
           {isEditing ? 'Save Changes' : 'Add Episode'}
         </button>

--- a/frontend/src/components/EpisodeForm.jsx
+++ b/frontend/src/components/EpisodeForm.jsx
@@ -127,7 +127,7 @@ export default function EpisodeForm({ episode, onSave, onCancel }) {
       : form.tags
     onSave({
         id: form.id,
-        seriesId: { id: Number(form.seriesId) },
+        series: { id: Number(form.seriesId) },
         episodeTitle: form.episodeTitle.trim() || null,
         description: form.description.trim() || null,
         videoFilePath: form.videoFilePath.trim(),

--- a/frontend/src/components/EpisodeForm.jsx
+++ b/frontend/src/components/EpisodeForm.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from 'react'
 import FileBrowserModal from './FileBrowserModal'
 
 const EPISODES_API = '/api/episodes'
+const SERIES_API = '/api/series'
 
 const EMPTY_FORM = {
   seriesId: '',

--- a/frontend/src/components/EpisodeList.jsx
+++ b/frontend/src/components/EpisodeList.jsx
@@ -34,6 +34,7 @@ export default function EpisodeList({ episodes, onEdit, onDelete, onTagClick, re
 
 function EpisodeCard({ episode, onEdit, onDelete, onTagClick, readOnly }) {
   const [showPlayer, setShowPlayer] = useState(false)
+  const seriesLabel = typeof episode.series === 'string' ? episode.series : episode.series?.name
 
   const seasonEpisodeLabel = [
     episode.season != null ? `S${episode.season}` : null,
@@ -45,7 +46,7 @@ function EpisodeCard({ episode, onEdit, onDelete, onTagClick, readOnly }) {
       {episode.hasThumbnail && !showPlayer && (
         <img
           src={`${EPISODES_API}/${episode.id}/thumbnail`}
-          alt={`${episode.seriesName} thumbnail`}
+          alt={`${seriesLabel} thumbnail`}
           className="w-full h-48 object-cover"
         />
       )}
@@ -59,7 +60,7 @@ function EpisodeCard({ episode, onEdit, onDelete, onTagClick, readOnly }) {
       <div className="p-5 flex flex-col gap-3 flex-1">
       <div className="flex items-start justify-between gap-2">
         <div className="flex flex-col gap-0.5">
-          <h2 className="text-lg font-semibold text-white leading-tight">{episode.seriesName}</h2>
+          <h2 className="text-lg font-semibold text-white leading-tight">{seriesLabel}</h2>
           {episode.episodeTitle && (
             <p className="text-sm text-gray-300 leading-tight">{episode.episodeTitle}</p>
           )}

--- a/frontend/src/components/SeriesForm.jsx
+++ b/frontend/src/components/SeriesForm.jsx
@@ -1,0 +1,201 @@
+import { useEffect, useRef, useState } from 'react'
+
+const SERIES_API = '/api/series'
+
+const EMPTY_FORM = {
+  id: null,
+  name: '',
+  description: '',
+  year: '',
+}
+
+export default function SeriesForm({ series, onSave, onCancel }) {
+  const [form, setForm] = useState(EMPTY_FORM)
+  const [errors, setErrors] = useState({})
+  const [thumbnailFile, setThumbnailFile] = useState(null)
+  const [thumbnailPreview, setThumbnailPreview] = useState(null)
+  const [clearThumbnail, setClearThumbnail] = useState(false)
+  const fileInputRef = useRef(null)
+  const objectUrlRef = useRef(null)
+
+  useEffect(() => {
+    return () => {
+      if (objectUrlRef.current) {
+        URL.revokeObjectURL(objectUrlRef.current)
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    if (objectUrlRef.current) {
+      URL.revokeObjectURL(objectUrlRef.current)
+      objectUrlRef.current = null
+    }
+
+    if (series) {
+      setForm({
+        id: series.id,
+        name: series.name ?? '',
+        description: series.description ?? '',
+        year: series.year ?? '',
+      })
+      setThumbnailPreview(series.hasThumbnail ? `${SERIES_API}/${series.id}/thumbnail` : null)
+    } else {
+      setForm(EMPTY_FORM)
+      setThumbnailPreview(null)
+    }
+
+    setErrors({})
+    setThumbnailFile(null)
+    setClearThumbnail(false)
+  }, [series])
+
+  const validate = () => {
+    const nextErrors = {}
+    if (!form.name.trim()) {
+      nextErrors.name = 'Name is required.'
+    }
+    if (form.year && (isNaN(form.year) || form.year < 1888 || form.year > 2100)) {
+      errs.year = 'Enter a valid year (1888–2100).'
+    }
+    return nextErrors
+  }
+
+  const handleChange = (event) => {
+    const { name, value } = event.target
+    setForm((prev) => ({ ...prev, [name]: value }))
+    if (errors[name]) {
+      setErrors((prev) => ({ ...prev, [name]: undefined }))
+    }
+  }
+
+  const handleSubmit = (event) => {
+    event.preventDefault()
+    const nextErrors = validate()
+    if (Object.keys(nextErrors).length > 0) {
+      setErrors(nextErrors)
+      return
+    }
+
+    onSave({
+      id: form.id,
+      name: form.name.trim(),
+      description: form.description?.trim() || null,
+      _thumbnail: thumbnailFile,
+      _clearThumbnail: clearThumbnail,
+      year: form.year !== '' ? Number(form.year) : null,
+    })
+  }
+
+  const isEditing = series != null
+
+  return (
+    <form onSubmit={handleSubmit} className="p-6 flex flex-col gap-4">
+      <h2 className="text-xl font-bold text-white">{isEditing ? 'Edit Series' : 'Add Series'}</h2>
+
+      <div>
+        <label className="block text-sm text-gray-400 mb-1">Name *</label>
+        <input
+          name="name"
+          value={form.name}
+          onChange={handleChange}
+          placeholder="e.g. The Office"
+          className={`w-full bg-gray-800 border rounded-lg px-3 py-2 text-gray-100 focus:outline-none focus:border-indigo-500 ${errors.name ? 'border-red-500' : 'border-gray-700'}`}
+        />
+        {errors.name && <p className="text-red-400 text-xs mt-1">{errors.name}</p>}
+      </div>
+
+      <div>
+        <label className="block text-sm text-gray-400 mb-1">Description</label>
+        <textarea
+          name="description"
+          value={form.description}
+          onChange={handleChange}
+          rows={4}
+          className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-gray-100 focus:outline-none focus:border-indigo-500 resize-none"
+        />
+      </div>
+
+        <div>
+          <label className="block text-sm text-gray-400 mb-1">Year</label>
+          <input
+            name="year"
+            type="number"
+            value={form.year}
+            onChange={handleChange}
+            placeholder="e.g. 2024"
+            className={`w-full bg-gray-800 border rounded-lg px-3 py-2 text-gray-100 focus:outline-none focus:border-indigo-500 ${errors.year ? 'border-red-500' : 'border-gray-700'}`}
+          />
+          {errors.year && <p className="text-red-400 text-xs mt-1">{errors.year}</p>}
+        </div>
+
+      <div>
+        <label className="block text-sm text-gray-400 mb-1">Thumbnail</label>
+        {thumbnailPreview && !clearThumbnail && (
+          <div className="mb-2 relative inline-block">
+            <img
+              src={thumbnailPreview}
+              alt="Series thumbnail preview"
+              className="rounded-lg max-h-40 object-cover border border-gray-700"
+            />
+            <button
+              type="button"
+              onClick={() => {
+                if (objectUrlRef.current) {
+                  URL.revokeObjectURL(objectUrlRef.current)
+                  objectUrlRef.current = null
+                }
+                setThumbnailPreview(null)
+                setThumbnailFile(null)
+                setClearThumbnail(series?.hasThumbnail ?? false)
+                if (fileInputRef.current) fileInputRef.current.value = ''
+              }}
+              className="absolute top-1 right-1 bg-gray-900/80 hover:bg-red-800/80 text-gray-300 hover:text-white rounded-full w-6 h-6 flex items-center justify-center text-xs leading-none"
+              aria-label="Remove thumbnail"
+            >
+              ×
+            </button>
+          </div>
+        )}
+
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/jpeg,image/png"
+          onChange={(event) => {
+            const file = event.target.files?.[0]
+            if (!file) return
+
+            if (objectUrlRef.current) {
+              URL.revokeObjectURL(objectUrlRef.current)
+            }
+            const url = URL.createObjectURL(file)
+            objectUrlRef.current = url
+            setThumbnailFile(file)
+            setClearThumbnail(false)
+            setThumbnailPreview(url)
+          }}
+          className="block w-full text-sm text-gray-400 file:mr-3 file:py-1.5 file:px-3 file:rounded-lg file:border-0 file:text-sm file:bg-gray-700 file:text-gray-200 hover:file:bg-gray-600 cursor-pointer"
+        />
+        <p className="text-xs text-gray-500 mt-1">JPEG or PNG, 26×26 to 2000×2000</p>
+      </div>
+
+      <div className="flex gap-3 pt-2">
+        <button
+          type="submit"
+          className="flex-1 bg-indigo-600 hover:bg-indigo-500 text-white font-medium py-2 rounded-lg transition-colors"
+        >
+          {isEditing ? 'Save Changes' : 'Add Series'}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="flex-1 bg-gray-700 hover:bg-gray-600 text-gray-200 font-medium py-2 rounded-lg transition-colors"
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  )
+}
+

--- a/frontend/src/components/SeriesForm.jsx
+++ b/frontend/src/components/SeriesForm.jsx
@@ -56,7 +56,7 @@ export default function SeriesForm({ series, onSave, onCancel }) {
       nextErrors.name = 'Name is required.'
     }
     if (form.year && (isNaN(form.year) || form.year < 1888 || form.year > 2100)) {
-      errs.year = 'Enter a valid year (1888–2100).'
+      nextErrors.year = 'Enter a valid year (1888–2100).'
     }
     return nextErrors
   }

--- a/frontend/src/components/SeriesList.jsx
+++ b/frontend/src/components/SeriesList.jsx
@@ -1,0 +1,93 @@
+const SERIES_API = '/api/series'
+
+export default function SeriesList({ series, onEdit, onDelete, onSeriesClick, readOnly = false }) {
+  if (series.length === 0) {
+    return (
+      <div className="text-center text-gray-500 py-16">
+        <p className="text-5xl mb-4" aria-hidden="true">🏷️</p>
+        <p className="text-xl">No series found.</p>
+        <p className="text-sm mt-2">
+          {readOnly ? 'Try adjusting your filters.' : 'Add a series to get started!'}
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
+      {series.map((series) => (
+        <SeriesCard
+          key={series.id}
+          series={series}
+          onEdit={onEdit}
+          onDelete={onDelete}
+          onSeriesClick={onSeriesClick}
+          readOnly={readOnly}
+        />
+      ))}
+    </div>
+  )
+}
+
+function SeriesCard({ series, onEdit, onDelete, onSeriesClick, readOnly }) {
+  const isClickable = typeof onSeriesClick === 'function'
+
+  return (
+    <div
+      className={`bg-gray-900 border border-gray-800 rounded-xl overflow-hidden flex flex-col transition-colors ${
+        isClickable ? 'cursor-pointer hover:border-indigo-500 hover:bg-gray-800/60' : 'hover:border-gray-600'
+      }`}
+      onClick={isClickable ? () => onSeriesClick(series) : undefined}
+    >
+      {series.hasThumbnail && (
+        <img
+          src={`${SERIES_API}/${series.id}/thumbnail`}
+          alt={`${series.name} thumbnail`}
+          className="w-full h-48 object-cover"
+        />
+      )}
+
+      <div className="p-5 flex flex-col gap-3 flex-1">
+        <div className="flex items-start justify-between gap-2">
+          <h2 className="text-lg font-semibold text-white leading-tight">{series.name}</h2>
+          {series.episodeCount > 0 && (
+            <span
+              className="shrink-0 text-xs bg-indigo-800/40 text-indigo-300 px-2 py-0.5 rounded-full"
+              aria-label={`${series.episodeCount} ${series.episodeCount === 1 ? 'episode' : 'episodes'} in this series`}
+            >
+              {series.episodeCount} {series.episodeCount === 1 ? 'episode' : 'episodes'}
+            </span>
+          )}
+        </div>
+
+      <div className="flex flex-wrap gap-x-4 gap-y-1 text-sm text-gray-400">
+        {series.year && <span>📅 {series.year}</span>}
+      </div>
+
+        {series.description ? (
+          <p className="text-sm text-gray-400 line-clamp-3">{series.description}</p>
+        ) : (
+          <p className="text-sm text-gray-500 italic">No description.</p>
+        )}
+
+        {!readOnly && (
+          <div className="flex gap-2 mt-auto pt-2" onClick={(e) => e.stopPropagation()}>
+            <button
+              onClick={() => onEdit(series)}
+              className="flex-1 bg-gray-800 hover:bg-gray-700 text-gray-200 text-sm px-3 py-1.5 rounded-lg transition-colors"
+            >
+              Edit
+            </button>
+            <button
+              onClick={() => onDelete(series.id)}
+              className="flex-1 bg-red-900/40 hover:bg-red-800/60 text-red-300 text-sm px-3 py-1.5 rounded-lg transition-colors"
+            >
+              Delete
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+

--- a/frontend/src/pages/MediaLibraryPage.jsx
+++ b/frontend/src/pages/MediaLibraryPage.jsx
@@ -369,7 +369,7 @@ export default function MediaLibraryPage({ mode }) {
                 } else if (activeTab === 'episodes') {
                   setEditingEpisode(null)
                   setShowEpisodeForm(true)
-                } else if (activeTab == 'genres') {
+                } else if (activeTab === 'genres') {
                   setEditingGenre(null)
                   setShowGenreForm(true)
                 } else if (activeTab === 'series') {

--- a/frontend/src/pages/MediaLibraryPage.jsx
+++ b/frontend/src/pages/MediaLibraryPage.jsx
@@ -91,7 +91,7 @@ export default function MediaLibraryPage({ mode }) {
     try {
       setEpisodesLoading(true)
       const params = new URLSearchParams()
-      if (episodeSeriesQuery) params.append('seriesName', episodeSeriesQuery)
+      if (episodeSeriesQuery) params.append('seriesId', episodeSeriesQuery)
       if (episodeSeasonQuery !== '') params.append('season', episodeSeasonQuery)
       if (filterEpisodeWatched !== '') params.append('watched', filterEpisodeWatched)
       if (episodeTagQuery) params.append('tag', episodeTagQuery)
@@ -603,7 +603,7 @@ export default function MediaLibraryPage({ mode }) {
           <div className="flex flex-col sm:flex-row gap-3 mb-6">
             <input
               type="text"
-              placeholder="Search by series name…"
+              placeholder="Search by series…"
               value={episodeSeriesQuery}
               onChange={(e) => setEpisodeSeriesQuery(e.target.value)}
               className="flex-1 bg-gray-800 border border-gray-700 rounded-lg px-4 py-2 text-gray-100 placeholder-gray-500 focus:outline-none focus:border-indigo-500"

--- a/frontend/src/pages/MediaLibraryPage.jsx
+++ b/frontend/src/pages/MediaLibraryPage.jsx
@@ -5,10 +5,13 @@ import EpisodeList from '../components/EpisodeList'
 import EpisodeForm from '../components/EpisodeForm'
 import GenreList from '../components/GenreList'
 import GenreForm from '../components/GenreForm'
+import SeriesList from '../components/SeriesList'
+import SeriesForm from '../components/SeriesForm'
 
 const MOVIES_API = '/api/movies'
 const EPISODES_API = '/api/episodes'
 const GENRES_API = '/api/genres'
+const SERIES_API = '/api/series'
 
 export default function MediaLibraryPage({ mode }) {
   const isAdmin = mode === 'admin'
@@ -40,6 +43,14 @@ export default function MediaLibraryPage({ mode }) {
   const [editingGenre, setEditingGenre] = useState(null)
   const [genreSearchQuery, setGenreSearchQuery] = useState('')
   const [selectedGenre, setSelectedGenre] = useState(null)
+
+  const [series, setSeries] = useState([])
+  const [seriesLoading, setSeriesLoading] = useState(true)
+  const [seriesError, setSeriesError] = useState(null)
+  const [showSeriesForm, setShowSeriesForm] = useState(false)
+  const [editingSeries, setEditingSeries] = useState(null)
+  const [seriesSearchQuery, setSeriesSearchQuery] = useState('')
+  const [selectedSeries, setSelectedSeries] = useState(null)
 
   const getErrorMessage = async (response, fallbackMessage) => {
     const body = await response.text()
@@ -99,6 +110,29 @@ export default function MediaLibraryPage({ mode }) {
     if (activeTab !== 'episodes') return
     fetchEpisodes()
   }, [activeTab, episodeSeriesQuery, episodeSeasonQuery, filterEpisodeWatched, episodeTagQuery])
+
+  const fetchSeries = async () => {
+    try {
+      setSeriesLoading(true)
+      const res = await fetch(SERIES_API)
+      if (!res.ok) throw new Error('Failed to fetch series')
+      const data = await res.json()
+      const sortedSeries = Array.isArray(data)
+        ? [...data].sort((a, b) => a.name.localeCompare(b.name))
+        : []
+      setSeries(sortedSeries)
+      setSeriesError(null)
+    } catch (err) {
+      setSeriesError(err.message)
+    } finally {
+      setSeriesLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    if (activeTab !== 'series' && activeTab !== 'episodes') return
+    fetchSeries()
+  }, [activeTab])
 
   const fetchGenres = async () => {
     try {
@@ -249,13 +283,64 @@ export default function MediaLibraryPage({ mode }) {
     ? '+ Add Movie'
     : activeTab === 'episodes'
       ? '+ Add Episode'
-      : '+ Add Genre'
+      : activeTab === 'genres'
+      ? '+ Add Genre'
+      : '+ Add Series'
 
   const filteredGenres = genres.filter((genre) => {
     const q = genreSearchQuery.trim().toLowerCase()
     if (!q) return true
     return (genre.name || '').toLowerCase().includes(q)
       || (genre.description || '').toLowerCase().includes(q)
+  })
+
+  const handleSaveSeries = async (seriesData) => {
+    try {
+      const { _thumbnail, _clearThumbnail, ...data } = seriesData
+      const isEdit = data.id != null
+      const url = isEdit ? `${SERIES_API}/${data.id}` : SERIES_API
+      const res = await fetch(url, {
+        method: isEdit ? 'PUT' : 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      })
+      if (!res.ok) throw new Error(await getErrorMessage(res, 'Failed to save series'))
+
+      const saved = await res.json()
+      if (_clearThumbnail) {
+        const thumbnailRes = await fetch(`${SERIES_API}/${saved.id}/thumbnail`, { method: 'DELETE' })
+        if (!thumbnailRes.ok) throw new Error('Failed to delete series thumbnail')
+      } else if (_thumbnail) {
+        const formData = new FormData()
+        formData.append('file', _thumbnail)
+        const thumbnailRes = await fetch(`${SERIES_API}/${saved.id}/thumbnail`, { method: 'POST', body: formData })
+        if (!thumbnailRes.ok) throw new Error('Failed to upload series thumbnail')
+      }
+
+      setShowSeriesForm(false)
+      setEditingSeries(null)
+      fetchSeries()
+    } catch (err) {
+      setSeriesError(err.message)
+    }
+  }
+
+  const handleDeleteSeries = async (id) => {
+    if (!confirm('Delete this series?')) return
+    try {
+      const res = await fetch(`${SERIES_API}/${id}`, { method: 'DELETE' })
+      if (!res.ok) throw new Error(await getErrorMessage(res, 'Failed to delete series'))
+      fetchSeries()
+    } catch (err) {
+      setSeriesError(err.message)
+    }
+  }
+
+  const filteredSeries = series.filter((series) => {
+    const q = seriesSearchQuery.trim().toLowerCase()
+    if (!q) return true
+    return (series.name || '').toLowerCase().includes(q)
+      || (series.description || '').toLowerCase().includes(q)
   })
 
   return (
@@ -284,9 +369,12 @@ export default function MediaLibraryPage({ mode }) {
                 } else if (activeTab === 'episodes') {
                   setEditingEpisode(null)
                   setShowEpisodeForm(true)
-                } else {
+                } else if (activeTab == 'genres') {
                   setEditingGenre(null)
                   setShowGenreForm(true)
+                } else if (activeTab === 'series') {
+                    setEditingSeries(null)
+                    setShowSeriesForm(true)
                 }
               }}
               className="bg-indigo-600 hover:bg-indigo-500 text-white px-4 py-2 rounded-lg font-medium transition-colors"
@@ -305,6 +393,8 @@ export default function MediaLibraryPage({ mode }) {
             setEditingEpisode(null)
             setShowGenreForm(false)
             setEditingGenre(null)
+            setShowSeriesForm(false)
+            setEditingSeries(null)
           }}
           className={`px-5 py-2 rounded-md text-sm font-medium transition-colors ${
             activeTab === 'movies'
@@ -321,6 +411,8 @@ export default function MediaLibraryPage({ mode }) {
             setEditingMovie(null)
             setShowGenreForm(false)
             setEditingGenre(null)
+            setShowSeriesForm(false)
+            setEditingSeries(null)
           }}
           className={`px-5 py-2 rounded-md text-sm font-medium transition-colors ${
             activeTab === 'episodes'
@@ -331,22 +423,44 @@ export default function MediaLibraryPage({ mode }) {
           📺 Episodes
         </button>
         {isAdmin && (
-          <button
-            onClick={() => {
-              setActiveTab('genres')
-              setShowMovieForm(false)
-              setEditingMovie(null)
-              setShowEpisodeForm(false)
-              setEditingEpisode(null)
-            }}
-            className={`px-5 py-2 rounded-md text-sm font-medium transition-colors ${
-              activeTab === 'genres'
-                ? 'bg-indigo-600 text-white'
-                : 'text-gray-400 hover:text-gray-200'
-            }`}
-          >
-            🏷️ Genres
-          </button>
+          <>
+            <button
+              onClick={() => {
+                setActiveTab('genres')
+                setShowMovieForm(false)
+                setEditingMovie(null)
+                setShowEpisodeForm(false)
+                setEditingEpisode(null)
+                setShowSeriesForm(false)
+                setEditingSeries(null)
+              }}
+              className={`px-5 py-2 rounded-md text-sm font-medium transition-colors ${
+                activeTab === 'genres'
+                  ? 'bg-indigo-600 text-white'
+                  : 'text-gray-400 hover:text-gray-200'
+              }`}
+            >
+              🏷️ Genres
+            </button>
+            <button
+              onClick={() => {
+                setActiveTab('series')
+                setShowMovieForm(false)
+                setEditingMovie(null)
+                setShowEpisodeForm(false)
+                setEditingEpisode(null)
+                setShowGenreForm(false)
+                setEditingGenre(null)
+              }}
+              className={`px-5 py-2 rounded-md text-sm font-medium transition-colors ${
+                activeTab === 'series'
+                  ? 'bg-indigo-600 text-white'
+                  : 'text-gray-400 hover:text-gray-200'
+              }`}
+            >
+              Series
+            </button>
+          </>
         )}
       </div>
 
@@ -610,6 +724,54 @@ export default function MediaLibraryPage({ mode }) {
                 setShowGenreForm(true)
               }}
               onDelete={handleDeleteGenre}
+              readOnly={!isAdmin}
+            />
+          )}
+        </>
+      )}
+      {activeTab === 'series' && (
+        <>
+          <div className="flex flex-col sm:flex-row gap-3 mb-6">
+            <input
+              type="text"
+              placeholder="Search series…"
+              value={seriesSearchQuery}
+              onChange={(e) => setSeriesSearchQuery(e.target.value)}
+              className="flex-1 bg-gray-800 border border-gray-700 rounded-lg px-4 py-2 text-gray-100 placeholder-gray-500 focus:outline-none focus:border-indigo-500"
+            />
+          </div>
+
+          {seriesError && (
+            <div className="bg-red-900/50 border border-red-700 text-red-300 px-4 py-3 rounded-lg mb-6">
+              {seriesError}
+            </div>
+          )}
+
+          {isAdmin && showSeriesForm && (
+            <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4">
+              <div className="bg-gray-900 border border-gray-700 rounded-xl shadow-2xl w-full max-w-lg overflow-y-auto max-h-[90vh]">
+                <SeriesForm
+                  series={editingSeries}
+                  onSave={handleSaveSeries}
+                  onCancel={() => {
+                    setShowSeriesForm(false)
+                    setEditingSeries(null)
+                  }}
+                />
+              </div>
+            </div>
+          )}
+
+          {seriesLoading ? (
+            <div className="text-center text-gray-400 py-16">Loading…</div>
+          ) : (
+            <SeriesList
+              series={filteredSeries}
+              onEdit={(series) => {
+                setEditingSeries(series)
+                setShowSeriesForm(true)
+              }}
+              onDelete={handleDeleteSeries}
               readOnly={!isAdmin}
             />
           )}


### PR DESCRIPTION
This PR addresses issue #29 by extracting `Episode.seriesName` into a new model object `Series`.  Made the necessary back end changes to support CRUD on series objects. Exposed Series CRUD via the admin UI. Every Episode must be associated with exactly one Series. (This is exactly what was done for Movie and Genre). 

Closes #29 