### PR TITLE
Issue #59 - better performance when streaming large files

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,23 @@ Each media item card has a "Watch" button which will bring up an inline media pl
 Use the media player controls to play, pause, or seek through the media. You can go full screen for
 a better viewing experience! Click the "Hide" button while streaming to hide the media player and stop the stream.
 
+### Note about very large media files
+
+If you have full-length high-resolution movies in your collection, you may encounter a significant delay
+when you begin streaming. You can mitigate this by configuring the max size of range requests in the properties file:
+
+```properties
+# You can optionally restrict range requests to a certain size, in MB.
+# Set this to 0 to allow range requests of any size.
+# Caution: setting this too low may cause LONG delays streaming large videos.
+# The default value is 32MB.
+movienight.max-range-request-size-mb=32
+```
+
+The default value of 32 is a good starting point, but you can increase it if you find that your media files
+are taking too long to start streaming. If your server has a lot of memory, and your local network has
+decent bandwidth, you can set this to 0 to allow range requests of any size.
+
 ## More information
 
 Project page: https://github.com/scorbo2/MovieNight

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ when you begin streaming. You can mitigate this by configuring the max size of r
 
 ```properties
 # You can optionally restrict range requests to a certain size, in MB.
-# Set this to 0 to allow range requests of any size.
+# Set this to 0 to allow range requests of any size (up to 2GB for Integer.MAX_VALUE).
 # Caution: setting this too low may cause LONG delays streaming large videos.
 # The default value is 32MB.
 movienight.max-range-request-size-mb=32

--- a/backend/src/main/java/ca/corbett/movienight/controller/StreamController.java
+++ b/backend/src/main/java/ca/corbett/movienight/controller/StreamController.java
@@ -1,6 +1,7 @@
 package ca.corbett.movienight.controller;
 
 import ca.corbett.movienight.service.MediaService;
+import jakarta.annotation.PostConstruct;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -39,10 +40,19 @@ public class StreamController {
     @Value("${movienight.max-range-request-size-mb:32}")
     private int rangeRequestMaxChunkMB;
 
-    private boolean rangeLimitWarningIssued = false;
-
     public StreamController(MediaService mediaService) {
         this.mediaService = mediaService;
+    }
+
+    @PostConstruct
+    public void logRangeLimit() {
+        if (rangeRequestMaxChunkMB <= 0) {
+            logger.warn("StreamController range request chunk size is unlimited - this may cause memory issues. "
+                                + "You can control this with the movienight.max-range-request-size-mb property.");
+        }
+        else {
+            logger.info("StreamController range request chunk size set to {} MB", rangeRequestMaxChunkMB);
+        }
     }
 
     /**
@@ -52,18 +62,6 @@ public class StreamController {
     @GetMapping("/{id}")
     public ResponseEntity<?> streamVideo(@PathVariable String id,
                                          @RequestHeader HttpHeaders headers) {
-        // We'll log ONE notice about the configured range request limit:
-        if (!rangeLimitWarningIssued) {
-            if (rangeRequestMaxChunkMB <= 0) {
-                logger.warn("StreamController range request chunk size is unlimited - this may cause memory issues. "
-                                    + "You can control this with the movienight.max-range-request-size-mb property.");
-            }
-            else {
-                logger.info("StreamController range request chunk size set to {} MB", rangeRequestMaxChunkMB);
-            }
-            rangeLimitWarningIssued = true;
-        }
-
         String filePath = mediaService.findById(id);
         Path videoPath = Paths.get(filePath);
 
@@ -116,16 +114,18 @@ public class StreamController {
         // By default, we'll limit range requests to 32MB, which is good for streaming,
         // but the user can configure this in our properties. (zero means no limit)
         int rangeLimitMB = Math.max(0, rangeRequestMaxChunkMB); // reject negative config values
-        int maxChunkSize = rangeLimitMB == 0 ? Integer.MAX_VALUE : 1024 * 1024 * rangeLimitMB;
+        long maxChunkSize = rangeLimitMB == 0 ? Integer.MAX_VALUE : 1024 * 1024 * (long)rangeLimitMB;
+        maxChunkSize = Math.min(maxChunkSize, Integer.MAX_VALUE); // cap to max int for array allocation
         int bytesToRead = (int) Math.min(rangeLength, maxChunkSize);
         if (bytesToRead < rangeLength) {
-            logger.info("Client requested {} bytes with offset {} for media id {}. " +
+            logger.info("Client requested {} with offset {} for media id {}. " +
                                 "Supplying configured max range of {} MB instead.",
-                        rangeLength, start, id, rangeLimitMB);
+                        getPrintableSize(rangeLength), getPrintableSize(start), id, rangeLimitMB);
         }
         end = start + bytesToRead - 1;
         rangeLength = bytesToRead;
 
+        // TODO: A streaming response body might be a better approach than in-memory buffering...
         byte[] data = new byte[bytesToRead];
         try (var input = Files.newInputStream(videoPath)) {
             input.skipNBytes(start);
@@ -147,5 +147,23 @@ public class StreamController {
                 .header(HttpHeaders.CONTENT_RANGE, "bytes " + start + "-" + end + "/" + contentLength)
                 .contentLength(rangeLength)
                 .body(data);
+    }
+
+    /**
+     * Given a count in bytes, returns a formatted String like "75 MB" or "1.2 GB"
+     * for easier readability in logs and error messages.
+     *
+     * @param bytes a byte count to format
+     * @return a human-readable string representing the size in appropriate units (B, KB, MB, GB, etc.)
+     */
+    public static String getPrintableSize(long bytes) {
+        if (bytes < 1024) {
+            return bytes + " B";
+        }
+        int exp = (int)(Math.log(bytes) / Math.log(1024));
+        String unit = "KMGTPE".charAt(exp - 1) + "B";
+        double size = bytes / Math.pow(1024, exp);
+        return String.format("%.1f %s", size, unit);
+
     }
 }

--- a/backend/src/main/java/ca/corbett/movienight/controller/StreamController.java
+++ b/backend/src/main/java/ca/corbett/movienight/controller/StreamController.java
@@ -3,6 +3,7 @@ package ca.corbett.movienight.controller;
 import ca.corbett.movienight.service.MediaService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.FileSystemResource;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
@@ -35,6 +36,11 @@ public class StreamController {
 
     private final MediaService mediaService;
 
+    @Value("${movienight.max-range-request-size-mb:32}")
+    private int rangeRequestMaxChunkMB;
+
+    private boolean rangeLimitWarningIssued = false;
+
     public StreamController(MediaService mediaService) {
         this.mediaService = mediaService;
     }
@@ -46,6 +52,18 @@ public class StreamController {
     @GetMapping("/{id}")
     public ResponseEntity<?> streamVideo(@PathVariable String id,
                                          @RequestHeader HttpHeaders headers) {
+        // We'll log ONE notice about the configured range request limit:
+        if (!rangeLimitWarningIssued) {
+            if (rangeRequestMaxChunkMB <= 0) {
+                logger.warn("StreamController range request chunk size is unlimited - this may cause memory issues. "
+                                    + "You can control this with the movienight.max-range-request-size-mb property.");
+            }
+            else {
+                logger.info("StreamController range request chunk size set to {} MB", rangeRequestMaxChunkMB);
+            }
+            rangeLimitWarningIssued = true;
+        }
+
         String filePath = mediaService.findById(id);
         Path videoPath = Paths.get(filePath);
 
@@ -95,8 +113,16 @@ public class StreamController {
         }
 
         // Optional safety cap to avoid huge in-memory chunks from abusive ranges.
-        int maxChunkSize = 1024 * 1024; // 1 MiB
+        // By default, we'll limit range requests to 32MB, which is good for streaming,
+        // but the user can configure this in our properties. (zero means no limit)
+        int rangeLimitMB = Math.max(0, rangeRequestMaxChunkMB); // reject negative config values
+        int maxChunkSize = rangeLimitMB == 0 ? Integer.MAX_VALUE : 1024 * 1024 * rangeLimitMB;
         int bytesToRead = (int) Math.min(rangeLength, maxChunkSize);
+        if (bytesToRead < rangeLength) {
+            logger.info("Client requested {} bytes with offset {} for media id {}. " +
+                                "Supplying configured max range of {} MB instead.",
+                        rangeLength, start, id, rangeLimitMB);
+        }
         end = start + bytesToRead - 1;
         rangeLength = bytesToRead;
 

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -33,3 +33,9 @@ movienight.admin.localhost-only=true
 # This can help you remember where you left off in a long TV series, for example.
 # Set this to 0 to disable the "recently watched" feature.
 movienight.recently-watched-days=3
+
+# You can optionally restrict range requests to a certain size, in MB.
+# Set this to 0 to allow range requests of any size.
+# Caution: setting this too low may cause LONG delays streaming large videos.
+# The default value is 32MB.
+movienight.max-range-request-size-mb=32

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -35,7 +35,7 @@ movienight.admin.localhost-only=true
 movienight.recently-watched-days=3
 
 # You can optionally restrict range requests to a certain size, in MB.
-# Set this to 0 to allow range requests of any size.
+# Set this to 0 to allow range requests of any size (up to 2GB for Integer.MAX_VALUE).
 # Caution: setting this too low may cause LONG delays streaming large videos.
 # The default value is 32MB.
 movienight.max-range-request-size-mb=32

--- a/backend/src/test/java/ca/corbett/movienight/StreamControllerTest.java
+++ b/backend/src/test/java/ca/corbett/movienight/StreamControllerTest.java
@@ -1,5 +1,6 @@
 package ca.corbett.movienight;
 
+import ca.corbett.movienight.controller.StreamController;
 import ca.corbett.movienight.service.MediaService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -17,6 +18,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -186,5 +188,20 @@ class StreamControllerTest {
                         .header("Range", "bytes=10-14"))
                 .andExpect(status().isPartialContent())
                 .andExpect(header().string("Content-Length", "5"));
+    }
+
+    @Test
+    void getPrintableSize_returnsFormattedSizeStrings() {
+        // GIVEN various byte values
+        // WHEN we call getPrintableSize on the StreamController
+        // THEN we should get a pretty formatted value:
+        assertEquals("0 B", StreamController.getPrintableSize(0));
+        assertEquals("500 B", StreamController.getPrintableSize(500));
+        assertEquals("1.0 KB", StreamController.getPrintableSize(1024));
+        assertEquals("1.5 KB", StreamController.getPrintableSize(1536));
+        assertEquals("1.0 MB", StreamController.getPrintableSize(1024 * 1024));
+        assertEquals("1.5 MB", StreamController.getPrintableSize(1024 * 1024 + 512 * 1024));
+        assertEquals("1.0 GB", StreamController.getPrintableSize(1024L * 1024 * 1024));
+        assertEquals("2.5 GB", StreamController.getPrintableSize(2L * 1024 * 1024 * 1024 + 512L * 1024 * 1024));
     }
 }


### PR DESCRIPTION
Overly defensive coding in `StreamController` was causing significant initial load delays when attempting to stream very large (1GB+) media files. Relaxed the default max range request limit, and added a config property so that it can be fine-tuned by the user.

Closes #59 
