### PR TITLE
Issue #51 - make thumbnail uploading less painful

### DIFF
--- a/frontend/src/components/ArtistForm.jsx
+++ b/frontend/src/components/ArtistForm.jsx
@@ -158,7 +158,7 @@ export default function ArtistForm({ artist, onSave, onCancel }) {
           }}
           className="block w-full text-sm text-gray-400 file:mr-3 file:py-1.5 file:px-3 file:rounded-lg file:border-0 file:text-sm file:bg-gray-700 file:text-gray-200 hover:file:bg-gray-600 cursor-pointer"
         />
-        <p className="text-xs text-gray-500 mt-1">JPEG or PNG, Recommend 2:1 aspect ratio</p>
+        <p className="text-xs text-gray-500 mt-1">JPEG or PNG, max size 2000x2000, recommend a 2:1 aspect ratio</p>
       </div>
 
       <div className="flex gap-3 pt-2">

--- a/frontend/src/components/ArtistForm.jsx
+++ b/frontend/src/components/ArtistForm.jsx
@@ -117,7 +117,7 @@ export default function ArtistForm({ artist, onSave, onCancel }) {
             <img
               src={thumbnailPreview}
               alt="Artist thumbnail preview"
-              className="rounded-lg max-h-40 object-cover border border-gray-700"
+              className="rounded-lg max-h-40 object-cover object-top border border-gray-700"
             />
             <button
               type="button"
@@ -158,7 +158,7 @@ export default function ArtistForm({ artist, onSave, onCancel }) {
           }}
           className="block w-full text-sm text-gray-400 file:mr-3 file:py-1.5 file:px-3 file:rounded-lg file:border-0 file:text-sm file:bg-gray-700 file:text-gray-200 hover:file:bg-gray-600 cursor-pointer"
         />
-        <p className="text-xs text-gray-500 mt-1">JPEG or PNG, 26×26 to 2000×2000</p>
+        <p className="text-xs text-gray-500 mt-1">JPEG or PNG, Recommend 2:1 aspect ratio</p>
       </div>
 
       <div className="flex gap-3 pt-2">

--- a/frontend/src/components/ArtistList.jsx
+++ b/frontend/src/components/ArtistList.jsx
@@ -43,7 +43,7 @@ function ArtistCard({ artist, onEdit, onDelete, onArtistClick, readOnly }) {
         <img
           src={`${ARTISTS_API}/${artist.id}/thumbnail`}
           alt={`${artist.name} thumbnail`}
-          className="w-full h-48 object-cover"
+          className="w-full h-48 object-cover object-top"
         />
       )}
 

--- a/frontend/src/components/EpisodeForm.jsx
+++ b/frontend/src/components/EpisodeForm.jsx
@@ -294,7 +294,7 @@ export default function EpisodeForm({ episode, onSave, onCancel }) {
             <img
               src={thumbnailPreview}
               alt="Thumbnail preview"
-              className="rounded-lg max-h-40 object-cover border border-gray-700"
+              className="rounded-lg max-h-40 object-cover object-top border border-gray-700"
             />
             <button
               type="button"
@@ -334,7 +334,7 @@ export default function EpisodeForm({ episode, onSave, onCancel }) {
           }}
           className="block w-full text-sm text-gray-400 file:mr-3 file:py-1.5 file:px-3 file:rounded-lg file:border-0 file:text-sm file:bg-gray-700 file:text-gray-200 hover:file:bg-gray-600 cursor-pointer"
         />
-        <p className="text-xs text-gray-500 mt-1">JPEG or PNG, 26×26 to 2000×2000</p>
+        <p className="text-xs text-gray-500 mt-1">JPEG or PNG, Recommend 2:1 aspect ratio</p>
       </div>
 
       {/* Video File Path */}

