### PR TITLE
Issue #56 - better thumbnail upload error messaging

### DIFF
--- a/backend/src/main/java/ca/corbett/movienight/service/ThumbnailService.java
+++ b/backend/src/main/java/ca/corbett/movienight/service/ThumbnailService.java
@@ -72,7 +72,7 @@ public class ThumbnailService {
     public void saveThumbnail(MultipartFile file, String subDir, Long id) {
         if (!enabled) {
             throw new ResponseStatusException(HttpStatus.SERVICE_UNAVAILABLE,
-                    "Thumbnail support is not available");
+                                              "Thumbnail support is not available - set data directory in properties to enable");
         }
 
         byte[] bytes;
@@ -80,7 +80,7 @@ public class ThumbnailService {
             bytes = file.getBytes();
         } catch (IOException e) {
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
-                    "Unable to read uploaded image", e);
+                                              "Unable to read uploaded image!", e);
         }
 
         // Use ImageReader to read dimensions from metadata first (avoids full decode)
@@ -89,15 +89,18 @@ public class ThumbnailService {
         try {
             iis = ImageIO.createImageInputStream(new ByteArrayInputStream(bytes));
         } catch (Exception e) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid image file");
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid image file!", e);
         }
         if (iis == null) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid image file");
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid image file!");
         }
         Iterator<ImageReader> readers = ImageIO.getImageReaders(iis);
         if (!readers.hasNext()) {
             try { iis.close(); } catch (IOException ignored) {}
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid image file");
+            // This is extremely unlikely, but it could happen.
+            // It's hard to return a meaningful error here, but let's return something
+            // other than "Invalid image file!" since that might get confused with the above exceptions.
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Unable to read images of this type!");
         }
         ImageReader reader = readers.next();
         try {
@@ -114,7 +117,7 @@ public class ThumbnailService {
                             "Image too small (min " + MIN_DIMENSION + "x" + MIN_DIMENSION + ")");
                 }
             } catch (IOException e) {
-                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid image file", e);
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Image file appears corrupt!", e);
             }
         } finally {
             reader.dispose();
@@ -126,10 +129,10 @@ public class ThumbnailService {
         try {
             image = ImageIO.read(new ByteArrayInputStream(bytes));
         } catch (Exception e) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid image file");
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid image file!", e);
         }
         if (image == null) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid image file");
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid image file!");
         }
 
         // Delete any existing thumbnail before saving the new one
@@ -140,8 +143,13 @@ public class ThumbnailService {
         try {
             Files.write(dest, bytes);
         } catch (IOException e) {
+            // This can happen if we were configured with a data directory that
+            // we don't have write access to, or if the disk gets full, or if our
+            // data dir has been deleted or moved since we started up.
+            // No need to return a super specific error message here.
+            // Users can check the log for full details.
             throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
-                    "Unable to save thumbnail", e);
+                                              "Unable to save thumbnail!", e);
         }
     }
 

--- a/frontend/src/pages/MediaLibraryPage.jsx
+++ b/frontend/src/pages/MediaLibraryPage.jsx
@@ -255,7 +255,18 @@ export default function MediaLibraryPage({ mode }) {
         const formData = new FormData()
         formData.append('file', _thumbnail)
         const thumbnailRes = await fetch(`${MOVIES_API}/${saved.id}/thumbnail`, { method: 'POST', body: formData })
-        if (!thumbnailRes.ok) throw new Error('Failed to upload movie thumbnail')
+        if (!thumbnailRes.ok) {
+          const errorText = await thumbnailRes.text()
+          let message = 'Failed to upload movie thumbnail'
+          try {
+            const errorData = JSON.parse(errorText)
+            message = errorData.message || message
+          } catch {
+            // Body wasn't JSON — use the raw text if it's non-empty, otherwise keep the fallback
+            if (errorText.trim()) message = errorText
+          }
+          throw new Error(message)
+        }
       }
       setShowMovieForm(false)
       setEditingMovie(null)
@@ -295,7 +306,18 @@ export default function MediaLibraryPage({ mode }) {
         const formData = new FormData()
         formData.append('file', _thumbnail)
         const thumbnailRes = await fetch(`${EPISODES_API}/${saved.id}/thumbnail`, { method: 'POST', body: formData })
-        if (!thumbnailRes.ok) throw new Error('Failed to upload episode thumbnail')
+        if (!thumbnailRes.ok) {
+          const errorText = await thumbnailRes.text()
+          let message = 'Failed to upload episode thumbnail'
+          try {
+            const errorData = JSON.parse(errorText)
+            message = errorData.message || message
+          } catch {
+            // Body wasn't JSON — use the raw text if it's non-empty, otherwise keep the fallback
+            if (errorText.trim()) message = errorText
+          }
+          throw new Error(message)
+        }
       }
       setShowEpisodeForm(false)
       setEditingEpisode(null)
