### PR TITLE
Issue #37 - make localhost-only Admin API check optional (default true)

### DIFF
--- a/backend/src/main/java/ca/corbett/movienight/config/SecurityConfig.java
+++ b/backend/src/main/java/ca/corbett/movienight/config/SecurityConfig.java
@@ -107,7 +107,7 @@ public class SecurityConfig {
      */
     private void emitLocalhostWarning() {
         if (!localhostWarningIssued) {
-            logger.warn("WARNING: movienight.admin.localhost-only is disabled." +
+            logger.warn("WARNING: movienight.admin.localhost-only is disabled. " +
                                 "This allows admin access from any IP address, which may be a security risk. ");
             localhostWarningIssued = true;
         }

--- a/backend/src/main/java/ca/corbett/movienight/config/SecurityConfig.java
+++ b/backend/src/main/java/ca/corbett/movienight/config/SecurityConfig.java
@@ -1,5 +1,7 @@
 package ca.corbett.movienight.config;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,6 +12,7 @@ import org.springframework.security.authorization.AuthorizationManagers;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -17,9 +20,6 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.intercept.RequestAuthorizationContext;
-import org.springframework.security.config.http.SessionCreationPolicy;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -30,6 +30,7 @@ import static org.springframework.security.authorization.AuthorityAuthorizationM
 public class SecurityConfig {
 
     private static final Logger logger = LoggerFactory.getLogger(SecurityConfig.class);
+    private static boolean localhostWarningIssued = false;
 
     @Bean
     public SecurityFilterChain securityFilterChain(
@@ -60,9 +61,15 @@ public class SecurityConfig {
     }
 
     @Bean
-    public AuthorizationManager<RequestAuthorizationContext> localhostOnlyAccess() {
-        return (authentication, context) ->
-                new AuthorizationDecision(isLoopbackAddress(context.getRequest().getRemoteAddr()));
+    public AuthorizationManager<RequestAuthorizationContext> localhostOnlyAccess(
+            @Value("${movienight.admin.localhost-only:true}") boolean localhostOnly) {
+        return (authentication, context) -> {
+            if (!localhostOnly) {
+                emitLocalhostWarning();
+                return new AuthorizationDecision(true);
+            }
+            return new AuthorizationDecision(isLoopbackAddress(context.getRequest().getRemoteAddr()));
+        };
     }
 
     @Bean
@@ -90,6 +97,19 @@ public class SecurityConfig {
         } catch (UnknownHostException e) {
             logger.warn("Could not resolve remote address {}", remoteAddress, e);
             return false;
+        }
+    }
+
+    /**
+     * The first time this is invoked, it will emit a short warning to the log
+     * about localhost-only access being disabled on the Admin API.
+     * The warning is only emitted once per application run.
+     */
+    private void emitLocalhostWarning() {
+        if (!localhostWarningIssued) {
+            logger.warn("WARNING: movienight.admin.localhost-only is disabled." +
+                                "This allows admin access from any IP address, which may be a security risk. ");
+            localhostWarningIssued = true;
         }
     }
 }

--- a/backend/src/main/java/ca/corbett/movienight/config/SecurityConfig.java
+++ b/backend/src/main/java/ca/corbett/movienight/config/SecurityConfig.java
@@ -23,6 +23,7 @@ import org.springframework.security.web.access.intercept.RequestAuthorizationCon
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.springframework.security.authorization.AuthorityAuthorizationManager.hasRole;
 
@@ -30,7 +31,7 @@ import static org.springframework.security.authorization.AuthorityAuthorizationM
 public class SecurityConfig {
 
     private static final Logger logger = LoggerFactory.getLogger(SecurityConfig.class);
-    private static boolean localhostWarningIssued = false;
+    private static final AtomicBoolean localhostWarningIssued = new AtomicBoolean(false);
 
     @Bean
     public SecurityFilterChain securityFilterChain(
@@ -106,10 +107,10 @@ public class SecurityConfig {
      * The warning is only emitted once per application run.
      */
     private void emitLocalhostWarning() {
-        if (!localhostWarningIssued) {
+        if (!localhostWarningIssued.get()) {
             logger.warn("WARNING: movienight.admin.localhost-only is disabled. " +
-                                "This allows admin access from any IP address, which may be a security risk. ");
-            localhostWarningIssued = true;
+                                "This allows admin access from any IP address, which may be a security risk.");
+            localhostWarningIssued.set(true);
         }
     }
 }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -21,3 +21,8 @@ logging.level.root=INFO
 logging.file.name=${MOVIENIGHT_LOG_FILE:${java.io.tmpdir}/movienight.log}
 logging.pattern.console=%d{yyyy-MM-dd'T'HH:mm:ss.SSSXXX} %-5level [%thread] [%X{correlationId:-}] %logger{36} - %msg%n
 logging.pattern.file=%d{yyyy-MM-dd'T'HH:mm:ss.SSSXXX} %-5level [%thread] [%X{correlationId:-}] %logger{36} - %msg%n
+
+# By default, the Admin API can only be accessed from localhost.
+# You can disable that here, if deploying on a trusted local network.
+# If disabled, the only security on the Admin API is basic auth!
+movienight.admin.localhost-only=true

--- a/backend/src/test/java/ca/corbett/movienight/SecurityIntegrationTest.java
+++ b/backend/src/test/java/ca/corbett/movienight/SecurityIntegrationTest.java
@@ -9,8 +9,8 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.RequestPostProcessor;
 
-import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.blankOrNullString;
+import static org.hamcrest.Matchers.not;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;

--- a/backend/src/test/java/ca/corbett/movienight/SecurityIntegrationWithoutLocalhostOnlyTest.java
+++ b/backend/src/test/java/ca/corbett/movienight/SecurityIntegrationWithoutLocalhostOnlyTest.java
@@ -30,8 +30,7 @@ public class SecurityIntegrationWithoutLocalhostOnlyTest {
     private MockMvc mockMvc;
 
     @Test
-    void writeEndpoints_requireAuthButAllowAnyRemoteAddress() throws Exception {
-        // This test assumes that movienight.admin.localhost-only is set to false in the test properties.
+    void writeEndpointsAllowAnyRemoteAddress() throws Exception {
         String movieJson = """
                 {
                   "title": "Secured Movie",
@@ -44,12 +43,37 @@ public class SecurityIntegrationWithoutLocalhostOnlyTest {
                 }
                 """;
 
+        // Remote address but with the right credentials should work,
+        // because our localhost-only check is disabled:
         mockMvc.perform(post("/api/movies")
                                 .with(remoteAddr("192.168.1.50"))
                                 .with(httpBasic("admin", "secret"))
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content(movieJson))
                .andExpect(status().isCreated());
+    }
+
+    @Test
+    void writeEndpointsStillFailWithoutAuth() throws Exception {
+        String movieJson = """
+                {
+                  "title": "Secured Movie",
+                  "year": 2024,
+                  "genre": { "id": 1 },
+                  "description": "Created through the secured admin API.",
+                  "watched": false,
+                  "tags": ["security"],
+                  "videoFilePath": "/movies/secured_movie.mkv"
+                }
+                """;
+
+        // Localhost access but no credentials should fail,
+        // even though our localhost-only check is disabled, because auth is still required:
+        mockMvc.perform(post("/api/movies")
+                                .with(remoteAddr("127.0.0.1"))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(movieJson))
+               .andExpect(status().isUnauthorized());
     }
 
     private static RequestPostProcessor remoteAddr(String remoteAddress) {

--- a/backend/src/test/java/ca/corbett/movienight/SecurityIntegrationWithoutLocalhostOnlyTest.java
+++ b/backend/src/test/java/ca/corbett/movienight/SecurityIntegrationWithoutLocalhostOnlyTest.java
@@ -1,0 +1,61 @@
+package ca.corbett.movienight;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:sqlite:file:security-tests-localhost-off?mode=memory&cache=shared",
+        "spring.datasource.driver-class-name=org.sqlite.JDBC",
+        "spring.jpa.database-platform=org.hibernate.community.dialect.SQLiteDialect",
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "movienight.data-dir=",
+        "movienight.admin.username=admin",
+        "movienight.admin.password=secret",
+        "movienight.admin.localhost-only=false"
+})
+public class SecurityIntegrationWithoutLocalhostOnlyTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void writeEndpoints_requireAuthButAllowAnyRemoteAddress() throws Exception {
+        // This test assumes that movienight.admin.localhost-only is set to false in the test properties.
+        String movieJson = """
+                {
+                  "title": "Secured Movie",
+                  "year": 2024,
+                  "genre": { "id": 1 },
+                  "description": "Created through the secured admin API.",
+                  "watched": false,
+                  "tags": ["security"],
+                  "videoFilePath": "/movies/secured_movie.mkv"
+                }
+                """;
+
+        mockMvc.perform(post("/api/movies")
+                                .with(remoteAddr("192.168.1.50"))
+                                .with(httpBasic("admin", "secret"))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(movieJson))
+               .andExpect(status().isCreated());
+    }
+
+    private static RequestPostProcessor remoteAddr(String remoteAddress) {
+        return request -> {
+            request.setRemoteAddr(remoteAddress);
+            return request;
+        };
+    }
+}


### PR DESCRIPTION
This PR addresses issue #37 by providing a way to disable the localhost-only security check for the Admin API endpoints. A log warning will be emitted (once per application run) if this option is disabled. The default is kept to `true` to keep the check enabled by default.

Closes #37 