--- a/frontend/src/components/EpisodeForm.jsx
+++ b/frontend/src/components/EpisodeForm.jsx
@@ -334,7 +334,7 @@ export default function EpisodeForm({ episode, onSave, onCancel }) {
           }}
           className="block w-full text-sm text-gray-400 file:mr-3 file:py-1.5 file:px-3 file:rounded-lg file:border-0 file:text-sm file:bg-gray-700 file:text-gray-200 hover:file:bg-gray-600 cursor-pointer"
         />
-        <p className="text-xs text-gray-500 mt-1">JPEG or PNG, Recommend 2:1 aspect ratio</p>
+        <p className="text-xs text-gray-500 mt-1">JPEG or PNG, max size 2000x2000, recommend a 2:1 aspect ratio</p>
       </div>
 
       {/* Video File Path */}

--- a/frontend/src/components/EpisodeList.jsx
+++ b/frontend/src/components/EpisodeList.jsx
@@ -47,7 +47,7 @@ function EpisodeCard({ episode, onEdit, onDelete, onTagClick, readOnly }) {
         <img
           src={`${EPISODES_API}/${episode.id}/thumbnail`}
           alt={`${seriesLabel} thumbnail`}
-          className="w-full h-48 object-cover"
+          className="w-full h-48 object-cover object-top"
         />
       )}
       {showPlayer && (

--- a/frontend/src/components/GenreForm.jsx
+++ b/frontend/src/components/GenreForm.jsx
@@ -117,7 +117,7 @@ export default function GenreForm({ genre, onSave, onCancel }) {
             <img
               src={thumbnailPreview}
               alt="Genre thumbnail preview"
-              className="rounded-lg max-h-40 object-cover border border-gray-700"
+              className="rounded-lg max-h-40 object-cover object-top border border-gray-700"
             />
             <button
               type="button"
@@ -158,7 +158,7 @@ export default function GenreForm({ genre, onSave, onCancel }) {
           }}
           className="block w-full text-sm text-gray-400 file:mr-3 file:py-1.5 file:px-3 file:rounded-lg file:border-0 file:text-sm file:bg-gray-700 file:text-gray-200 hover:file:bg-gray-600 cursor-pointer"
         />
-        <p className="text-xs text-gray-500 mt-1">JPEG or PNG, 26×26 to 2000×2000</p>
+        <p className="text-xs text-gray-500 mt-1">JPEG or PNG, Recommend 2:1 aspect ratio</p>
       </div>
 
       <div className="flex gap-3 pt-2">

--- a/frontend/src/components/GenreForm.jsx
+++ b/frontend/src/components/GenreForm.jsx
@@ -158,7 +158,7 @@ export default function GenreForm({ genre, onSave, onCancel }) {
           }}
           className="block w-full text-sm text-gray-400 file:mr-3 file:py-1.5 file:px-3 file:rounded-lg file:border-0 file:text-sm file:bg-gray-700 file:text-gray-200 hover:file:bg-gray-600 cursor-pointer"
         />
-        <p className="text-xs text-gray-500 mt-1">JPEG or PNG, Recommend 2:1 aspect ratio</p>
+        <p className="text-xs text-gray-500 mt-1">JPEG or PNG, max size 2000x2000, recommend a 2:1 aspect ratio</p>
       </div>
 
       <div className="flex gap-3 pt-2">

--- a/frontend/src/components/GenreList.jsx
+++ b/frontend/src/components/GenreList.jsx
@@ -43,7 +43,7 @@ function GenreCard({ genre, onEdit, onDelete, onGenreClick, readOnly }) {
         <img
           src={`${GENRES_API}/${genre.id}/thumbnail`}
           alt={`${genre.name} thumbnail`}
-          className="w-full h-48 object-cover"
+          className="w-full h-48 object-cover object-top"
         />
       )}
 

