### PR TITLE
Issue #41 - watched recently

### DIFF
--- a/backend/src/main/java/ca/corbett/movienight/config/DataInitializer.java
+++ b/backend/src/main/java/ca/corbett/movienight/config/DataInitializer.java
@@ -25,27 +25,27 @@ public class DataInitializer {
                 genreRepository.save(sciFi);
 
                 Movie m1 = new Movie("The Shawshank Redemption", 1994, drama,
-                        "Two imprisoned men bond over a number of years.", true);
+                                     "Two imprisoned men bond over a number of years.", null);
                 m1.setVideoFilePath("/movies/shawshank_redemption.mkv");
                 movieRepository.save(m1);
 
                 Movie m2 = new Movie("The Godfather", 1972, crime,
-                        "The aging patriarch of an organized crime dynasty.", true);
+                                     "The aging patriarch of an organized crime dynasty.", null);
                 m2.setVideoFilePath("/movies/the_godfather.mkv");
                 movieRepository.save(m2);
 
                 Movie m3 = new Movie("The Dark Knight", 2008, action,
-                        "When the Joker wreaks havoc on Gotham City.", false);
+                                     "When the Joker wreaks havoc on Gotham City.", null);
                 m3.setVideoFilePath("/movies/the_dark_knight.mkv");
                 movieRepository.save(m3);
 
                 Movie m4 = new Movie("Pulp Fiction", 1994, crime,
-                        "The lives of two mob hitmen intertwine.", false);
+                                     "The lives of two mob hitmen intertwine.", null);
                 m4.setVideoFilePath("/movies/pulp_fiction.mkv");
                 movieRepository.save(m4);
 
                 Movie m5 = new Movie("Interstellar", 2014, sciFi,
-                        "A team of explorers travels through a wormhole.", false);
+                                     "A team of explorers travels through a wormhole.", null);
                 m5.setVideoFilePath("/movies/interstellar.mkv");
                 movieRepository.save(m5);
             }

--- a/backend/src/main/java/ca/corbett/movienight/controller/EpisodeController.java
+++ b/backend/src/main/java/ca/corbett/movienight/controller/EpisodeController.java
@@ -43,9 +43,8 @@ public class EpisodeController {
                                         @RequestParam(required = false) String seriesName,
                                         @RequestParam(required = false) Integer season,
                                         @RequestParam(required = false) Integer episode,
-                                        @RequestParam(required = false) Boolean watched,
                                         @RequestParam(required = false) String tag) {
-        return episodeService.searchEpisodes(seriesId, seriesName, season, episode, watched, tag);
+        return episodeService.searchEpisodes(seriesId, seriesName, season, episode, tag);
     }
 
     @GetMapping("/{id}")

--- a/backend/src/main/java/ca/corbett/movienight/controller/MovieController.java
+++ b/backend/src/main/java/ca/corbett/movienight/controller/MovieController.java
@@ -9,11 +9,21 @@ import org.springframework.core.io.Resource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
+
 import java.nio.file.Path;
 import java.util.List;
-import org.springframework.web.server.ResponseStatusException;
 
 @RestController
 @RequestMapping("/api/movies")