@@ -336,7 +358,19 @@ export default function MediaLibraryPage({ mode }) {
         const formData = new FormData()
         formData.append('file', _thumbnail)
         const thumbnailRes = await fetch(`${GENRES_API}/${saved.id}/thumbnail`, { method: 'POST', body: formData })
-        if (!thumbnailRes.ok) throw new Error('Failed to upload genre thumbnail')
+        if (!thumbnailRes.ok) {
+          const errorText = await thumbnailRes.text()
+          let message = 'Failed to upload genre thumbnail'
+          try {
+            const errorData = JSON.parse(errorText)
+            message = errorData.message || message
+          } catch {
+            // Body wasn't JSON — use the raw text if it's non-empty, otherwise keep the fallback
+            if (errorText.trim()) message = errorText
+          }
+          throw new Error(message)
+        }
+
       }
 
       setShowGenreForm(false)
@@ -397,7 +431,19 @@ export default function MediaLibraryPage({ mode }) {
         const formData = new FormData()
         formData.append('file', _thumbnail)
         const thumbnailRes = await fetch(`${SERIES_API}/${saved.id}/thumbnail`, { method: 'POST', body: formData })
-        if (!thumbnailRes.ok) throw new Error('Failed to upload series thumbnail')
+        if (!thumbnailRes.ok) {
+          const errorText = await thumbnailRes.text()
+          let message = 'Failed to upload series thumbnail'
+          try {
+            const errorData = JSON.parse(errorText)
+            message = errorData.message || message
+          } catch {
+            // Body wasn't JSON — use the raw text if it's non-empty, otherwise keep the fallback
+            if (errorText.trim()) message = errorText
+          }
+          throw new Error(message)
+        }
+
       }
 
       setShowSeriesForm(false)
@@ -446,7 +492,19 @@ export default function MediaLibraryPage({ mode }) {
         const formData = new FormData()
         formData.append('file', _thumbnail)
         const thumbnailRes = await fetch(`${ARTISTS_API}/${saved.id}/thumbnail`, { method: 'POST', body: formData })
-        if (!thumbnailRes.ok) throw new Error('Failed to upload artist thumbnail')
+        if (!thumbnailRes.ok) {
+          const errorText = await thumbnailRes.text()
+          let message = 'Failed to upload artist thumbnail'
+          try {
+            const errorData = JSON.parse(errorText)
+            message = errorData.message || message
+          } catch {
+            // Body wasn't JSON — use the raw text if it's non-empty, otherwise keep the fallback
+            if (errorText.trim()) message = errorText
+          }
+          throw new Error(message)
+        }
+
       }
 
       setShowArtistForm(false)
@@ -487,7 +545,19 @@ export default function MediaLibraryPage({ mode }) {
         const formData = new FormData()
         formData.append('file', _thumbnail)
         const thumbnailRes = await fetch(`${MUSIC_VIDEOS_API}/${saved.id}/thumbnail`, { method: 'POST', body: formData })
-        if (!thumbnailRes.ok) throw new Error('Failed to upload music video thumbnail')
+        if (!thumbnailRes.ok) {
+          const errorText = await thumbnailRes.text()
+          let message = 'Failed to upload music video thumbnail'
+          try {
+            const errorData = JSON.parse(errorText)
+            message = errorData.message || message
+          } catch {
+            // Body wasn't JSON — use the raw text if it's non-empty, otherwise keep the fallback
+            if (errorText.trim()) message = errorText
+          }
+          throw new Error(message)
+        }
+
       }
       setShowMusicVideoForm(false)
       setEditingMusicVideo(null)

--- a/frontend/src/pages/MediaLibraryPage.jsx
+++ b/frontend/src/pages/MediaLibraryPage.jsx
@@ -256,18 +256,10 @@ export default function MediaLibraryPage({ mode }) {
         formData.append('file', _thumbnail)
         const thumbnailRes = await fetch(`${MOVIES_API}/${saved.id}/thumbnail`, { method: 'POST', body: formData })
         if (!thumbnailRes.ok) {
-          const errorText = await thumbnailRes.text()
-          let message = 'Failed to upload movie thumbnail'
-          try {
-            const errorData = JSON.parse(errorText)
-            message = errorData.message || message
-          } catch {
-            // Body wasn't JSON — use the raw text if it's non-empty, otherwise keep the fallback
-            if (errorText.trim()) message = errorText
-          }
-          throw new Error(message)
+            throw new Error(await getErrorMessage(thumbnailRes, 'Failed to upload movie thumbnail'))
         }
       }
+
       setShowMovieForm(false)
       setEditingMovie(null)
       fetchMovies()