--- a/frontend/src/components/MovieForm.jsx
+++ b/frontend/src/components/MovieForm.jsx
@@ -283,7 +283,7 @@ export default function MovieForm({ movie, onSave, onCancel }) {
             <img
               src={thumbnailPreview}
               alt="Thumbnail preview"
-              className="rounded-lg max-h-40 object-cover border border-gray-700"
+              className="rounded-lg max-h-40 object-cover object-top border border-gray-700"
             />
             <button
               type="button"
@@ -323,7 +323,7 @@ export default function MovieForm({ movie, onSave, onCancel }) {
           }}
           className="block w-full text-sm text-gray-400 file:mr-3 file:py-1.5 file:px-3 file:rounded-lg file:border-0 file:text-sm file:bg-gray-700 file:text-gray-200 hover:file:bg-gray-600 cursor-pointer"
         />
-        <p className="text-xs text-gray-500 mt-1">JPEG or PNG, 26×26 to 2000×2000</p>
+        <p className="text-xs text-gray-500 mt-1">JPEG or PNG, Recommend 2:1 aspect ratio</p>
       </div>
 
       {/* Video File Path */}

--- a/frontend/src/components/MovieForm.jsx
+++ b/frontend/src/components/MovieForm.jsx
@@ -323,7 +323,7 @@ export default function MovieForm({ movie, onSave, onCancel }) {
           }}
           className="block w-full text-sm text-gray-400 file:mr-3 file:py-1.5 file:px-3 file:rounded-lg file:border-0 file:text-sm file:bg-gray-700 file:text-gray-200 hover:file:bg-gray-600 cursor-pointer"
         />
-        <p className="text-xs text-gray-500 mt-1">JPEG or PNG, Recommend 2:1 aspect ratio</p>
+        <p className="text-xs text-gray-500 mt-1">JPEG or PNG, max size 2000x2000, recommend a 2:1 aspect ratio</p>
       </div>
 
       {/* Video File Path */}

