### PR TITLE
Issue #43 - better horizontal resize policy

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -21,7 +21,7 @@ export default function App() {
     <BrowserRouter>
       <div className="min-h-screen bg-gray-950 text-gray-100">
         <header className="bg-gray-900 border-b border-gray-800 shadow-lg">
-          <div className="max-w-6xl mx-auto px-4 py-4 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+          <div className="max-w-screen-2xl mx-auto px-4 py-4 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
             <div className="flex items-center gap-3">
               <span className="text-3xl" aria-hidden="true">🎬</span>
               <div>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -35,7 +35,7 @@ export default function App() {
           </div>
         </header>
 
-        <main className="max-w-6xl mx-auto px-4 py-8">
+        <main className="max-w-screen-2xl mx-auto px-4 py-8">
           <Routes>
             <Route path="/" element={<MediaLibraryPage mode="user" />} />
             <Route path="/admin" element={<MediaLibraryPage mode="admin" />} />

--- a/frontend/src/components/ArtistList.jsx
+++ b/frontend/src/components/ArtistList.jsx
@@ -14,7 +14,7 @@ export default function ArtistList({ artists, onEdit, onDelete, onArtistClick, r
   }
 
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-5">
       {artists.map((artist) => (
         <ArtistCard
           key={artist.id}

--- a/frontend/src/components/EpisodeList.jsx
+++ b/frontend/src/components/EpisodeList.jsx
@@ -17,7 +17,7 @@ export default function EpisodeList({ episodes, onEdit, onDelete, onTagClick, re
   }
 
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-5">
       {episodes.map((episode) => (
         <EpisodeCard
           key={episode.id}

--- a/frontend/src/components/GenreList.jsx
+++ b/frontend/src/components/GenreList.jsx
@@ -14,7 +14,7 @@ export default function GenreList({ genres, onEdit, onDelete, onGenreClick, read
   }
 
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-5">
       {genres.map((genre) => (
         <GenreCard
           key={genre.id}

--- a/frontend/src/components/MovieList.jsx
+++ b/frontend/src/components/MovieList.jsx
@@ -17,7 +17,7 @@ export default function MovieList({ movies, onEdit, onDelete, onTagClick, readOn
   }
 
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-5">
       {movies.map((movie) => (
         <MovieCard key={movie.id} movie={movie} onEdit={onEdit} onDelete={onDelete} onTagClick={onTagClick} readOnly={readOnly} />
       ))}

--- a/frontend/src/components/MusicVideoList.jsx
+++ b/frontend/src/components/MusicVideoList.jsx
@@ -17,7 +17,7 @@ export default function MusicVideoList({ musicVideos, onEdit, onDelete, onTagCli
   }
 
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-5">
       {musicVideos.map((mv) => (
         <MusicVideoCard
           key={mv.id}

--- a/frontend/src/components/SeriesList.jsx
+++ b/frontend/src/components/SeriesList.jsx
@@ -14,7 +14,7 @@ export default function SeriesList({ series, onEdit, onDelete, onSeriesClick, re
   }
 
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-5">
       {series.map((series) => (
         <SeriesCard
           key={series.id}


### PR DESCRIPTION
This PR addresses issue #43 by providing better horizontal resizing in the UI. The behavior on small screens is unchanged from before. But on wider screens, for example on a full-screen browser window on a 1920x1080 monitor, all grids will now expand to 4 columns wide, and will use more horizontal space within the browser window. This looks nicer.

Closes #43 