@@ -30,10 +40,9 @@ public class MovieController {
 
     @GetMapping
     public List<Movie> getAllMovies(@RequestParam(required = false) String title,
-                                   @RequestParam(required = false) Boolean watched,
                                    @RequestParam(required = false) String tag,
                                    @RequestParam(required = false) Long genreId) {
-        return movieService.searchMovies(title, watched, tag, genreId);
+        return movieService.searchMovies(title, tag, genreId);
     }
 
     @GetMapping("/{id}")

--- a/backend/src/main/java/ca/corbett/movienight/model/Episode.java
+++ b/backend/src/main/java/ca/corbett/movienight/model/Episode.java
@@ -16,6 +16,7 @@ import jakarta.persistence.Transient;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -57,7 +58,11 @@ public class Episode {
     private String description;
 
     @Column
-    private Boolean watched = false;
+    private LocalDate lastWatchedDate;
+
+    @Transient
+    @JsonProperty(value = "watchedRecently", access = JsonProperty.Access.READ_ONLY)
+    private boolean watchedRecently;
 
     @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(name = "episode_tags", joinColumns = @JoinColumn(name = "episode_id"))
@@ -76,13 +81,13 @@ public class Episode {
     }
 
     public Episode(Series series, String episodeTitle, Integer season, Integer episode,
-                   String description, Boolean watched) {
+                   String description, LocalDate lastWatchedDate) {
         this.series = series;
         this.episodeTitle = episodeTitle;
         this.season = season;
         this.episode = episode;
         this.description = description;
-        this.watched = watched;
+        this.lastWatchedDate = lastWatchedDate;
     }
 
     // Getters and setters
@@ -135,12 +140,12 @@ public class Episode {
         this.description = description;
     }
 
-    public Boolean getWatched() {
-        return watched;
+    public LocalDate getLastWatchedDate() {
+        return lastWatchedDate;
     }
 
-    public void setWatched(Boolean watched) {
-        this.watched = watched;
+    public void setLastWatchedDate(LocalDate lastWatchedDate) {
+        this.lastWatchedDate = lastWatchedDate;
     }
 
     public List<String> getTags() {
@@ -166,6 +171,14 @@ public class Episode {
 
     public void setHasThumbnail(boolean hasThumbnail) {
         this.hasThumbnail = hasThumbnail;
+    }
+
+    public boolean isWatchedRecently() {
+        return watchedRecently;
+    }
+
+    public void setWatchedRecently(boolean watchedRecently) {
+        this.watchedRecently = watchedRecently;
     }
 
     public String getVideoFilePath() {

--- a/backend/src/main/java/ca/corbett/movienight/model/Movie.java
+++ b/backend/src/main/java/ca/corbett/movienight/model/Movie.java
@@ -16,6 +16,7 @@ import jakarta.persistence.Transient;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -55,7 +56,11 @@ public class Movie {
     private String description;
 
     @Column
-    private Boolean watched = false;
+    private LocalDate lastWatchedDate;
+
+    @Transient
+    @JsonProperty(value = "watchedRecently", access = JsonProperty.Access.READ_ONLY)
+    private boolean watchedRecently;
 
     @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(name = "movie_tags", joinColumns = @JoinColumn(name = "movie_id"))
@@ -74,12 +79,12 @@ public class Movie {
     }
 
     public Movie(String title, Integer year, Genre genre,
-                 String description, Boolean watched) {
+                 String description, LocalDate lastWatchedDate) {
         this.title = title;
         this.year = year;
         this.genre = genre;
         this.description = description;
-        this.watched = watched;
+        this.lastWatchedDate = lastWatchedDate;
     }
 
     // Getters and setters
@@ -124,12 +129,12 @@ public class Movie {
         this.description = description;
     }
 
-    public Boolean getWatched() {
-        return watched;
+    public LocalDate getLastWatchedDate() {
+        return lastWatchedDate;
     }
 
-    public void setWatched(Boolean watched) {
-        this.watched = watched;
+    public void setLastWatchedDate(LocalDate lastWatchedDate) {
+        this.lastWatchedDate = lastWatchedDate;
     }
 
     public List<String> getTags() {
@@ -155,6 +160,14 @@ public class Movie {
 
     public void setHasThumbnail(boolean hasThumbnail) {
         this.hasThumbnail = hasThumbnail;
+    }
+
+    public boolean isWatchedRecently() {
+        return watchedRecently;
+    }
+
+    public void setWatchedRecently(boolean watchedRecently) {
+        this.watchedRecently = watchedRecently;
     }
 
     public String getVideoFilePath() {

--- a/backend/src/main/java/ca/corbett/movienight/model/MusicVideo.java
+++ b/backend/src/main/java/ca/corbett/movienight/model/MusicVideo.java
@@ -17,6 +17,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -60,6 +61,13 @@ public class MusicVideo {
     @Column(length = 2000)
     private String description;
 
+    @Column
+    private LocalDate lastWatchedDate;
+
+    @Transient
+    @JsonProperty(value = "watchedRecently", access = JsonProperty.Access.READ_ONLY)
+    private boolean watchedRecently;
+
     @ElementCollection(fetch = FetchType.EAGER)
     @CollectionTable(name = "music_video_tags", joinColumns = @JoinColumn(name = "music_video_id"))
     @Column(name = "tag")
@@ -76,12 +84,14 @@ public class MusicVideo {
     public MusicVideo() {
     }
 
-    public MusicVideo(String title, Artist artist, String album, Integer year, String description) {
+    public MusicVideo(String title, Artist artist, String album,
+                      Integer year, String description, LocalDate lastWatchedDate) {
         this.title = title;
         this.artist = artist;
         this.album = album;
         this.year = year;
         this.description = description;
+        this.lastWatchedDate = lastWatchedDate;
     }
 
     // Getters and setters
@@ -134,6 +144,14 @@ public class MusicVideo {
         this.description = description;
     }
 
+    public LocalDate getLastWatchedDate() {
+        return lastWatchedDate;
+    }
+
+    public void setLastWatchedDate(LocalDate lastWatchedDate) {
+        this.lastWatchedDate = lastWatchedDate;
+    }
+
     public List<String> getTags() {
         return tags;
     }
@@ -165,5 +183,13 @@ public class MusicVideo {
 
     public void setHasThumbnail(boolean hasThumbnail) {
         this.hasThumbnail = hasThumbnail;
+    }
+
+    public boolean isWatchedRecently() {
+        return watchedRecently;
+    }
+
+    public void setWatchedRecently(boolean watchedRecently) {
+        this.watchedRecently = watchedRecently;
     }
 }

--- a/backend/src/main/java/ca/corbett/movienight/repository/MovieRepository.java
+++ b/backend/src/main/java/ca/corbett/movienight/repository/MovieRepository.java
@@ -13,8 +13,6 @@ public interface MovieRepository extends JpaRepository<Movie, Long>, JpaSpecific
 
     List<Movie> findByTitleContainingIgnoreCase(String title);
 
-    List<Movie> findByWatched(Boolean watched);
-
     List<Movie> findByGenre(Genre genre);
 
     long countByGenre(Genre genre);

--- a/backend/src/main/java/ca/corbett/movienight/service/EpisodeService.java
+++ b/backend/src/main/java/ca/corbett/movienight/service/EpisodeService.java
@@ -4,17 +4,22 @@ import ca.corbett.movienight.model.Episode;
 import ca.corbett.movienight.repository.EpisodeRepository;
 import jakarta.persistence.criteria.Join;
 import jakarta.persistence.criteria.JoinType;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
 @Service
 public class EpisodeService {
+
+    @Value("${movienight.recently-watched-days:3}")
+    private int RECENTLY_WATCHED_DAYS;
 
     private final EpisodeRepository episodeRepository;
     private final ThumbnailService thumbnailService;
@@ -25,11 +30,11 @@ public class EpisodeService {
     }
 
     public Optional<Episode> getEpisodeById(Long id) {
-        return episodeRepository.findById(id).map(this::populateHasThumbnail);
+        return episodeRepository.findById(id).map(this::populateTransientFields);
     }
 
     public Episode saveEpisode(Episode episode) {
-        return populateHasThumbnail(episodeRepository.save(episode));
+        return populateTransientFields(episodeRepository.save(episode));
     }
 
     public Episode updateEpisode(Long id, Episode updatedEpisode) {
@@ -44,10 +49,9 @@ public class EpisodeService {
             ep.setSeason(updatedEpisode.getSeason());
             ep.setEpisode(updatedEpisode.getEpisode());
             ep.setDescription(updatedEpisode.getDescription());
-            ep.setWatched(updatedEpisode.getWatched());
             ep.setTags(updatedEpisode.getTags());
             ep.setVideoFilePath(updatedEpisode.getVideoFilePath());
-            return populateHasThumbnail(episodeRepository.save(ep));
+            return populateTransientFields(episodeRepository.save(ep));
         }).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Episode not found with id: " + id));
     }
 
@@ -63,10 +67,10 @@ public class EpisodeService {
                                                                "Episode not found with id: " + id));
     }
 
-    public List<Episode> searchEpisodes(Long seriesId, String seriesName, Integer season, Integer episode,
-                                        Boolean watched, String tag) {
-        Specification<Episode> spec = Specification.where(seasonEquals(season)).and(episodeEquals(episode))
-                                                   .and(watchedEquals(watched)).and(tagContains(tag))
+    public List<Episode> searchEpisodes(Long seriesId, String seriesName, Integer season, Integer episode, String tag) {
+        Specification<Episode> spec = Specification.where(seasonEquals(season))
+                                                   .and(episodeEquals(episode))
+                                                   .and(tagContains(tag))
                                                    .and(seriesEquals(seriesId))
                                                    .and(seriesNameContains(seriesName));
         Sort sort = Sort.by(
@@ -75,7 +79,7 @@ public class EpisodeService {
                 Sort.Order.asc("episode").nullsLast(),
                 Sort.Order.asc("episodeTitle").nullsLast()
         );
-        return populateHasThumbnail(episodeRepository.findAll(spec, sort));
+        return populateTransientFields(episodeRepository.findAll(spec, sort));
     }
 
     private Episode populateHasThumbnail(Episode episode) {
@@ -83,9 +87,19 @@ public class EpisodeService {
         return episode;
     }
 
-    private List<Episode> populateHasThumbnail(List<Episode> episodes) {
-        episodes.forEach(this::populateHasThumbnail);
-        return episodes;
+    private Episode populateWatchedRecently(Episode episode) {
+        // This feature can be explicitly disabled by setting day count to 0.
+        // It's also possible this video has never been watched.
+        if (RECENTLY_WATCHED_DAYS == 0 || episode.getLastWatchedDate() == null) {
+            episode.setWatchedRecently(false);
+            return episode;
+        }
+
+        // Otherwise, do the math on the last watch date to determine if it's recent:
+        episode.setWatchedRecently(
+                episode.getLastWatchedDate().isAfter(LocalDate.now().minusDays(RECENTLY_WATCHED_DAYS)));
+
+        return episode;
     }
 
     private static Specification<Episode> seasonEquals(Integer season) {
@@ -108,10 +122,6 @@ public class EpisodeService {
         return (root, query, cb) -> episode == null ? null : cb.equal(root.get("episode"), episode);
     }
 
-    private static Specification<Episode> watchedEquals(Boolean watched) {
-        return (root, query, cb) -> watched == null ? null : cb.equal(root.get("watched"), watched);
-    }
-
     private static Specification<Episode> tagContains(String tag) {
         return (root, query, cb) -> {
             if (tag == null || tag.isBlank()) { return null; }
@@ -119,5 +129,23 @@ public class EpisodeService {
             Join<Episode, String> tagsJoin = root.join("tags", JoinType.INNER);
             return cb.like(cb.lower(tagsJoin.as(String.class)), "%" + tag.trim().toLowerCase() + "%");
         };
+    }
+
+    private Episode populateTransientFields(Episode episode) {
+        populateHasThumbnail(episode);
+        populateWatchedRecently(episode);
+        return episode;
+    }
+
+    private List<Episode> populateTransientFields(List<Episode> episodes) {
+        episodes.forEach(this::populateTransientFields);
+        return episodes;
+    }
+
+    /**
+     * Visible only for testing, because Spring is dumb.
+     */
+    public void setRecentlyWatchedDays(int number) {
+        this.RECENTLY_WATCHED_DAYS = Math.max(number, 0);
     }
 }

--- a/backend/src/main/java/ca/corbett/movienight/service/EpisodeService.java
+++ b/backend/src/main/java/ca/corbett/movienight/service/EpisodeService.java
@@ -19,7 +19,7 @@ import java.util.Optional;
 public class EpisodeService {
 
     @Value("${movienight.recently-watched-days:3}")
-    private int RECENTLY_WATCHED_DAYS;
+    private int recentlyWatchedDays;
 
     private final EpisodeRepository episodeRepository;
     private final ThumbnailService thumbnailService;
@@ -88,16 +88,18 @@ public class EpisodeService {
     }
 
     private Episode populateWatchedRecently(Episode episode) {
+        int recentlyWatchedDays = Math.max(this.recentlyWatchedDays, 0);
+        
         // This feature can be explicitly disabled by setting day count to 0.
         // It's also possible this video has never been watched.
-        if (RECENTLY_WATCHED_DAYS == 0 || episode.getLastWatchedDate() == null) {
+        if (recentlyWatchedDays == 0 || episode.getLastWatchedDate() == null) {
             episode.setWatchedRecently(false);
             return episode;
         }
 
         // Otherwise, do the math on the last watch date to determine if it's recent:
         episode.setWatchedRecently(
-                episode.getLastWatchedDate().isAfter(LocalDate.now().minusDays(RECENTLY_WATCHED_DAYS)));
+                episode.getLastWatchedDate().isAfter(LocalDate.now().minusDays(recentlyWatchedDays)));
 
         return episode;
     }
@@ -146,6 +148,6 @@ public class EpisodeService {
      * Visible only for testing, because Spring is dumb.
      */
     public void setRecentlyWatchedDays(int number) {
-        this.RECENTLY_WATCHED_DAYS = Math.max(number, 0);
+        this.recentlyWatchedDays = Math.max(number, 0);
     }
 }

--- a/backend/src/main/java/ca/corbett/movienight/service/MediaService.java
+++ b/backend/src/main/java/ca/corbett/movienight/service/MediaService.java
@@ -1,10 +1,15 @@
 package ca.corbett.movienight.service;
 
+import ca.corbett.movienight.model.Episode;
+import ca.corbett.movienight.model.Movie;
+import ca.corbett.movienight.model.MusicVideo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDate;
 
 @Service
 public class MediaService {
@@ -26,6 +31,12 @@ public class MediaService {
      * Returns the absolute video file path for an encoded media ID.
      * The id must be "M" followed by a numeric movie ID, "E" followed by a numeric episode ID,
      * or "V" followed by a numeric music video ID.
+     * <p>
+     * Note that invoking this method for any existing model object will
+     * update that model object's lastWatchedDate to the current date and save it back to the database.
+     * This seems like a nice centralized place to do this, but it does mean
+     * that this method has a side effect of updating the database, which is a bit unexpected for a "find" method.
+     * </p>
      *
      * @param encodedId encoded media ID, e.g. "M31", "E77", or "V12"
      * @return absolute path to the video file
@@ -48,15 +59,24 @@ public class MediaService {
         }
 
         if (type == 'M') {
-            String path = movieService.requireMovie(numericId).getVideoFilePath();
+            Movie movie = movieService.requireMovie(numericId);
+            String path = movie.getVideoFilePath();
+            movie.setLastWatchedDate(LocalDate.now());
+            movieService.saveMovie(movie);
             logger.debug("Resolved media id {} to movie file path: {}", encodedId, path);
             return path;
         } else if (type == 'E') {
-            String path = episodeService.requireEpisode(numericId).getVideoFilePath();
+            Episode episode = episodeService.requireEpisode(numericId);
+            String path = episode.getVideoFilePath();
+            episode.setLastWatchedDate(LocalDate.now());
+            episodeService.saveEpisode(episode);
             logger.debug("Resolved media id {} to episode file path: {}", encodedId, path);
             return path;
         } else if (type == 'V') {
-            String path = musicVideoService.requireMusicVideo(numericId).getVideoFilePath();
+            MusicVideo musicVideo = musicVideoService.requireMusicVideo(numericId);
+            String path = musicVideo.getVideoFilePath();
+            musicVideo.setLastWatchedDate(LocalDate.now());
+            musicVideoService.saveMusicVideo(musicVideo);
             logger.debug("Resolved media id {} to music video file path: {}", encodedId, path);
             return path;
         } else {

--- a/backend/src/main/java/ca/corbett/movienight/service/MediaService.java
+++ b/backend/src/main/java/ca/corbett/movienight/service/MediaService.java
@@ -3,6 +3,9 @@ package ca.corbett.movienight.service;
 import ca.corbett.movienight.model.Episode;
 import ca.corbett.movienight.model.Movie;
 import ca.corbett.movienight.model.MusicVideo;
+import ca.corbett.movienight.repository.EpisodeRepository;
+import ca.corbett.movienight.repository.MovieRepository;
+import ca.corbett.movienight.repository.MusicVideoRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -19,12 +22,22 @@ public class MediaService {
     private final MovieService movieService;
     private final EpisodeService episodeService;
     private final MusicVideoService musicVideoService;
+    private final MovieRepository movieRepository;
+    private final EpisodeRepository episodeRepository;
+    private final MusicVideoRepository musicVideoRepository;
 
-    public MediaService(MovieService movieService, EpisodeService episodeService,
-                        MusicVideoService musicVideoService) {
+    public MediaService(MovieService movieService,
+                        EpisodeService episodeService,
+                        MusicVideoService musicVideoService,
+                        MovieRepository movieRepository,
+                        EpisodeRepository episodeRepository,
+                        MusicVideoRepository musicVideoRepository) {
         this.movieService = movieService;
         this.episodeService = episodeService;
         this.musicVideoService = musicVideoService;
+        this.movieRepository = movieRepository;
+        this.episodeRepository = episodeRepository;
+        this.musicVideoRepository = musicVideoRepository;
     }
 
     /**
@@ -36,6 +49,12 @@ public class MediaService {
      * update that model object's lastWatchedDate to the current date and save it back to the database.
      * This seems like a nice centralized place to do this, but it does mean
      * that this method has a side effect of updating the database, which is a bit unexpected for a "find" method.
+     * </p>
+     * <p>
+     * Dev note: the above-mentioned saves are done via the repositories instead of via the service
+     * layer, to avoid the filesystem overhead that the services will incur when they go to
+     * update the thumbnail on save. Since we know the thumbnail won't change when just updating
+     * the last watched date, we can skip that overhead.
      * </p>
      *
      * @param encodedId encoded media ID, e.g. "M31", "E77", or "V12"
@@ -62,21 +81,24 @@ public class MediaService {
             Movie movie = movieService.requireMovie(numericId);
             String path = movie.getVideoFilePath();
             movie.setLastWatchedDate(LocalDate.now());
-            movieService.saveMovie(movie);
+            movie.setWatchedRecently(true); // Set manually, since we know it's "true" even without date math
+            movieRepository.save(movie); // Save via repository to avoid unnecessary filesystem overhead in the service
             logger.debug("Resolved media id {} to movie file path: {}", encodedId, path);
             return path;
         } else if (type == 'E') {
             Episode episode = episodeService.requireEpisode(numericId);
             String path = episode.getVideoFilePath();
             episode.setLastWatchedDate(LocalDate.now());
-            episodeService.saveEpisode(episode);
+            episode.setWatchedRecently(true);
+            episodeRepository.save(episode);
             logger.debug("Resolved media id {} to episode file path: {}", encodedId, path);
             return path;
         } else if (type == 'V') {
             MusicVideo musicVideo = musicVideoService.requireMusicVideo(numericId);
             String path = musicVideo.getVideoFilePath();
             musicVideo.setLastWatchedDate(LocalDate.now());
-            musicVideoService.saveMusicVideo(musicVideo);
+            musicVideo.setWatchedRecently(true);
+            musicVideoRepository.save(musicVideo);
             logger.debug("Resolved media id {} to music video file path: {}", encodedId, path);
             return path;
         } else {

--- a/backend/src/main/java/ca/corbett/movienight/service/MovieService.java
+++ b/backend/src/main/java/ca/corbett/movienight/service/MovieService.java
@@ -5,16 +5,21 @@ import ca.corbett.movienight.model.Movie;
 import ca.corbett.movienight.repository.MovieRepository;
 import jakarta.persistence.criteria.Join;
 import jakarta.persistence.criteria.JoinType;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
 @Service
 public class MovieService {
+
+    @Value("${movienight.recently-watched-days:3}")
+    private int RECENTLY_WATCHED_DAYS;
 
     private final MovieRepository movieRepository;
     private final ThumbnailService thumbnailService;
@@ -25,11 +30,11 @@ public class MovieService {
     }
 
     public List<Movie> getAllMovies() {
-        return populateHasThumbnail(movieRepository.findAll());
+        return populateTransientFields(movieRepository.findAll());
     }
 
     public Optional<Movie> getMovieById(Long id) {
-        return movieRepository.findById(id).map(this::populateHasThumbnail);
+        return movieRepository.findById(id).map(this::populateTransientFields);
     }
 
     public Movie saveMovie(Movie movie) {
@@ -38,7 +43,7 @@ public class MovieService {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Movie genre is required.");
         }
 
-        return populateHasThumbnail(movieRepository.save(movie));
+        return populateTransientFields(movieRepository.save(movie));
     }
 
     public Movie updateMovie(Long id, Movie updatedMovie) {
@@ -52,10 +57,9 @@ public class MovieService {
             movie.setYear(updatedMovie.getYear());
             movie.setGenre(updatedMovie.getGenre());
             movie.setDescription(updatedMovie.getDescription());
-            movie.setWatched(updatedMovie.getWatched());
             movie.setTags(updatedMovie.getTags());
             movie.setVideoFilePath(updatedMovie.getVideoFilePath());
-            return populateHasThumbnail(movieRepository.save(movie));
+            return populateTransientFields(movieRepository.save(movie));
         }).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Movie not found with id: " + id));
     }
 
@@ -72,27 +76,22 @@ public class MovieService {
     }
 
     public List<Movie> searchByTitle(String title) {
-        return populateHasThumbnail(movieRepository.findByTitleContainingIgnoreCase(title));
-    }
-
-    public List<Movie> getByWatched(Boolean watched) {
-        return populateHasThumbnail(movieRepository.findByWatched(watched));
+        return populateTransientFields(movieRepository.findByTitleContainingIgnoreCase(title));
     }
 
     public List<Movie> searchByTag(String tag) {
-        return populateHasThumbnail(movieRepository.findByTagsContainingIgnoreCase(tag));
+        return populateTransientFields(movieRepository.findByTagsContainingIgnoreCase(tag));
     }
 
     public List<Movie> searchMovies(Genre genre) {
-        return populateHasThumbnail(movieRepository.findByGenre(genre));
+        return populateTransientFields(movieRepository.findByGenre(genre));
     }
 
-    public List<Movie> searchMovies(String title, Boolean watched, String tag, Long genreId) {
+    public List<Movie> searchMovies(String title, String tag, Long genreId) {
         Specification<Movie> spec = Specification.where(titleContains(title))
-                .and(watchedEquals(watched))
                 .and(tagContains(tag))
                 .and(genreEquals(genreId));
-        return populateHasThumbnail(movieRepository.findAll(spec));
+        return populateTransientFields(movieRepository.findAll(spec));
     }
 
     private Movie populateHasThumbnail(Movie movie) {
@@ -100,9 +99,18 @@ public class MovieService {
         return movie;
     }
 
-    private List<Movie> populateHasThumbnail(List<Movie> movies) {
-        movies.forEach(this::populateHasThumbnail);
-        return movies;
+    private Movie populateWatchedRecently(Movie movie) {
+        // This feature can be explicitly disabled by setting day count to 0.
+        // It's also possible this video has never been watched.
+        if (RECENTLY_WATCHED_DAYS == 0 || movie.getLastWatchedDate() == null) {
+            movie.setWatchedRecently(false);
+            return movie;
+        }
+
+        // Otherwise, do the math on the last watch date to determine if it's recent:
+        movie.setWatchedRecently(movie.getLastWatchedDate().isAfter(LocalDate.now().minusDays(RECENTLY_WATCHED_DAYS)));
+
+        return movie;
     }
 
     private static Specification<Movie> titleContains(String title) {
@@ -110,10 +118,6 @@ public class MovieService {
             if (title == null || title.isBlank()) return null;
             return cb.like(cb.lower(root.get("title")), "%" + title.trim().toLowerCase() + "%");
         };
-    }
-
-    private static Specification<Movie> watchedEquals(Boolean watched) {
-        return (root, query, cb) -> watched == null ? null : cb.equal(root.get("watched"), watched);
     }
 
     private static Specification<Movie> tagContains(String tag) {
@@ -127,5 +131,23 @@ public class MovieService {
 
     private static Specification<Movie> genreEquals(Long genreId) {
         return (root, query, cb) -> genreId == null ? null : cb.equal(root.get("genre").get("id"), genreId);
+    }
+
+    private Movie populateTransientFields(Movie movie) {
+        populateHasThumbnail(movie);
+        populateWatchedRecently(movie);
+        return movie;
+    }
+
+    private List<Movie> populateTransientFields(List<Movie> movies) {
+        movies.forEach(this::populateTransientFields);
+        return movies;
+    }
+
+    /**
+     * Visible only for testing, because Spring is dumb.
+     */
+    public void setRecentlyWatchedDays(int number) {
+        this.RECENTLY_WATCHED_DAYS = Math.max(number, 0);
     }
 }

--- a/backend/src/main/java/ca/corbett/movienight/service/MovieService.java
+++ b/backend/src/main/java/ca/corbett/movienight/service/MovieService.java
@@ -19,7 +19,7 @@ import java.util.Optional;
 public class MovieService {
 
     @Value("${movienight.recently-watched-days:3}")
-    private int RECENTLY_WATCHED_DAYS;
+    private int recentlyWatchedDays;
 
     private final MovieRepository movieRepository;
     private final ThumbnailService thumbnailService;
@@ -100,15 +100,17 @@ public class MovieService {
     }
 
     private Movie populateWatchedRecently(Movie movie) {
+        int recentlyWatchedDays = Math.max(this.recentlyWatchedDays, 0);
+        
         // This feature can be explicitly disabled by setting day count to 0.
         // It's also possible this video has never been watched.
-        if (RECENTLY_WATCHED_DAYS == 0 || movie.getLastWatchedDate() == null) {
+        if (recentlyWatchedDays == 0 || movie.getLastWatchedDate() == null) {
             movie.setWatchedRecently(false);
             return movie;
         }
 
         // Otherwise, do the math on the last watch date to determine if it's recent:
-        movie.setWatchedRecently(movie.getLastWatchedDate().isAfter(LocalDate.now().minusDays(RECENTLY_WATCHED_DAYS)));
+        movie.setWatchedRecently(movie.getLastWatchedDate().isAfter(LocalDate.now().minusDays(recentlyWatchedDays)));
 
         return movie;
     }
@@ -148,6 +150,6 @@ public class MovieService {
      * Visible only for testing, because Spring is dumb.
      */
     public void setRecentlyWatchedDays(int number) {
-        this.RECENTLY_WATCHED_DAYS = Math.max(number, 0);
+        this.recentlyWatchedDays = Math.max(number, 0);
     }
 }

--- a/backend/src/main/java/ca/corbett/movienight/service/MusicVideoService.java
+++ b/backend/src/main/java/ca/corbett/movienight/service/MusicVideoService.java
@@ -19,7 +19,7 @@ import java.util.Optional;
 public class MusicVideoService {
 
     @Value("${movienight.recently-watched-days:3}")
-    private int RECENTLY_WATCHED_DAYS;
+    private int recentlyWatchedDays;
 
     private final MusicVideoRepository musicVideoRepository;
     private final ThumbnailService thumbnailService;
@@ -92,16 +92,18 @@ public class MusicVideoService {
     }
 
     private MusicVideo populateWatchedRecently(MusicVideo musicVideo) {
+        int recentlyWatchedDays = Math.max(this.recentlyWatchedDays, 0);
+
         // This feature can be explicitly disabled by setting day count to 0.
         // It's also possible this video has never been watched.
-        if (RECENTLY_WATCHED_DAYS == 0 || musicVideo.getLastWatchedDate() == null) {
+        if (recentlyWatchedDays == 0 || musicVideo.getLastWatchedDate() == null) {
             musicVideo.setWatchedRecently(false);
             return musicVideo;
         }
 
         // Otherwise, do the math on the last watch date to determine if it's recent:
         musicVideo.setWatchedRecently(
-                musicVideo.getLastWatchedDate().isAfter(LocalDate.now().minusDays(RECENTLY_WATCHED_DAYS)));
+                musicVideo.getLastWatchedDate().isAfter(LocalDate.now().minusDays(recentlyWatchedDays)));
 
         return musicVideo;
     }
@@ -141,6 +143,6 @@ public class MusicVideoService {
      * Visible only for testing, because Spring is dumb.
      */
     public void setRecentlyWatchedDays(int number) {
-        this.RECENTLY_WATCHED_DAYS = Math.max(number, 0);
+        this.recentlyWatchedDays = Math.max(number, 0);
     }
 }

--- a/backend/src/main/java/ca/corbett/movienight/service/MusicVideoService.java
+++ b/backend/src/main/java/ca/corbett/movienight/service/MusicVideoService.java
@@ -4,17 +4,22 @@ import ca.corbett.movienight.model.MusicVideo;
 import ca.corbett.movienight.repository.MusicVideoRepository;
 import jakarta.persistence.criteria.Join;
 import jakarta.persistence.criteria.JoinType;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 
 @Service
 public class MusicVideoService {
+
+    @Value("${movienight.recently-watched-days:3}")
+    private int RECENTLY_WATCHED_DAYS;
 
     private final MusicVideoRepository musicVideoRepository;
     private final ThumbnailService thumbnailService;
@@ -25,18 +30,18 @@ public class MusicVideoService {
     }
 
     public List<MusicVideo> getAllMusicVideos() {
-        return populateHasThumbnail(musicVideoRepository.findAll());
+        return populateTransientFields(musicVideoRepository.findAll());
     }
 
     public Optional<MusicVideo> getMusicVideoById(Long id) {
-        return musicVideoRepository.findById(id).map(this::populateHasThumbnail);
+        return musicVideoRepository.findById(id).map(this::populateTransientFields);
     }
 
     public MusicVideo saveMusicVideo(MusicVideo musicVideo) {
         if (musicVideo.getArtist() == null) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Music video artist is required.");
         }
-        return populateHasThumbnail(musicVideoRepository.save(musicVideo));
+        return populateTransientFields(musicVideoRepository.save(musicVideo));
     }
 
     public MusicVideo updateMusicVideo(Long id, MusicVideo updatedMusicVideo) {
@@ -52,7 +57,7 @@ public class MusicVideoService {
             mv.setDescription(updatedMusicVideo.getDescription());
             mv.setTags(updatedMusicVideo.getTags());
             mv.setVideoFilePath(updatedMusicVideo.getVideoFilePath());
-            return populateHasThumbnail(musicVideoRepository.save(mv));
+            return populateTransientFields(musicVideoRepository.save(mv));
         }).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
                                                          "Music video not found with id: " + id));
     }
@@ -78,7 +83,7 @@ public class MusicVideoService {
                 Sort.Order.asc("album").nullsLast(),
                 Sort.Order.asc("title").nullsLast()
         );
-        return populateHasThumbnail(musicVideoRepository.findAll(spec, sort));
+        return populateTransientFields(musicVideoRepository.findAll(spec, sort));
     }
 
     private MusicVideo populateHasThumbnail(MusicVideo musicVideo) {
@@ -86,9 +91,19 @@ public class MusicVideoService {
         return musicVideo;
     }
 
-    private List<MusicVideo> populateHasThumbnail(List<MusicVideo> musicVideos) {
-        musicVideos.forEach(this::populateHasThumbnail);
-        return musicVideos;
+    private MusicVideo populateWatchedRecently(MusicVideo musicVideo) {
+        // This feature can be explicitly disabled by setting day count to 0.
+        // It's also possible this video has never been watched.
+        if (RECENTLY_WATCHED_DAYS == 0 || musicVideo.getLastWatchedDate() == null) {
+            musicVideo.setWatchedRecently(false);
+            return musicVideo;
+        }
+
+        // Otherwise, do the math on the last watch date to determine if it's recent:
+        musicVideo.setWatchedRecently(
+                musicVideo.getLastWatchedDate().isAfter(LocalDate.now().minusDays(RECENTLY_WATCHED_DAYS)));
+
+        return musicVideo;
     }
 
     private static Specification<MusicVideo> titleContains(String title) {
@@ -109,5 +124,23 @@ public class MusicVideoService {
 
     private static Specification<MusicVideo> artistEquals(Long artistId) {
         return (root, query, cb) -> artistId == null ? null : cb.equal(root.get("artist").get("id"), artistId);
+    }
+
+    private MusicVideo populateTransientFields(MusicVideo musicVideo) {
+        populateHasThumbnail(musicVideo);
+        populateWatchedRecently(musicVideo);
+        return musicVideo;
+    }
+
+    private List<MusicVideo> populateTransientFields(List<MusicVideo> musicVideos) {
+        musicVideos.forEach(this::populateTransientFields);
+        return musicVideos;
+    }
+
+    /**
+     * Visible only for testing, because Spring is dumb.
+     */
+    public void setRecentlyWatchedDays(int number) {
+        this.RECENTLY_WATCHED_DAYS = Math.max(number, 0);
     }
 }

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -26,3 +26,10 @@ logging.pattern.file=%d{yyyy-MM-dd'T'HH:mm:ss.SSSXXX} %-5level [%thread] [%X{cor
 # You can disable that here, if deploying on a trusted local network.
 # If disabled, the only security on the Admin API is basic auth!
 movienight.admin.localhost-only=true
+
+# If the "last watched date" for a given video was fewer than
+# this many days ago, it will be considered "recently watched".
+# Such videos are marked with a "recently watched" badge in the UI.
+# This can help you remember where you left off in a long TV series, for example.
+# Set this to 0 to disable the "recently watched" feature.
+movienight.recently-watched-days=3

--- a/backend/src/test/java/ca/corbett/movienight/DisabledRecentFeatureRepositoryTest.java
+++ b/backend/src/test/java/ca/corbett/movienight/DisabledRecentFeatureRepositoryTest.java
@@ -1,0 +1,123 @@
+package ca.corbett.movienight;
+
+import ca.corbett.movienight.model.Artist;
+import ca.corbett.movienight.model.Episode;
+import ca.corbett.movienight.model.Genre;
+import ca.corbett.movienight.model.Movie;
+import ca.corbett.movienight.model.MusicVideo;
+import ca.corbett.movienight.model.Series;
+import ca.corbett.movienight.repository.ArtistRepository;
+import ca.corbett.movienight.repository.EpisodeRepository;
+import ca.corbett.movienight.repository.GenreRepository;
+import ca.corbett.movienight.repository.MovieRepository;
+import ca.corbett.movienight.repository.MusicVideoRepository;
+import ca.corbett.movienight.repository.SeriesRepository;
+import ca.corbett.movienight.service.EpisodeService;
+import ca.corbett.movienight.service.MovieService;
+import ca.corbett.movienight.service.MusicVideoService;
+import ca.corbett.movienight.service.ThumbnailService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.TestPropertySource;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:sqlite::memory:",
+        "spring.datasource.driver-class-name=org.sqlite.JDBC",
+        "spring.jpa.database-platform=org.hibernate.community.dialect.SQLiteDialect",
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "movienight.data-dir=",
+        "movienight.recently-watched-days=0" // explicitly disables this feature
+})
+public class DisabledRecentFeatureRepositoryTest {
+
+    @Autowired
+    private EpisodeRepository episodeRepository;
+
+    @Autowired
+    private SeriesRepository seriesRepository;
+
+    @Autowired
+    private MovieRepository movieRepository;
+
+    @Autowired
+    private GenreRepository genreRepository;
+
+    @Autowired
+    private MusicVideoRepository musicVideoRepository;
+
+    @Autowired
+    private ArtistRepository artistRepository;
+
+    @MockBean
+    private ThumbnailService thumbnailService;
+
+    @Test
+    public void recentlyWatchedMovie_returnsFalse() {
+        MovieService movieService = new MovieService(movieRepository, thumbnailService);
+        movieService.setRecentlyWatchedDays(0); // explicitly disable the feature for this test
+
+        // GIVEN a Movie that was recently watched:
+        Genre genre = new Genre("Test Genre", "A genre for testing.");
+        genreRepository.save(genre);
+        Movie movie = new Movie("Test Movie", 2024, genre, "A test movie.", LocalDate.now());
+        movie.setVideoFilePath("/movies/test_movie.mkv");
+        Movie savedMovie = movieService.saveMovie(movie);
+
+        // WHEN we query for "is recently watched":
+        boolean isRecentlyWatched = savedMovie.isWatchedRecently();
+
+        // THEN it should be false, because the feature is explicitly disabled:
+        assertFalse(isRecentlyWatched,
+                    "Expected isWatchedRecently to return false when the feature is disabled, but it returned true.");
+    }
+
+    @Test
+    public void recentlyWatchedEpisode_returnsFalse() {
+        EpisodeService episodeService = new EpisodeService(episodeRepository, thumbnailService);
+        episodeService.setRecentlyWatchedDays(0); // explicitly disable the feature for this test
+
+        // GIVEN an Episode that was recently watched:
+        Series series = new Series("Test Series", "A series for testing.");
+        seriesRepository.save(series);
+        Episode episode = new Episode(series, "Test Episode", 1, 1, "A test episode.", LocalDate.now());
+        episode.setVideoFilePath("/episodes/test_series/s01e01.mkv");
+        Episode savedEpisode = episodeService.saveEpisode(episode);
+
+        // WHEN we query for "is recently watched":
+        boolean isRecentlyWatched = savedEpisode.isWatchedRecently();
+
+        // THEN it should be false, because the feature is explicitly disabled:
+        assertFalse(isRecentlyWatched,
+                    "Expected isWatchedRecently to return false when the feature is disabled, but it returned true.");
+    }
+
+    @Test
+    public void recentlyWatchedMusicVideo_returnsFalse() {
+        MusicVideoService musicVideoService = new MusicVideoService(musicVideoRepository, thumbnailService);
+        musicVideoService.setRecentlyWatchedDays(0); // explicitly disable the feature for this test
+
+        // GIVEN a Music Video that was recently watched:
+        Artist artist = new Artist("Test Artist", "An artist for testing.");
+        artistRepository.save(artist);
+        MusicVideo musicVideo = new MusicVideo("Test Music Video", artist, "album", 2024, "A test music video.",
+                                               LocalDate.now());
+        musicVideo.setVideoFilePath("/music-videos/test_artist/test_music_video.mkv");
+        MusicVideo savedMusicVideo = musicVideoService.saveMusicVideo(musicVideo);
+
+        // WHEN we query for "is recently watched":
+        boolean isRecentlyWatched = savedMusicVideo.isWatchedRecently();
+
+        // THEN it should be false, because the feature is explicitly disabled:
+        assertFalse(isRecentlyWatched,
+                    "Expected isWatchedRecently to return false when the feature is disabled, but it returned true.");
+    }
+}

--- a/backend/src/test/java/ca/corbett/movienight/EpisodeRepositoryTest.java
+++ b/backend/src/test/java/ca/corbett/movienight/EpisodeRepositoryTest.java
@@ -4,17 +4,23 @@ import ca.corbett.movienight.model.Episode;
 import ca.corbett.movienight.model.Series;
 import ca.corbett.movienight.repository.EpisodeRepository;
 import ca.corbett.movienight.repository.SeriesRepository;
+import ca.corbett.movienight.service.EpisodeService;
+import ca.corbett.movienight.service.ThumbnailService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.test.context.TestPropertySource;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
@@ -22,7 +28,8 @@ import static org.assertj.core.api.Assertions.assertThat;
         "spring.datasource.url=jdbc:sqlite::memory:",
         "spring.datasource.driver-class-name=org.sqlite.JDBC",
         "spring.jpa.database-platform=org.hibernate.community.dialect.SQLiteDialect",
-        "spring.jpa.hibernate.ddl-auto=create-drop"
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "movienight.recently-watched-days=5" // This is ignored because we create the service ourselves here
 })
 class EpisodeRepositoryTest {
 
@@ -32,11 +39,14 @@ class EpisodeRepositoryTest {
     @Autowired
     private SeriesRepository seriesRepository;
 
+    @MockBean
+    private ThumbnailService thumbnailService;
+
     @Test
     void saveAndFindEpisode() {
         Series dexter = new Series("Dexter", "A blood spatter analyst leads a secret life as a vigilante.");
         seriesRepository.save(dexter);
-        Episode ep = new Episode(dexter, "Hungry Man", 4, 9, "Thanksgiving.", false);
+        Episode ep = new Episode(dexter, "Hungry Man", 4, 9, "Thanksgiving.", null);
         ep.setVideoFilePath("/shows/dexter/s04e09.mkv");
         episodeRepository.save(ep);
 
@@ -50,7 +60,7 @@ class EpisodeRepositoryTest {
     void saveAndFindEpisodeWithTags() {
         Series dexter = new Series("Dexter");
         seriesRepository.save(dexter);
-        Episode ep = new Episode(dexter, "Hungry Man", 4, 9, "Thanksgiving.", false);
+        Episode ep = new Episode(dexter, "Hungry Man", 4, 9, "Thanksgiving.", null);
         ep.setVideoFilePath("/shows/dexter/s04e09.mkv");
         ep.setTags(List.of("Drama", "Thriller", "Must-See"));
         episodeRepository.save(ep);
@@ -64,7 +74,7 @@ class EpisodeRepositoryTest {
     void tagsAreNormalizedToLowercase() {
         Series dexter = new Series("Dexter");
         seriesRepository.save(dexter);
-        Episode ep = new Episode(dexter, "Ep", 1, 1, null, false);
+        Episode ep = new Episode(dexter, "Ep", 1, 1, null, null);
         ep.setVideoFilePath("/shows/show/s01e01.mkv");
         ep.setTags(List.of("Drama", "DRAMA", "drama", "  Drama  "));
         episodeRepository.save(ep);
@@ -77,13 +87,13 @@ class EpisodeRepositoryTest {
     void findByTagsContainingIgnoreCase() {
         Series showA = new Series("Show A");
         seriesRepository.save(showA);
-        Episode ep1 = new Episode(showA, "Ep1", 1, 1, null, false);
+        Episode ep1 = new Episode(showA, "Ep1", 1, 1, null, null);
         ep1.setVideoFilePath("/shows/showa/s01e01.mkv");
         ep1.setTags(List.of("drama", "award-winner"));
 
         Series showB = new Series("Show B");
         seriesRepository.save(showB);
-        Episode ep2 = new Episode(showB, "Ep1", 1, 1, null, false);
+        Episode ep2 = new Episode(showB, "Ep1", 1, 1, null, null);
         ep2.setVideoFilePath("/shows/showb/s01e01.mkv");
         ep2.setTags(List.of("comedy", "family"));
 
@@ -98,16 +108,16 @@ class EpisodeRepositoryTest {
     void searchOrderedBySeasonThenEpisode() {
         Series dexter = new Series("Dexter");
         seriesRepository.save(dexter);
-        Episode s4e3 = new Episode(dexter, "S4E3", 4, 3, null, false);
+        Episode s4e3 = new Episode(dexter, "S4E3", 4, 3, null, null);
         s4e3.setVideoFilePath("/shows/dexter/s04e03.mkv");
         episodeRepository.save(s4e3);
-        Episode s2e1 = new Episode(dexter, "S2E1", 2, 1, null, false);
+        Episode s2e1 = new Episode(dexter, "S2E1", 2, 1, null, null);
         s2e1.setVideoFilePath("/shows/dexter/s02e01.mkv");
         episodeRepository.save(s2e1);
-        Episode s4e1 = new Episode(dexter, "S4E1", 4, 1, null, false);
+        Episode s4e1 = new Episode(dexter, "S4E1", 4, 1, null, null);
         s4e1.setVideoFilePath("/shows/dexter/s04e01.mkv");
         episodeRepository.save(s4e1);
-        Episode s1e1 = new Episode(dexter, "S1E1", 1, 1, null, false);
+        Episode s1e1 = new Episode(dexter, "S1E1", 1, 1, null, null);
         s1e1.setVideoFilePath("/shows/dexter/s01e01.mkv");
         episodeRepository.save(s1e1);
 
@@ -122,5 +132,65 @@ class EpisodeRepositoryTest {
         assertThat(results.get(1).getEpisodeTitle()).isEqualTo("S2E1");
         assertThat(results.get(2).getEpisodeTitle()).isEqualTo("S4E1");
         assertThat(results.get(3).getEpisodeTitle()).isEqualTo("S4E3");
+    }
+
+    @Test
+    void isWatchedRecently_withRecentWatch_shouldReturnTrue() {
+        EpisodeService episodeService = new EpisodeService(episodeRepository, thumbnailService);
+        episodeService.setRecentlyWatchedDays(5); // ensure our threshold is 5 days for this test
+
+        // GIVEN an episode that was watched recently:
+        Series series = new Series("Test Series", "A series for testing.");
+        seriesRepository.save(series);
+        Episode episode = new Episode(series, "Test Episode", 1, 1, "A test episode.", LocalDate.now());
+        episode.setVideoFilePath("/episodes/test_series/s01e01.mkv");
+        Episode savedEpisode = episodeService.saveEpisode(episode);
+
+        // WHEN we query for "is recently watched":
+        boolean isRecentlyWatched = savedEpisode.isWatchedRecently();
+
+        // THEN it should return true, because it's within our five-day threshold from properties:
+        assertTrue(isRecentlyWatched,
+                   "Expected isWatchedRecently to return true for an episode watched within the recent threshold, but it returned false.");
+    }
+
+    @Test
+    void isWatchedRecently_withNullWatchedDate_shouldReturnFalse() {
+        EpisodeService episodeService = new EpisodeService(episodeRepository, thumbnailService);
+        episodeService.setRecentlyWatchedDays(5); // ensure our threshold is 5 days for this test
+
+        // GIVEN an episode that has never been watched:
+        Series series = new Series("Test Series", "A series for testing.");
+        seriesRepository.save(series);
+        Episode episode = new Episode(series, "Test Episode", 1, 1, "A test episode.", null);
+        episode.setVideoFilePath("/episodes/test_series/s01e01.mkv");
+        Episode savedEpisode = episodeService.saveEpisode(episode);
+
+        // WHEN we query for "is recently watched":
+        boolean isRecentlyWatched = savedEpisode.isWatchedRecently();
+
+        // THEN it should return false, because "never been watched" means "not watched recently" by definition.
+        assertFalse(isRecentlyWatched,
+                    "Expected isWatchedRecently to return false for an episode that has never been watched.");
+    }
+
+    @Test
+    void isWatchedRecently_withOldWatchedDate_shouldReturnFalse() {
+        EpisodeService episodeService = new EpisodeService(episodeRepository, thumbnailService);
+        episodeService.setRecentlyWatchedDays(5); // ensure our threshold is 5 days for this test
+
+        // GIVEN an episode that was watched a long time ago:
+        Series series = new Series("Test Series", "A series for testing.");
+        seriesRepository.save(series);
+        Episode episode = new Episode(series, "Test Episode", 1, 1, "A test episode.", LocalDate.now().minusDays(10));
+        episode.setVideoFilePath("/episodes/test_series/s01e01.mkv");
+        Episode savedEpisode = episodeService.saveEpisode(episode);
+
+        // WHEN we query for "is recently watched":
+        boolean isRecentlyWatched = savedEpisode.isWatchedRecently();
+
+        // THEN it should return false, because it's outside our five-day threshold from properties.
+        assertFalse(isRecentlyWatched,
+                    "Expected isWatchedRecently to return false for an episode watched outside the recent threshold, but it returned true.");
     }
 }

--- a/backend/src/test/java/ca/corbett/movienight/MediaServiceTest.java
+++ b/backend/src/test/java/ca/corbett/movienight/MediaServiceTest.java
@@ -37,7 +37,7 @@ class MediaServiceTest {
     void resolvesMovieId() {
         Genre drama = new Genre("Drama", "");
 
-        Movie movie = new Movie("Test Movie", 2024, drama, "A test.", false);
+        Movie movie = new Movie("Test Movie", 2024, drama, "A test.", null);
         movie.setVideoFilePath("/movies/test_movie.mp4");
         when(movieService.requireMovie(42L)).thenReturn(movie);
 
@@ -48,7 +48,7 @@ class MediaServiceTest {
     @Test
     void resolvesEpisodeId() {
         Series series = new Series("Test Series", "A test series.");
-        Episode episode = new Episode(series, "Pilot", 1, 1, "First episode.", false);
+        Episode episode = new Episode(series, "Pilot", 1, 1, "First episode.", null);
         episode.setVideoFilePath("/episodes/s01e01.mp4");
         when(episodeService.requireEpisode(7L)).thenReturn(episode);
 

--- a/backend/src/test/java/ca/corbett/movienight/MediaServiceTest.java
+++ b/backend/src/test/java/ca/corbett/movienight/MediaServiceTest.java
@@ -4,13 +4,22 @@ import ca.corbett.movienight.model.Episode;
 import ca.corbett.movienight.model.Genre;
 import ca.corbett.movienight.model.Movie;
 import ca.corbett.movienight.model.Series;
+import ca.corbett.movienight.repository.EpisodeRepository;
+import ca.corbett.movienight.repository.GenreRepository;
+import ca.corbett.movienight.repository.MovieRepository;
+import ca.corbett.movienight.repository.MusicVideoRepository;
+import ca.corbett.movienight.repository.SeriesRepository;
 import ca.corbett.movienight.service.EpisodeService;
 import ca.corbett.movienight.service.MediaService;
 import ca.corbett.movienight.service.MovieService;
 import ca.corbett.movienight.service.MusicVideoService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.http.HttpStatus;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.web.server.ResponseStatusException;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -18,6 +27,14 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:sqlite::memory:",
+        "spring.datasource.driver-class-name=org.sqlite.JDBC",
+        "spring.jpa.database-platform=org.hibernate.community.dialect.SQLiteDialect",
+        "spring.jpa.hibernate.ddl-auto=create-drop"
+})
 class MediaServiceTest {
 
     private MovieService movieService;
@@ -25,35 +42,62 @@ class MediaServiceTest {
     private MusicVideoService musicVideoService;
     private MediaService mediaService;
 
+    @Autowired
+    private SeriesRepository seriesRepository;
+
+    @Autowired
+    private GenreRepository genreRepository;
+
+    @Autowired
+    private MovieRepository movieRepository;
+
+    @Autowired
+    private EpisodeRepository episodeRepository;
+
+    @Autowired
+    private MusicVideoRepository musicVideoRepository;
+
     @BeforeEach
     void setUp() {
         movieService = mock(MovieService.class);
         episodeService = mock(EpisodeService.class);
         musicVideoService = mock(MusicVideoService.class);
-        mediaService = new MediaService(movieService, episodeService, musicVideoService);
+        mediaService = new MediaService(movieService, episodeService, musicVideoService,
+                                        movieRepository, episodeRepository, musicVideoRepository);
     }
 
     @Test
     void resolvesMovieId() {
         Genre drama = new Genre("Drama", "");
-
+        genreRepository.save(drama);
         Movie movie = new Movie("Test Movie", 2024, drama, "A test.", null);
         movie.setVideoFilePath("/movies/test_movie.mp4");
-        when(movieService.requireMovie(42L)).thenReturn(movie);
+        movie = movieRepository.save(movie);
+        when(movieService.requireMovie(movie.getId())).thenReturn(movie);
 
-        String path = mediaService.findById("M42");
+        String path = mediaService.findById("M" + movie.getId());
         assertThat(path).isEqualTo("/movies/test_movie.mp4");
+
+        // Also verify that the side effect of the mediaService.findById set a lastWatchedDate and saved it.
+        Movie actual = movieRepository.findById(movie.getId()).orElseThrow();
+        assertThat(actual.getLastWatchedDate()).isNotNull();
     }
 
     @Test
     void resolvesEpisodeId() {
         Series series = new Series("Test Series", "A test series.");
+        seriesRepository.save(series);
         Episode episode = new Episode(series, "Pilot", 1, 1, "First episode.", null);
         episode.setVideoFilePath("/episodes/s01e01.mp4");
-        when(episodeService.requireEpisode(7L)).thenReturn(episode);
+        episode = episodeRepository.save(episode);
+        when(episodeService.requireEpisode(episode.getId())).thenReturn(episode);
 
-        String path = mediaService.findById("E7");
+        String path = mediaService.findById("E" + episode.getId());
         assertThat(path).isEqualTo("/episodes/s01e01.mp4");
+
+        // Also verify that the side effect of the mediaService.findById set a lastWatchedDate and saved it.
+        Episode actual = episodeRepository.findById(episode.getId()).orElseThrow();
+        assertThat(actual.getLastWatchedDate()).isNotNull();
     }
 
     @Test

--- a/backend/src/test/java/ca/corbett/movienight/MovieRepositoryTest.java
+++ b/backend/src/test/java/ca/corbett/movienight/MovieRepositoryTest.java
@@ -4,6 +4,8 @@ import ca.corbett.movienight.model.Genre;
 import ca.corbett.movienight.model.Movie;
 import ca.corbett.movienight.repository.GenreRepository;
 import ca.corbett.movienight.repository.MovieRepository;
+import ca.corbett.movienight.service.MovieService;
+import ca.corbett.movienight.service.ThumbnailService;
 import jakarta.persistence.criteria.Join;
 import jakarta.persistence.criteria.JoinType;
 import org.junit.jupiter.api.BeforeEach;
@@ -11,12 +13,16 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.test.context.TestPropertySource;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
@@ -24,7 +30,8 @@ import static org.assertj.core.api.Assertions.assertThat;
         "spring.datasource.url=jdbc:sqlite::memory:",
         "spring.datasource.driver-class-name=org.sqlite.JDBC",
         "spring.jpa.database-platform=org.hibernate.community.dialect.SQLiteDialect",
-        "spring.jpa.hibernate.ddl-auto=create-drop"
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "movienight.recently-watched-days=5" // This is ignored because we create the service ourselves here
 })
 class MovieRepositoryTest {
 
@@ -33,6 +40,9 @@ class MovieRepositoryTest {
 
     @Autowired
     private GenreRepository genreRepository;
+
+    @MockBean
+    private ThumbnailService thumbnailService;
 
     private Genre drama;
     private Genre comedy;
@@ -56,7 +66,7 @@ class MovieRepositoryTest {
 
     @Test
     void saveAndFindMovie() {
-        Movie movie = new Movie("Test Movie", 2024, drama, "A test movie.", false);
+        Movie movie = new Movie("Test Movie", 2024, drama, "A test movie.", null);
         movie.setVideoFilePath("/movies/test_movie.mkv");
         movieRepository.save(movie);
 
@@ -67,10 +77,10 @@ class MovieRepositoryTest {
 
     @Test
     void findByTitleContainingIgnoreCase() {
-        Movie inception = new Movie("Inception", 2010, sciFi, "Dream heist.", false);
+        Movie inception = new Movie("Inception", 2010, sciFi, "Dream heist.", null);
         inception.setVideoFilePath("/movies/inception.mkv");
         movieRepository.save(inception);
-        Movie interstellar = new Movie("Interstellar", 2014, sciFi, "Space travel.", false);
+        Movie interstellar = new Movie("Interstellar", 2014, sciFi, "Space travel.", null);
         interstellar.setVideoFilePath("/movies/interstellar.mkv");
         movieRepository.save(interstellar);
 
@@ -80,22 +90,8 @@ class MovieRepositoryTest {
     }
 
     @Test
-    void findByWatched() {
-        Movie watchedMovie = new Movie("Watched Movie", 2020, comedy, "Seen it.", true);
-        watchedMovie.setVideoFilePath("/movies/watched_movie.mkv");
-        movieRepository.save(watchedMovie);
-        Movie unwatchedMovie = new Movie("Unwatched Movie", 2021, thriller, "Not yet.", false);
-        unwatchedMovie.setVideoFilePath("/movies/unwatched_movie.mkv");
-        movieRepository.save(unwatchedMovie);
-
-        List<Movie> watched = movieRepository.findByWatched(true);
-        assertThat(watched).hasSize(1);
-        assertThat(watched.get(0).getTitle()).isEqualTo("Watched Movie");
-    }
-
-    @Test
     void saveAndFindMovieWithTags() {
-        Movie movie = new Movie("Tagged Movie", 2023, action, "Has tags.", false);
+        Movie movie = new Movie("Tagged Movie", 2023, action, "Has tags.", null);
         movie.setVideoFilePath("/movies/tagged_movie.mkv");
         movie.setTags(List.of("Action", "Thriller", "Must-See"));
         movieRepository.save(movie);
@@ -107,11 +103,11 @@ class MovieRepositoryTest {
 
     @Test
     void findByTagsContainingIgnoreCase() {
-        Movie movie1 = new Movie("Movie One", 2021, drama, "First.", false);
+        Movie movie1 = new Movie("Movie One", 2021, drama, "First.", null);
         movie1.setVideoFilePath("/movies/movie_one.mkv");
         movie1.setTags(List.of("drama", "award-winner"));
 
-        Movie movie2 = new Movie("Movie Two", 2022, comedy, "Second.", false);
+        Movie movie2 = new Movie("Movie Two", 2022, comedy, "Second.", null);
         movie2.setVideoFilePath("/movies/movie_two.mkv");
         movie2.setTags(List.of("comedy", "family"));
 
@@ -125,7 +121,7 @@ class MovieRepositoryTest {
 
     @Test
     void tagsAreNormalizedToLowercase() {
-        Movie movie = new Movie("Case Test", 2020, action, "Test normalization.", false);
+        Movie movie = new Movie("Case Test", 2020, action, "Test normalization.", null);
         movie.setVideoFilePath("/movies/case_test.mkv");
         movie.setTags(List.of("Action", "ACTION", "action", "  Action  "));
         movieRepository.save(movie);
@@ -135,27 +131,25 @@ class MovieRepositoryTest {
     }
 
     @Test
-    void combinedFilterTitleAndWatchedAndTag() {
-        Movie m1 = new Movie("Action Hero", 2020, action, "Hero stuff.", true);
+    void combinedFilterTitleAndTag() {
+        Movie m1 = new Movie("Action Hero", 2020, action, "Hero stuff.", null);
         m1.setVideoFilePath("/movies/action_hero.mkv");
         m1.setTags(List.of("action", "blockbuster"));
 
-        Movie m2 = new Movie("Action Zero", 2021, action, "Zero stuff.", false);
+        Movie m2 = new Movie("Action Zero", 2021, action, "Zero stuff.", null);
         m2.setVideoFilePath("/movies/action_zero.mkv");
-        m2.setTags(List.of("action", "blockbuster"));
+        m2.setTags(List.of("action"));
 
-        Movie m3 = new Movie("Comedy King", 2022, comedy, "Funny stuff.", true);
+        Movie m3 = new Movie("Comedy King", 2022, comedy, "Funny stuff.", null);
         m3.setVideoFilePath("/movies/comedy_king.mkv");
         m3.setTags(List.of("comedy"));
 
         movieRepository.saveAll(List.of(m1, m2, m3));
 
-        // title contains "action", watched=true, tag contains "blockbuster" → only m1
+        // title contains "action", tag contains "blockbuster" → only m1
         Specification<Movie> spec = Specification
                 .<Movie>where((root, query, cb) ->
                         cb.like(cb.lower(root.get("title")), "%action%"))
-                .and((root, query, cb) ->
-                        cb.equal(root.get("watched"), true))
                 .and((root, query, cb) -> {
                     query.distinct(true);
                     Join<Movie, String> tagsJoin = root.join("tags", JoinType.INNER);
@@ -169,11 +163,11 @@ class MovieRepositoryTest {
 
     @Test
     void countByGenre() {
-        Movie m1 = new Movie("Movie 1", 2020, drama, "Drama movie.", false);
+        Movie m1 = new Movie("Movie 1", 2020, drama, "Drama movie.", null);
         m1.setVideoFilePath("/movies/movie1.mkv");
-        Movie m2 = new Movie("Movie 2", 2021, drama, "Another drama.", false);
+        Movie m2 = new Movie("Movie 2", 2021, drama, "Another drama.", null);
         m2.setVideoFilePath("/movies/movie2.mkv");
-        Movie m3 = new Movie("Movie 3", 2022, comedy, "Comedy movie.", false);
+        Movie m3 = new Movie("Movie 3", 2022, comedy, "Comedy movie.", null);
         m3.setVideoFilePath("/movies/movie3.mkv");
         movieRepository.saveAll(List.of(m1, m2, m3));
 
@@ -188,11 +182,11 @@ class MovieRepositoryTest {
 
     @Test
     void findByGenre() {
-        Movie m1 = new Movie("Movie 1", 2020, drama, "Drama movie.", false);
+        Movie m1 = new Movie("Movie 1", 2020, drama, "Drama movie.", null);
         m1.setVideoFilePath("/movies/movie1.mkv");
-        Movie m2 = new Movie("Movie 2", 2021, drama, "Another drama.", false);
+        Movie m2 = new Movie("Movie 2", 2021, drama, "Another drama.", null);
         m2.setVideoFilePath("/movies/movie2.mkv");
-        Movie m3 = new Movie("Movie 3", 2022, comedy, "Comedy movie.", false);
+        Movie m3 = new Movie("Movie 3", 2022, comedy, "Comedy movie.", null);
         m3.setVideoFilePath("/movies/movie3.mkv");
         movieRepository.saveAll(List.of(m1, m2, m3));
 
@@ -203,5 +197,65 @@ class MovieRepositoryTest {
         assertThat(dramas).hasSize(2).extracting(Movie::getTitle).containsExactlyInAnyOrder("Movie 1", "Movie 2");
         assertThat(comedies).hasSize(1).extracting(Movie::getTitle).containsExactly("Movie 3");
         assertThat(sciFis).isEmpty();
+    }
+
+    @Test
+    void isWatchedRecently_withRecentWatch_shouldReturnTrue() {
+        MovieService movieService = new MovieService(movieRepository, thumbnailService);
+        movieService.setRecentlyWatchedDays(5); // ensure our threshold is 5 days for this test
+
+        // GIVEN a movie that was watched recently:
+        Genre genre = new Genre("Test Genre", "A genre for testing.");
+        genreRepository.save(genre);
+        Movie movie = new Movie("Test Movie", 2024, genre, "A test movie.", LocalDate.now().minusDays(2));
+        movie.setVideoFilePath("/movies/test_movie.mkv");
+        Movie savedMovie = movieService.saveMovie(movie);
+
+        // WHEN we query for "is recently watched":
+        boolean isRecentlyWatched = savedMovie.isWatchedRecently();
+
+        // THEN it should return true, because it's within our five-day threshold from properties:
+        assertTrue(isRecentlyWatched,
+                   "Expected isWatchedRecently to return true for a movie watched within the recent threshold, but it returned false.");
+    }
+
+    @Test
+    void isWatchedRecently_withNullWatchedDate_shouldReturnFalse() {
+        MovieService movieService = new MovieService(movieRepository, thumbnailService);
+        movieService.setRecentlyWatchedDays(5); // ensure our threshold is 5 days for this test
+
+        // GIVEN a movie that has never been watched:
+        Genre genre = new Genre("Test Genre", "A genre for testing.");
+        genreRepository.save(genre);
+        Movie movie = new Movie("Test Movie", 2024, genre, "A test movie.", null);
+        movie.setVideoFilePath("/movies/test_movie.mkv");
+        Movie savedMovie = movieService.saveMovie(movie);
+
+        // WHEN we query for "is recently watched":
+        boolean isRecentlyWatched = savedMovie.isWatchedRecently();
+
+        // THEN it should return false, because "never been watched" means "not watched recently" by definition.
+        assertFalse(isRecentlyWatched,
+                    "Expected isWatchedRecently to return false for a movie that has never been watched.");
+    }
+
+    @Test
+    void isWatchedRecently_withOldWatchedDate_shouldReturnFalse() {
+        MovieService movieService = new MovieService(movieRepository, thumbnailService);
+        movieService.setRecentlyWatchedDays(5); // ensure our threshold is 5 days for this test
+
+        // GIVEN a movie that was watched a long time ago:
+        Genre genre = new Genre("Test Genre", "A genre for testing.");
+        genreRepository.save(genre);
+        Movie movie = new Movie("Test Movie", 2024, genre, "A test movie.", LocalDate.now().minusDays(10));
+        movie.setVideoFilePath("/movies/test_movie.mkv");
+        Movie savedMovie = movieService.saveMovie(movie);
+
+        // WHEN we query for "is recently watched":
+        boolean isRecentlyWatched = savedMovie.isWatchedRecently();
+
+        // THEN it should return false, because it's outside our five-day threshold from properties.
+        assertFalse(isRecentlyWatched,
+                    "Expected isWatchedRecently to return false for a movie watched outside the recent threshold, but it returned true.");
     }
 }

--- a/backend/src/test/java/ca/corbett/movienight/MusicVideoRepositoryTest.java
+++ b/backend/src/test/java/ca/corbett/movienight/MusicVideoRepositoryTest.java
@@ -4,6 +4,8 @@ import ca.corbett.movienight.model.Artist;
 import ca.corbett.movienight.model.MusicVideo;
 import ca.corbett.movienight.repository.ArtistRepository;
 import ca.corbett.movienight.repository.MusicVideoRepository;
+import ca.corbett.movienight.service.MusicVideoService;
+import ca.corbett.movienight.service.ThumbnailService;
 import jakarta.persistence.criteria.Join;
 import jakarta.persistence.criteria.JoinType;
 import org.junit.jupiter.api.BeforeEach;
@@ -11,12 +13,16 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.test.context.TestPropertySource;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
@@ -24,7 +30,8 @@ import static org.assertj.core.api.Assertions.assertThat;
         "spring.datasource.url=jdbc:sqlite::memory:",
         "spring.datasource.driver-class-name=org.sqlite.JDBC",
         "spring.jpa.database-platform=org.hibernate.community.dialect.SQLiteDialect",
-        "spring.jpa.hibernate.ddl-auto=create-drop"
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "movienight.recently-watched-days=5" // This is ignored because we create the service ourselves here
 })
 class MusicVideoRepositoryTest {
 
@@ -33,6 +40,9 @@ class MusicVideoRepositoryTest {
 
     @Autowired
     private ArtistRepository artistRepository;
+
+    @MockBean
+    private ThumbnailService thumbnailService;
 
     private Artist beatles;
     private Artist queen;
@@ -50,7 +60,7 @@ class MusicVideoRepositoryTest {
 
     @Test
     void saveAndFindMusicVideo() {
-        MusicVideo mv = new MusicVideo("Hey Jude", beatles, null, 1968, "A classic Beatles song.");
+        MusicVideo mv = new MusicVideo("Hey Jude", beatles, null, 1968, "A classic Beatles song.", null);
         mv.setVideoFilePath("/music-videos/beatles/hey_jude.mp4");
         musicVideoRepository.save(mv);
 
@@ -62,10 +72,11 @@ class MusicVideoRepositoryTest {
 
     @Test
     void findByTitleContainingIgnoreCase() {
-        MusicVideo mv1 = new MusicVideo("Bohemian Rhapsody", queen, "A Night at the Opera", 1975, "Queen classic.");
+        MusicVideo mv1 = new MusicVideo("Bohemian Rhapsody", queen, "A Night at the Opera", 1975, "Queen classic.",
+                                        null);
         mv1.setVideoFilePath("/music-videos/queen/bohemian_rhapsody.mp4");
         musicVideoRepository.save(mv1);
-        MusicVideo mv2 = new MusicVideo("We Will Rock You", queen, "News of the World", 1977, "Anthem.");
+        MusicVideo mv2 = new MusicVideo("We Will Rock You", queen, "News of the World", 1977, "Anthem.", null);
         mv2.setVideoFilePath("/music-videos/queen/we_will_rock_you.mp4");
         musicVideoRepository.save(mv2);
 
@@ -76,7 +87,7 @@ class MusicVideoRepositoryTest {
 
     @Test
     void saveAndFindMusicVideoWithTags() {
-        MusicVideo mv = new MusicVideo("Creep", radiohead, "Pablo Honey", 1993, "Radiohead hit.");
+        MusicVideo mv = new MusicVideo("Creep", radiohead, "Pablo Honey", 1993, "Radiohead hit.", null);
         mv.setVideoFilePath("/music-videos/radiohead/creep.mp4");
         mv.setTags(List.of("Alternative", "Grunge", "Must-See"));
         musicVideoRepository.save(mv);
@@ -88,7 +99,7 @@ class MusicVideoRepositoryTest {
 
     @Test
     void tagsAreNormalizedToLowercase() {
-        MusicVideo mv = new MusicVideo("Karma Police", radiohead, "OK Computer", 1997, "OK Computer track.");
+        MusicVideo mv = new MusicVideo("Karma Police", radiohead, "OK Computer", 1997, "OK Computer track.", null);
         mv.setVideoFilePath("/music-videos/radiohead/karma_police.mp4");
         mv.setTags(List.of("Rock", "ROCK", "rock", "  Rock  "));
         musicVideoRepository.save(mv);
@@ -99,11 +110,11 @@ class MusicVideoRepositoryTest {
 
     @Test
     void findByTagsContainingIgnoreCase() {
-        MusicVideo mv1 = new MusicVideo("Let It Be", beatles, "Let It Be", 1970, "Beatles classic.");
+        MusicVideo mv1 = new MusicVideo("Let It Be", beatles, "Let It Be", 1970, "Beatles classic.", null);
         mv1.setVideoFilePath("/music-videos/beatles/let_it_be.mp4");
         mv1.setTags(List.of("classic", "pop"));
 
-        MusicVideo mv2 = new MusicVideo("Under Pressure", queen, "Hot Space", 1982, "Queen and Bowie.");
+        MusicVideo mv2 = new MusicVideo("Under Pressure", queen, "Hot Space", 1982, "Queen and Bowie.", null);
         mv2.setVideoFilePath("/music-videos/queen/under_pressure.mp4");
         mv2.setTags(List.of("rock", "collaboration"));
 
@@ -116,11 +127,11 @@ class MusicVideoRepositoryTest {
 
     @Test
     void countByArtist() {
-        MusicVideo mv1 = new MusicVideo("Come Together", beatles, "Abbey Road", 1969, null);
+        MusicVideo mv1 = new MusicVideo("Come Together", beatles, "Abbey Road", 1969, null, null);
         mv1.setVideoFilePath("/music-videos/beatles/come_together.mp4");
-        MusicVideo mv2 = new MusicVideo("Hey Jude", beatles, null, 1968, null);
+        MusicVideo mv2 = new MusicVideo("Hey Jude", beatles, null, 1968, null, null);
         mv2.setVideoFilePath("/music-videos/beatles/hey_jude.mp4");
-        MusicVideo mv3 = new MusicVideo("Bohemian Rhapsody", queen, "A Night at the Opera", 1975, null);
+        MusicVideo mv3 = new MusicVideo("Bohemian Rhapsody", queen, "A Night at the Opera", 1975, null, null);
         mv3.setVideoFilePath("/music-videos/queen/bohemian_rhapsody.mp4");
         musicVideoRepository.saveAll(List.of(mv1, mv2, mv3));
 
@@ -135,11 +146,11 @@ class MusicVideoRepositoryTest {
 
     @Test
     void findByArtist() {
-        MusicVideo mv1 = new MusicVideo("Come Together", beatles, "Abbey Road", 1969, null);
+        MusicVideo mv1 = new MusicVideo("Come Together", beatles, "Abbey Road", 1969, null, null);
         mv1.setVideoFilePath("/music-videos/beatles/come_together.mp4");
-        MusicVideo mv2 = new MusicVideo("Hey Jude", beatles, null, 1968, null);
+        MusicVideo mv2 = new MusicVideo("Hey Jude", beatles, null, 1968, null, null);
         mv2.setVideoFilePath("/music-videos/beatles/hey_jude.mp4");
-        MusicVideo mv3 = new MusicVideo("Bohemian Rhapsody", queen, "A Night at the Opera", 1975, null);
+        MusicVideo mv3 = new MusicVideo("Bohemian Rhapsody", queen, "A Night at the Opera", 1975, null, null);
         mv3.setVideoFilePath("/music-videos/queen/bohemian_rhapsody.mp4");
         musicVideoRepository.saveAll(List.of(mv1, mv2, mv3));
 
@@ -158,11 +169,11 @@ class MusicVideoRepositoryTest {
 
     @Test
     void combinedFilterTitleAndTag() {
-        MusicVideo mv1 = new MusicVideo("Come Together", beatles, "Abbey Road", 1969, null);
+        MusicVideo mv1 = new MusicVideo("Come Together", beatles, "Abbey Road", 1969, null, null);
         mv1.setVideoFilePath("/music-videos/beatles/come_together.mp4");
         mv1.setTags(List.of("classic", "rock"));
 
-        MusicVideo mv2 = new MusicVideo("Creep", radiohead, "Pablo Honey", 1993, null);
+        MusicVideo mv2 = new MusicVideo("Creep", radiohead, "Pablo Honey", 1993, null, null);
         mv2.setVideoFilePath("/music-videos/radiohead/creep.mp4");
         mv2.setTags(List.of("grunge"));
 
@@ -181,5 +192,68 @@ class MusicVideoRepositoryTest {
         List<MusicVideo> results = musicVideoRepository.findAll(spec);
         assertThat(results).hasSize(1);
         assertThat(results.get(0).getTitle()).isEqualTo("Come Together");
+    }
+
+    @Test
+    void isWatchedRecently_withRecentWatch_shouldReturnTrue() {
+        MusicVideoService musicVideoService = new MusicVideoService(musicVideoRepository, thumbnailService);
+        musicVideoService.setRecentlyWatchedDays(5); // ensure our threshold is 5 days for this test
+
+        // GIVEN a music video that was watched recently:
+        Artist artist = new Artist("Test Artist", "An artist for testing.");
+        artistRepository.save(artist);
+        MusicVideo musicVideo = new MusicVideo("Test Music Video", artist, "album", 2024, "A test music video.",
+                                               LocalDate.now().minusDays(2));
+        musicVideo.setVideoFilePath("/music-videos/test_artist/test_music_video.mkv");
+        MusicVideo savedMusicVideo = musicVideoService.saveMusicVideo(musicVideo);
+
+        // WHEN we query for "is recently watched":
+        boolean isRecentlyWatched = savedMusicVideo.isWatchedRecently();
+
+        // THEN it should return true, because it's within our five-day threshold from properties:
+        assertTrue(isRecentlyWatched,
+                   "Expected isWatchedRecently to return true for a music video watched within the recent threshold, but it returned false.");
+    }
+
+    @Test
+    void isWatchedRecently_withNullWatchedDate_shouldReturnFalse() {
+        MusicVideoService musicVideoService = new MusicVideoService(musicVideoRepository, thumbnailService);
+        musicVideoService.setRecentlyWatchedDays(5); // ensure our threshold is 5 days for this test
+
+        // GIVEN a music video that has never been watched:
+        Artist artist = new Artist("Test Artist", "An artist for testing.");
+        artistRepository.save(artist);
+        MusicVideo musicVideo = new MusicVideo("Test Music Video", artist, "album", 2024, "A test music video.",
+                                               null);
+        musicVideo.setVideoFilePath("/music-videos/test_artist/test_music_video.mkv");
+        MusicVideo savedMusicVideo = musicVideoService.saveMusicVideo(musicVideo);
+
+        // WHEN we query for "is recently watched":
+        boolean isRecentlyWatched = savedMusicVideo.isWatchedRecently();
+
+        // THEN it should return false, because "never been watched" means "not watched recently" by definition.
+        assertFalse(isRecentlyWatched,
+                    "Expected isWatchedRecently to return false for a music video that has never been watched.");
+    }
+
+    @Test
+    void isWatchedRecently_withOldWatchedDate_shouldReturnFalse() {
+        MusicVideoService musicVideoService = new MusicVideoService(musicVideoRepository, thumbnailService);
+        musicVideoService.setRecentlyWatchedDays(5); // ensure our threshold is 5 days for this test
+
+        // GIVEN a music video that was watched a long time ago:
+        Artist artist = new Artist("Test Artist", "An artist for testing.");
+        artistRepository.save(artist);
+        MusicVideo musicVideo = new MusicVideo("Test Music Video", artist, "album", 2024, "A test music video.",
+                                               LocalDate.now().minusDays(10));
+        musicVideo.setVideoFilePath("/music-videos/test_artist/test_music_video.mkv");
+        MusicVideo savedMusicVideo = musicVideoService.saveMusicVideo(musicVideo);
+
+        // WHEN we query for "is recently watched":
+        boolean isRecentlyWatched = savedMusicVideo.isWatchedRecently();
+
+        // THEN it should return false, because it's outside our five-day threshold from properties.
+        assertFalse(isRecentlyWatched,
+                    "Expected isWatchedRecently to return false for a music video watched outside the recent threshold, but it returned true.");
     }
 }

--- a/frontend/src/components/EpisodeForm.jsx
+++ b/frontend/src/components/EpisodeForm.jsx
@@ -11,7 +11,6 @@ const EMPTY_FORM = {
   season: '',
   episode: '',
   description: '',
-  watched: false,
   tags: [],
   videoFilePath: '',
 }
@@ -88,7 +87,6 @@ export default function EpisodeForm({ episode, onSave, onCancel }) {
         episodeTitle: episode.episodeTitle ?? '',
         description: episode.description ?? '',
         videoFilePath: episode.videoFilePath ?? '',
-        watched: episode.watched ?? false,
         seriesId: episode.series?.id != null ? String(episode.series.id) : '',
         season: episode.season ?? '',
         episode: episode.episode ?? '',
@@ -139,7 +137,6 @@ export default function EpisodeForm({ episode, onSave, onCancel }) {
         episodeTitle: form.episodeTitle.trim() || null,
         description: form.description.trim() || null,
         videoFilePath: form.videoFilePath.trim(),
-        watched: form.watched,
       season: form.season !== '' ? Number(form.season) : null,
       episode: form.episode !== '' ? Number(form.episode) : null,
       tags: pendingTags,
@@ -361,18 +358,6 @@ export default function EpisodeForm({ episode, onSave, onCancel }) {
         </div>
         {errors.videoFilePath && <p className="text-red-400 text-xs mt-1">{errors.videoFilePath}</p>}
       </div>
-
-      {/* Watched */}
-      <label className="flex items-center gap-2 text-sm text-gray-300 cursor-pointer">
-        <input
-          name="watched"
-          type="checkbox"
-          checked={form.watched}
-          onChange={handleChange}
-          className="w-4 h-4 accent-indigo-500"
-        />
-        Marked as watched
-      </label>
 
       {/* Buttons */}
       <div className="flex gap-3 pt-2">

--- a/frontend/src/components/EpisodeList.jsx
+++ b/frontend/src/components/EpisodeList.jsx
@@ -65,10 +65,10 @@ function EpisodeCard({ episode, onEdit, onDelete, onTagClick, readOnly }) {
             <p className="text-sm text-gray-300 leading-tight">{episode.episodeTitle}</p>
           )}
         </div>
-        {episode.watched ? (
-          <span className="shrink-0 text-xs bg-green-800/60 text-green-300 px-2 py-0.5 rounded-full">Watched</span>
-        ) : (
-          <span className="shrink-0 text-xs bg-gray-700 text-gray-400 px-2 py-0.5 rounded-full">Unwatched</span>
+        {episode.watchedRecently && (
+          <span className="shrink-0 text-xs bg-green-800/60 text-green-300 px-2 py-0.5 rounded-full">
+            Watched recently
+          </span>
         )}
       </div>
 

--- a/frontend/src/components/MovieForm.jsx
+++ b/frontend/src/components/MovieForm.jsx
@@ -11,7 +11,6 @@ const EMPTY_FORM = {
   year: '',
   genreId: '',
   description: '',
-  watched: false,
   tags: [],
   videoFilePath: '',
 }
@@ -89,7 +88,6 @@ export default function MovieForm({ movie, onSave, onCancel }) {
         year: movie.year ?? '',
         genreId: movie.genre?.id != null ? String(movie.genre.id) : '',
         description: movie.description ?? '',
-        watched: Boolean(movie.watched),
         tags: movie.tags ?? [],
         videoFilePath: movie.videoFilePath ?? '',
       })
@@ -143,7 +141,6 @@ export default function MovieForm({ movie, onSave, onCancel }) {
       year: form.year !== '' ? Number(form.year) : null,
       genre: { id: Number(form.genreId) },
       description: form.description,
-      watched: form.watched,
       tags: pendingTags,
       videoFilePath: form.videoFilePath,
       _thumbnail: thumbnailFile,
@@ -350,18 +347,6 @@ export default function MovieForm({ movie, onSave, onCancel }) {
         </div>
         {errors.videoFilePath && <p className="text-red-400 text-xs mt-1">{errors.videoFilePath}</p>}
       </div>
-
-      {/* Watched */}
-      <label className="flex items-center gap-2 text-sm text-gray-300 cursor-pointer">
-        <input
-          name="watched"
-          type="checkbox"
-          checked={form.watched}
-          onChange={handleChange}
-          className="w-4 h-4 accent-indigo-500"
-        />
-        Marked as watched
-      </label>
 
       {/* Buttons */}
       <div className="flex gap-3 pt-2">

--- a/frontend/src/components/MovieList.jsx
+++ b/frontend/src/components/MovieList.jsx
@@ -48,10 +48,10 @@ function MovieCard({ movie, onEdit, onDelete, onTagClick, readOnly }) {
       <div className="p-5 flex flex-col gap-3 flex-1">
       <div className="flex items-start justify-between gap-2">
         <h2 className="text-lg font-semibold text-white leading-tight">{movie.title}</h2>
-        {movie.watched ? (
-          <span className="shrink-0 text-xs bg-green-800/60 text-green-300 px-2 py-0.5 rounded-full">Watched</span>
-        ) : (
-          <span className="shrink-0 text-xs bg-gray-700 text-gray-400 px-2 py-0.5 rounded-full">Unwatched</span>
+        {movie.watchedRecently && (
+          <span className="shrink-0 text-xs bg-green-800/60 text-green-300 px-2 py-0.5 rounded-full">
+            Watched recently
+          </span>
         )}
       </div>
 

--- a/frontend/src/components/MusicVideoList.jsx
+++ b/frontend/src/components/MusicVideoList.jsx
@@ -60,6 +60,11 @@ function MusicVideoCard({ musicVideo, onEdit, onDelete, onTagClick, readOnly }) 
               <p className="text-sm text-gray-300 leading-tight">🎤 {artistLabel}</p>
             )}
           </div>
+            {musicVideo.watchedRecently && (
+              <span className="shrink-0 text-xs bg-green-800/60 text-green-300 px-2 py-0.5 rounded-full">
+                Watched recently
+              </span>
+            )}
         </div>
 
         <div className="flex flex-wrap gap-x-4 gap-y-1 text-sm text-gray-400">

--- a/frontend/src/pages/MediaLibraryPage.jsx
+++ b/frontend/src/pages/MediaLibraryPage.jsx
@@ -29,7 +29,6 @@ export default function MediaLibraryPage({ mode }) {
   const [showMovieForm, setShowMovieForm] = useState(false)
   const [editingMovie, setEditingMovie] = useState(null)
   const [movieSearchQuery, setMovieSearchQuery] = useState('')
-  const [filterWatched, setFilterWatched] = useState('')
   const [movieTagQuery, setMovieTagQuery] = useState('')
 
   const [episodes, setEpisodes] = useState([])
@@ -39,7 +38,6 @@ export default function MediaLibraryPage({ mode }) {
   const [editingEpisode, setEditingEpisode] = useState(null)
   const [episodeSeriesQuery, setEpisodeSeriesQuery] = useState('')
   const [episodeSeasonQuery, setEpisodeSeasonQuery] = useState('')
-  const [filterEpisodeWatched, setFilterEpisodeWatched] = useState('')
   const [episodeTagQuery, setEpisodeTagQuery] = useState('')
 
   const [genres, setGenres] = useState([])
@@ -91,7 +89,6 @@ export default function MediaLibraryPage({ mode }) {
       setMoviesLoading(true)
       const params = new URLSearchParams()
       if (movieSearchQuery) params.append('title', movieSearchQuery)
-      if (filterWatched !== '') params.append('watched', filterWatched)
       if (movieTagQuery) params.append('tag', movieTagQuery)
       if (selectedGenre) params.append('genreId', selectedGenre.id)
       const res = await fetch(`${MOVIES_API}?${params}`)
@@ -107,9 +104,9 @@ export default function MediaLibraryPage({ mode }) {
 
   useEffect(() => {
     fetchMovies()
-  }, [movieSearchQuery, filterWatched, movieTagQuery, selectedGenre])
+  }, [movieSearchQuery, movieTagQuery, selectedGenre])
 
-  const isEpisodeSearchActive = !!(episodeSeriesQuery || episodeSeasonQuery || filterEpisodeWatched || episodeTagQuery)
+  const isEpisodeSearchActive = !!(episodeSeriesQuery || episodeSeasonQuery || episodeTagQuery)
 
   const fetchEpisodes = async () => {
     try {
@@ -121,7 +118,6 @@ export default function MediaLibraryPage({ mode }) {
         params.append('seriesName', episodeSeriesQuery)
       }
       if (episodeSeasonQuery !== '') params.append('season', episodeSeasonQuery)
-      if (filterEpisodeWatched !== '') params.append('watched', filterEpisodeWatched)
       if (episodeTagQuery) params.append('tag', episodeTagQuery)
       const res = await fetch(`${EPISODES_API}?${params}`)
       if (!res.ok) throw new Error('Failed to fetch episodes')
@@ -138,7 +134,7 @@ export default function MediaLibraryPage({ mode }) {
     if (activeTab !== 'episodes') return
     if (!selectedSeries && !isEpisodeSearchActive) return
     fetchEpisodes()
-  }, [activeTab, selectedSeries, episodeSeriesQuery, episodeSeasonQuery, filterEpisodeWatched, episodeTagQuery])
+  }, [activeTab, selectedSeries, episodeSeriesQuery, episodeSeasonQuery, episodeTagQuery])
 
   const fetchSeries = async () => {
     try {
@@ -722,17 +718,6 @@ export default function MediaLibraryPage({ mode }) {
               }}
               className="flex-1 bg-gray-800 border border-gray-700 rounded-lg px-4 py-2 text-gray-100 placeholder-gray-500 focus:outline-none focus:border-indigo-500"
             />
-            {(selectedGenre || movieSearchQuery || movieTagQuery) && (
-              <select
-                value={filterWatched}
-                onChange={(e) => setFilterWatched(e.target.value)}
-                className="bg-gray-800 border border-gray-700 rounded-lg px-4 py-2 text-gray-100 focus:outline-none focus:border-indigo-500"
-              >
-                <option value="">All movies</option>
-                <option value="true">Watched</option>
-                <option value="false">Unwatched</option>
-              </select>
-            )}
           </div>
 
           {selectedGenre && !movieSearchQuery && (
@@ -864,15 +849,6 @@ export default function MediaLibraryPage({ mode }) {
               min="1"
               className="w-28 bg-gray-800 border border-gray-700 rounded-lg px-4 py-2 text-gray-100 placeholder-gray-500 focus:outline-none focus:border-indigo-500"
             />
-            <select
-              value={filterEpisodeWatched}
-              onChange={(e) => setFilterEpisodeWatched(e.target.value)}
-              className="bg-gray-800 border border-gray-700 rounded-lg px-4 py-2 text-gray-100 focus:outline-none focus:border-indigo-500"
-            >
-              <option value="">All episodes</option>
-              <option value="true">Watched</option>
-              <option value="false">Unwatched</option>
-            </select>
           </div>
 
           {selectedSeries && !episodeSeriesQuery && (
@@ -960,7 +936,6 @@ export default function MediaLibraryPage({ mode }) {
                     setSelectedSeries(s)
                     setEpisodeSeriesQuery('')
                     setEpisodeSeasonQuery('')
-                    setFilterEpisodeWatched('')
                     setEpisodeTagQuery('')
                   }}
                   readOnly={true}


### PR DESCRIPTION
This PR addresses issue #41 by removing the old "watched" boolean (which was never fully wired up anyway) with a new "watched recently" feature. For all three video types (movies, episodes, and music videos), the system will now track the last watched date. Videos that have been watched within a configurable number of days will be given a "watched recently" badge in the UI. This allows the user to more easily pick up where they left off, if watching a long series of videos over a stretch of days.

The feature can be explicitly disabled by setting the day threshold to 0. When disabled, the "last watched date" will still be silently tracked for all video types, but nothing will be surfaced in the UI.

Closes #41 