--- a/frontend/src/components/MovieList.jsx
+++ b/frontend/src/components/MovieList.jsx
@@ -35,7 +35,7 @@ function MovieCard({ movie, onEdit, onDelete, onTagClick, readOnly }) {
         <img
           src={`${MOVIES_API}/${movie.id}/thumbnail`}
           alt={`${movie.title} thumbnail`}
-          className="w-full h-48 object-cover"
+          className="w-full h-48 object-cover object-top"
         />
       )}
       {showPlayer && (

--- a/frontend/src/components/MusicVideoForm.jsx
+++ b/frontend/src/components/MusicVideoForm.jsx
@@ -296,7 +296,7 @@ export default function MusicVideoForm({ musicVideo, onSave, onCancel }) {
             <img
               src={thumbnailPreview}
               alt="Thumbnail preview"
-              className="rounded-lg max-h-40 object-cover border border-gray-700"
+              className="rounded-lg max-h-40 object-cover object-top border border-gray-700"
             />
             <button
               type="button"
@@ -336,7 +336,7 @@ export default function MusicVideoForm({ musicVideo, onSave, onCancel }) {
           }}
           className="block w-full text-sm text-gray-400 file:mr-3 file:py-1.5 file:px-3 file:rounded-lg file:border-0 file:text-sm file:bg-gray-700 file:text-gray-200 hover:file:bg-gray-600 cursor-pointer"
         />
-        <p className="text-xs text-gray-500 mt-1">JPEG or PNG, 26×26 to 2000×2000</p>
+        <p className="text-xs text-gray-500 mt-1">JPEG or PNG, Recommend 2:1 aspect ratio</p>
       </div>
 
       {/* Video File Path */}

--- a/frontend/src/components/MusicVideoForm.jsx
+++ b/frontend/src/components/MusicVideoForm.jsx
@@ -336,7 +336,7 @@ export default function MusicVideoForm({ musicVideo, onSave, onCancel }) {
           }}
           className="block w-full text-sm text-gray-400 file:mr-3 file:py-1.5 file:px-3 file:rounded-lg file:border-0 file:text-sm file:bg-gray-700 file:text-gray-200 hover:file:bg-gray-600 cursor-pointer"
         />
-        <p className="text-xs text-gray-500 mt-1">JPEG or PNG, Recommend 2:1 aspect ratio</p>
+        <p className="text-xs text-gray-500 mt-1">JPEG or PNG, max size 2000x2000, recommend a 2:1 aspect ratio</p>
       </div>
 
       {/* Video File Path */}

--- a/frontend/src/components/MusicVideoList.jsx
+++ b/frontend/src/components/MusicVideoList.jsx
@@ -42,7 +42,7 @@ function MusicVideoCard({ musicVideo, onEdit, onDelete, onTagClick, readOnly }) 
         <img
           src={`${MUSIC_VIDEOS_API}/${musicVideo.id}/thumbnail`}
           alt={`${musicVideo.title} thumbnail`}
-          className="w-full h-48 object-cover"
+          className="w-full h-48 object-cover object-top"
         />
       )}
       {showPlayer && (

--- a/frontend/src/components/SeriesForm.jsx
+++ b/frontend/src/components/SeriesForm.jsx
@@ -177,7 +177,7 @@ export default function SeriesForm({ series, onSave, onCancel }) {
           }}
           className="block w-full text-sm text-gray-400 file:mr-3 file:py-1.5 file:px-3 file:rounded-lg file:border-0 file:text-sm file:bg-gray-700 file:text-gray-200 hover:file:bg-gray-600 cursor-pointer"
         />
-        <p className="text-xs text-gray-500 mt-1">JPEG or PNG, Recommend 2:1 aspect ratio</p>
+        <p className="text-xs text-gray-500 mt-1">JPEG or PNG, max size 2000x2000, recommend a 2:1 aspect ratio</p>
       </div>
 
       <div className="flex gap-3 pt-2">

--- a/frontend/src/components/SeriesForm.jsx
+++ b/frontend/src/components/SeriesForm.jsx
@@ -136,7 +136,7 @@ export default function SeriesForm({ series, onSave, onCancel }) {
             <img
               src={thumbnailPreview}
               alt="Series thumbnail preview"
-              className="rounded-lg max-h-40 object-cover border border-gray-700"
+              className="rounded-lg max-h-40 object-cover object-top border border-gray-700"
             />
             <button
               type="button"
@@ -177,7 +177,7 @@ export default function SeriesForm({ series, onSave, onCancel }) {
           }}
           className="block w-full text-sm text-gray-400 file:mr-3 file:py-1.5 file:px-3 file:rounded-lg file:border-0 file:text-sm file:bg-gray-700 file:text-gray-200 hover:file:bg-gray-600 cursor-pointer"
         />
-        <p className="text-xs text-gray-500 mt-1">JPEG or PNG, 26×26 to 2000×2000</p>
+        <p className="text-xs text-gray-500 mt-1">JPEG or PNG, Recommend 2:1 aspect ratio</p>
       </div>
 
       <div className="flex gap-3 pt-2">

--- a/frontend/src/components/SeriesList.jsx
+++ b/frontend/src/components/SeriesList.jsx
@@ -43,7 +43,7 @@ function SeriesCard({ series, onEdit, onDelete, onSeriesClick, readOnly }) {
         <img
           src={`${SERIES_API}/${series.id}/thumbnail`}
           alt={`${series.name} thumbnail`}
-          className="w-full h-48 object-cover"
+          className="w-full h-48 object-cover object-top"
         />
       )}
 


### PR DESCRIPTION
This PR addresses issue #51 by making thumbnail cropping more predictable, and by offering the user some guidance on how to get best results. Specifically, we now use the `object-top` Tailwind class to preserve the top portion of an image when cropping. For portrait-shaped images, this will predictably keep the upper part of the image, which for movie posters, is usually the title and the actor/actress's heads. This PR also replaces the image size guidance with a better tip regarding aspect ratio. Uploading 16:9 or 2:1 images seems to do the least aggressive image cropping (though it will ultimately depend on screen size). Overall these changes aim to make the experience of uploading a thumbnail more predictable and less surprising.

Closes #51 