@@ -307,18 +299,10 @@ export default function MediaLibraryPage({ mode }) {
         formData.append('file', _thumbnail)
         const thumbnailRes = await fetch(`${EPISODES_API}/${saved.id}/thumbnail`, { method: 'POST', body: formData })
         if (!thumbnailRes.ok) {
-          const errorText = await thumbnailRes.text()
-          let message = 'Failed to upload episode thumbnail'
-          try {
-            const errorData = JSON.parse(errorText)
-            message = errorData.message || message
-          } catch {
-            // Body wasn't JSON — use the raw text if it's non-empty, otherwise keep the fallback
-            if (errorText.trim()) message = errorText
-          }
-          throw new Error(message)
+            throw new Error(await getErrorMessage(thumbnailRes, 'Failed to upload episode thumbnail'))
         }
       }
+
       setShowEpisodeForm(false)
       setEditingEpisode(null)
       fetchEpisodes()
@@ -359,18 +343,8 @@ export default function MediaLibraryPage({ mode }) {
         formData.append('file', _thumbnail)
         const thumbnailRes = await fetch(`${GENRES_API}/${saved.id}/thumbnail`, { method: 'POST', body: formData })
         if (!thumbnailRes.ok) {
-          const errorText = await thumbnailRes.text()
-          let message = 'Failed to upload genre thumbnail'
-          try {
-            const errorData = JSON.parse(errorText)
-            message = errorData.message || message
-          } catch {
-            // Body wasn't JSON — use the raw text if it's non-empty, otherwise keep the fallback
-            if (errorText.trim()) message = errorText
-          }
-          throw new Error(message)
+            throw new Error(await getErrorMessage(thumbnailRes, 'Failed to upload genre thumbnail'))
         }
-
       }
 
       setShowGenreForm(false)
@@ -432,18 +406,8 @@ export default function MediaLibraryPage({ mode }) {
         formData.append('file', _thumbnail)
         const thumbnailRes = await fetch(`${SERIES_API}/${saved.id}/thumbnail`, { method: 'POST', body: formData })
         if (!thumbnailRes.ok) {
-          const errorText = await thumbnailRes.text()
-          let message = 'Failed to upload series thumbnail'
-          try {
-            const errorData = JSON.parse(errorText)
-            message = errorData.message || message
-          } catch {
-            // Body wasn't JSON — use the raw text if it's non-empty, otherwise keep the fallback
-            if (errorText.trim()) message = errorText
-          }
-          throw new Error(message)
+            throw new Error(await getErrorMessage(thumbnailRes, 'Failed to upload series thumbnail'))
         }
-
       }
 
       setShowSeriesForm(false)
@@ -493,18 +457,8 @@ export default function MediaLibraryPage({ mode }) {
         formData.append('file', _thumbnail)
         const thumbnailRes = await fetch(`${ARTISTS_API}/${saved.id}/thumbnail`, { method: 'POST', body: formData })
         if (!thumbnailRes.ok) {
-          const errorText = await thumbnailRes.text()
-          let message = 'Failed to upload artist thumbnail'
-          try {
-            const errorData = JSON.parse(errorText)
-            message = errorData.message || message
-          } catch {
-            // Body wasn't JSON — use the raw text if it's non-empty, otherwise keep the fallback
-            if (errorText.trim()) message = errorText
-          }
-          throw new Error(message)
+            throw new Error(await getErrorMessage(thumbnailRes, 'Failed to upload artist thumbnail'))
         }
-
       }
 
       setShowArtistForm(false)
@@ -546,19 +500,10 @@ export default function MediaLibraryPage({ mode }) {
         formData.append('file', _thumbnail)
         const thumbnailRes = await fetch(`${MUSIC_VIDEOS_API}/${saved.id}/thumbnail`, { method: 'POST', body: formData })
         if (!thumbnailRes.ok) {
-          const errorText = await thumbnailRes.text()
-          let message = 'Failed to upload music video thumbnail'
-          try {
-            const errorData = JSON.parse(errorText)
-            message = errorData.message || message
-          } catch {
-            // Body wasn't JSON — use the raw text if it's non-empty, otherwise keep the fallback
-            if (errorText.trim()) message = errorText
-          }
-          throw new Error(message)
+            throw new Error(await getErrorMessage(thumbnailRes, 'Failed to upload music video thumbnail'))
         }
-
       }
+
       setShowMusicVideoForm(false)
       setEditingMusicVideo(null)
       const isArtistGridView = !selectedArtist && !musicVideoTitleQuery && !musicVideoTagQuery


### PR DESCRIPTION
The UI wasn't properly surfacing descriptive error messages from the back end if a thumbnail upload failed. This PR fixes the UI to attempt to parse out the error message supplied by the back end. If the response body can't be parsed, the generic error message is used as a fallback. Otherwise, the descriptive error message is shown.

Also went through ThumbnailService and reworded some of the error messages.

Closes #56 