### PR TITLE
Issue #35 - make file browser persistent

### DIFF
--- a/backend/src/main/java/ca/corbett/movienight/controller/FileBrowserController.java
+++ b/backend/src/main/java/ca/corbett/movienight/controller/FileBrowserController.java
@@ -1,7 +1,11 @@
 package ca.corbett.movienight.controller;
 
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.io.File;
 import java.io.IOException;
@@ -27,6 +31,11 @@ public class FileBrowserController {
             dir = new File(path).getCanonicalFile();
         } catch (IOException e) {
             dir = new File(File.separator);
+        }
+
+        // The UI might give us a file. Not a problem: just use its parent directory.
+        if (dir.isFile()) {
+            dir = dir.getParentFile() == null ? new File(File.separator) : dir.getParentFile();
         }
 
         if (!dir.exists() || !dir.isDirectory()) {

--- a/frontend/src/components/EpisodeForm.jsx
+++ b/frontend/src/components/EpisodeForm.jsx
@@ -3,6 +3,7 @@ import FileBrowserModal from './FileBrowserModal'
 
 const EPISODES_API = '/api/episodes'
 const SERIES_API = '/api/series'
+const LAST_DIR_KEY = 'movienight:lastBrowseDir'
 
 const EMPTY_FORM = {
   seriesId: '',
@@ -26,6 +27,8 @@ export default function EpisodeForm({ episode, onSave, onCancel }) {
   const [thumbnailPreview, setThumbnailPreview] = useState(null)
   const [clearThumbnail, setClearThumbnail] = useState(false)
   const [showFileBrowser, setShowFileBrowser] = useState(false)
+  const [isBrowserOpen, setIsBrowserOpen] = useState(false)
+  const initialBrowsePath = sessionStorage.getItem(LAST_DIR_KEY) || '/'
   const fileInputRef = useRef(null)
   const objectUrlRef = useRef(null)
 
@@ -387,9 +390,14 @@ export default function EpisodeForm({ episode, onSave, onCancel }) {
 
     {showFileBrowser && (
       <FileBrowserModal
-        initialPath={form.videoFilePath || '/'}
+        initialPath={form.videoFilePath || initialBrowsePath}
         onSelect={(path) => {
           const normalizedPath = typeof path === 'string' ? path.trim() : ''
+          // normalizedPath is full path; we want to store its parent dir
+          const parent = normalizedPath.includes('/')
+            ? normalizedPath.substring(0, normalizedPath.lastIndexOf('/')) || '/'
+            : '/'
+          sessionStorage.setItem(LAST_DIR_KEY, parent)
           setForm((prev) => ({ ...prev, videoFilePath: normalizedPath }))
           setErrors((prev) => ({ ...prev, videoFilePath: undefined }))
           setShowFileBrowser(false)

--- a/frontend/src/components/EpisodeForm.jsx
+++ b/frontend/src/components/EpisodeForm.jsx
@@ -27,7 +27,13 @@ export default function EpisodeForm({ episode, onSave, onCancel }) {
   const [thumbnailPreview, setThumbnailPreview] = useState(null)
   const [clearThumbnail, setClearThumbnail] = useState(false)
   const [showFileBrowser, setShowFileBrowser] = useState(false)
-  const initialBrowsePath = sessionStorage.getItem(LAST_DIR_KEY) || '/'
+  const [initialBrowsePath] = useState(() => {
+    try {
+      return sessionStorage.getItem(LAST_DIR_KEY) || '/'
+    } catch {
+      return '/'
+    }
+  })
   const fileInputRef = useRef(null)
   const objectUrlRef = useRef(null)
 

--- a/frontend/src/components/EpisodeForm.jsx
+++ b/frontend/src/components/EpisodeForm.jsx
@@ -27,7 +27,6 @@ export default function EpisodeForm({ episode, onSave, onCancel }) {
   const [thumbnailPreview, setThumbnailPreview] = useState(null)
   const [clearThumbnail, setClearThumbnail] = useState(false)
   const [showFileBrowser, setShowFileBrowser] = useState(false)
-  const [isBrowserOpen, setIsBrowserOpen] = useState(false)
   const initialBrowsePath = sessionStorage.getItem(LAST_DIR_KEY) || '/'
   const fileInputRef = useRef(null)
   const objectUrlRef = useRef(null)
@@ -393,11 +392,6 @@ export default function EpisodeForm({ episode, onSave, onCancel }) {
         initialPath={form.videoFilePath || initialBrowsePath}
         onSelect={(path) => {
           const normalizedPath = typeof path === 'string' ? path.trim() : ''
-          // normalizedPath is full path; we want to store its parent dir
-          const parent = normalizedPath.includes('/')
-            ? normalizedPath.substring(0, normalizedPath.lastIndexOf('/')) || '/'
-            : '/'
-          sessionStorage.setItem(LAST_DIR_KEY, parent)
           setForm((prev) => ({ ...prev, videoFilePath: normalizedPath }))
           setErrors((prev) => ({ ...prev, videoFilePath: undefined }))
           setShowFileBrowser(false)

--- a/frontend/src/components/FileBrowserModal.jsx
+++ b/frontend/src/components/FileBrowserModal.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react'
 
 const FILES_API = '/api/files'
+const LAST_DIR_KEY = 'movienight:lastBrowseDir'
 
 const VIDEO_EXTENSIONS = new Set([
   'mp4', 'mkv', 'avi', 'mov', 'wmv', 'flv', 'webm', 'm4v', 'mpg', 'mpeg', 'ts', 'm2ts',
@@ -29,6 +30,7 @@ export default function FileBrowserModal({ initialPath, onSelect, onClose }) {
       if (!res.ok) throw new Error(`Failed to list directory (${res.status})`)
       const data = await res.json()
       setCurrentPath(data.path)
+      sessionStorage.setItem(LAST_DIR_KEY, data.path)
       setParentPath(data.parent)
       setPathInput(data.path)
       setEntries(data.entries)

--- a/frontend/src/components/FileBrowserModal.jsx
+++ b/frontend/src/components/FileBrowserModal.jsx
@@ -30,7 +30,11 @@ export default function FileBrowserModal({ initialPath, onSelect, onClose }) {
       if (!res.ok) throw new Error(`Failed to list directory (${res.status})`)
       const data = await res.json()
       setCurrentPath(data.path)
-      sessionStorage.setItem(LAST_DIR_KEY, data.path)
+      try {
+        sessionStorage.setItem(LAST_DIR_KEY, data.path)
+      } catch {
+        // Ignore storage persistence failures so browsing still works.
+      }
       setParentPath(data.parent)
       setPathInput(data.path)
       setEntries(data.entries)

--- a/frontend/src/components/MovieForm.jsx
+++ b/frontend/src/components/MovieForm.jsx
@@ -27,7 +27,13 @@ export default function MovieForm({ movie, onSave, onCancel }) {
   const [thumbnailPreview, setThumbnailPreview] = useState(null)
   const [clearThumbnail, setClearThumbnail] = useState(false)
   const [showFileBrowser, setShowFileBrowser] = useState(false)
-  const initialBrowsePath = sessionStorage.getItem(LAST_DIR_KEY) || '/'
+  const [initialBrowsePath] = useState(() => {
+    try {
+      return sessionStorage.getItem(LAST_DIR_KEY) || '/'
+    } catch {
+      return '/'
+    }
+  })
   const fileInputRef = useRef(null)
   const objectUrlRef = useRef(null)
 

--- a/frontend/src/components/MovieForm.jsx
+++ b/frontend/src/components/MovieForm.jsx
@@ -27,7 +27,6 @@ export default function MovieForm({ movie, onSave, onCancel }) {
   const [thumbnailPreview, setThumbnailPreview] = useState(null)
   const [clearThumbnail, setClearThumbnail] = useState(false)
   const [showFileBrowser, setShowFileBrowser] = useState(false)
-  const [isBrowserOpen, setIsBrowserOpen] = useState(false)
   const initialBrowsePath = sessionStorage.getItem(LAST_DIR_KEY) || '/'
   const fileInputRef = useRef(null)
   const objectUrlRef = useRef(null)
@@ -382,11 +381,6 @@ export default function MovieForm({ movie, onSave, onCancel }) {
         initialPath={form.videoFilePath || initialBrowsePath}
         onSelect={(path) => {
           const normalizedPath = path.trim()
-          // normalizedPath is full path; we want to store its parent dir
-          const parent = normalizedPath.includes('/')
-            ? normalizedPath.substring(0, normalizedPath.lastIndexOf('/')) || '/'
-            : '/'
-          sessionStorage.setItem(LAST_DIR_KEY, parent)
           setForm((prev) => ({ ...prev, videoFilePath: normalizedPath }))
           setErrors((prev) => ({ ...prev, videoFilePath: undefined }))
           setShowFileBrowser(false)

--- a/frontend/src/components/MovieForm.jsx
+++ b/frontend/src/components/MovieForm.jsx
@@ -3,6 +3,7 @@ import FileBrowserModal from './FileBrowserModal'
 
 const MOVIES_API = '/api/movies'
 const GENRES_API = '/api/genres'
+const LAST_DIR_KEY = 'movienight:lastBrowseDir'
 
 const EMPTY_FORM = {
   id: null,
@@ -26,6 +27,8 @@ export default function MovieForm({ movie, onSave, onCancel }) {
   const [thumbnailPreview, setThumbnailPreview] = useState(null)
   const [clearThumbnail, setClearThumbnail] = useState(false)
   const [showFileBrowser, setShowFileBrowser] = useState(false)
+  const [isBrowserOpen, setIsBrowserOpen] = useState(false)
+  const initialBrowsePath = sessionStorage.getItem(LAST_DIR_KEY) || '/'
   const fileInputRef = useRef(null)
   const objectUrlRef = useRef(null)
 
@@ -376,9 +379,14 @@ export default function MovieForm({ movie, onSave, onCancel }) {
 
     {showFileBrowser && (
       <FileBrowserModal
-        initialPath={form.videoFilePath || '/'}
+        initialPath={form.videoFilePath || initialBrowsePath}
         onSelect={(path) => {
           const normalizedPath = path.trim()
+          // normalizedPath is full path; we want to store its parent dir
+          const parent = normalizedPath.includes('/')
+            ? normalizedPath.substring(0, normalizedPath.lastIndexOf('/')) || '/'
+            : '/'
+          sessionStorage.setItem(LAST_DIR_KEY, parent)
           setForm((prev) => ({ ...prev, videoFilePath: normalizedPath }))
           setErrors((prev) => ({ ...prev, videoFilePath: undefined }))
           setShowFileBrowser(false)

--- a/frontend/src/components/MusicVideoForm.jsx
+++ b/frontend/src/components/MusicVideoForm.jsx
@@ -27,7 +27,6 @@ export default function MusicVideoForm({ musicVideo, onSave, onCancel }) {
   const [thumbnailPreview, setThumbnailPreview] = useState(null)
   const [clearThumbnail, setClearThumbnail] = useState(false)
   const [showFileBrowser, setShowFileBrowser] = useState(false)
-  const [isBrowserOpen, setIsBrowserOpen] = useState(false)
   const initialBrowsePath = sessionStorage.getItem(LAST_DIR_KEY) || '/'
   const fileInputRef = useRef(null)
   const objectUrlRef = useRef(null)
@@ -380,11 +379,6 @@ export default function MusicVideoForm({ musicVideo, onSave, onCancel }) {
         initialPath={form.videoFilePath || initialBrowsePath}
         onSelect={(path) => {
           const normalizedPath = typeof path === 'string' ? path.trim() : ''
-          // normalizedPath is full path; we want to store its parent dir
-          const parent = normalizedPath.includes('/')
-            ? normalizedPath.substring(0, normalizedPath.lastIndexOf('/')) || '/'
-            : '/'
-          sessionStorage.setItem(LAST_DIR_KEY, parent)
           setForm((prev) => ({ ...prev, videoFilePath: normalizedPath }))
           setErrors((prev) => ({ ...prev, videoFilePath: undefined }))
           setShowFileBrowser(false)

--- a/frontend/src/components/MusicVideoForm.jsx
+++ b/frontend/src/components/MusicVideoForm.jsx
@@ -3,6 +3,7 @@ import FileBrowserModal from './FileBrowserModal'
 
 const MUSIC_VIDEOS_API = '/api/music-videos'
 const ARTISTS_API = '/api/artists'
+const LAST_DIR_KEY = 'movienight:lastBrowseDir'
 
 const EMPTY_FORM = {
   id: null,
@@ -26,6 +27,8 @@ export default function MusicVideoForm({ musicVideo, onSave, onCancel }) {
   const [thumbnailPreview, setThumbnailPreview] = useState(null)
   const [clearThumbnail, setClearThumbnail] = useState(false)
   const [showFileBrowser, setShowFileBrowser] = useState(false)
+  const [isBrowserOpen, setIsBrowserOpen] = useState(false)
+  const initialBrowsePath = sessionStorage.getItem(LAST_DIR_KEY) || '/'
   const fileInputRef = useRef(null)
   const objectUrlRef = useRef(null)
 
@@ -374,9 +377,14 @@ export default function MusicVideoForm({ musicVideo, onSave, onCancel }) {
 
     {showFileBrowser && (
       <FileBrowserModal
-        initialPath={form.videoFilePath || '/'}
+        initialPath={form.videoFilePath || initialBrowsePath}
         onSelect={(path) => {
           const normalizedPath = typeof path === 'string' ? path.trim() : ''
+          // normalizedPath is full path; we want to store its parent dir
+          const parent = normalizedPath.includes('/')
+            ? normalizedPath.substring(0, normalizedPath.lastIndexOf('/')) || '/'
+            : '/'
+          sessionStorage.setItem(LAST_DIR_KEY, parent)
           setForm((prev) => ({ ...prev, videoFilePath: normalizedPath }))
           setErrors((prev) => ({ ...prev, videoFilePath: undefined }))
           setShowFileBrowser(false)

--- a/frontend/src/components/MusicVideoForm.jsx
+++ b/frontend/src/components/MusicVideoForm.jsx
@@ -27,7 +27,13 @@ export default function MusicVideoForm({ musicVideo, onSave, onCancel }) {
   const [thumbnailPreview, setThumbnailPreview] = useState(null)
   const [clearThumbnail, setClearThumbnail] = useState(false)
   const [showFileBrowser, setShowFileBrowser] = useState(false)
-  const initialBrowsePath = sessionStorage.getItem(LAST_DIR_KEY) || '/'
+  const [initialBrowsePath] = useState(() => {
+    try {
+      return sessionStorage.getItem(LAST_DIR_KEY) || '/'
+    } catch {
+      return '/'
+    }
+  })
   const fileInputRef = useRef(null)
   const objectUrlRef = useRef(null)
 

--- a/frontend/src/pages/MediaLibraryPage.jsx
+++ b/frontend/src/pages/MediaLibraryPage.jsx
@@ -493,7 +493,7 @@ export default function MediaLibraryPage({ mode }) {
       }
       setShowMusicVideoForm(false)
       setEditingMusicVideo(null)
-      const isArtistGridView = !selectedArtist && !title && !tag
+      const isArtistGridView = !selectedArtist && !musicVideoTitleQuery && !musicVideoTagQuery
       if (isArtistGridView) {
         fetchArtists()
       } else {


### PR DESCRIPTION
This PR addresses issue #35 by making the file browser remember its last-selected directory within the current session. If the last-selected directory no longer exists, the back end will gracefully fall back to the `/` directory.

Closes #35 

Unrelated to this PR: found and fixed a small bug in `MediaLibraryPage.jsx` that would cause "title is not defined" to appear in the UI when saving a music video from the "browse by artist" list.