### PR TITLE
Issue #62 - better thumbnail render

### DIFF
--- a/frontend/src/components/ArtistForm.jsx
+++ b/frontend/src/components/ArtistForm.jsx
@@ -117,7 +117,7 @@ export default function ArtistForm({ artist, onSave, onCancel }) {
             <img
               src={thumbnailPreview}
               alt="Artist thumbnail preview"
-              className="rounded-lg max-h-40 object-cover object-top border border-gray-700"
+              className="rounded-lg max-h-40 object-contain border border-gray-700"
             />
             <button
               type="button"

--- a/frontend/src/components/ArtistList.jsx
+++ b/frontend/src/components/ArtistList.jsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 const ARTISTS_API = '/api/artists'
 
 export default function ArtistList({ artists, onEdit, onDelete, onArtistClick, readOnly = false }) {
@@ -30,6 +31,7 @@ export default function ArtistList({ artists, onEdit, onDelete, onArtistClick, r
 }
 
 function ArtistCard({ artist, onEdit, onDelete, onArtistClick, readOnly }) {
+  const [isLandscapeThumb, setIsLandscapeThumb] = useState(null) // null = not loaded yet
   const isClickable = typeof onArtistClick === 'function'
 
   return (
@@ -43,7 +45,17 @@ function ArtistCard({ artist, onEdit, onDelete, onArtistClick, readOnly }) {
         <img
           src={`${ARTISTS_API}/${artist.id}/thumbnail`}
           alt={`${artist.name} thumbnail`}
-          className="w-full h-48 object-cover object-top"
+          onLoad={(e) => {
+            const { naturalWidth, naturalHeight } = e.currentTarget
+            setIsLandscapeThumb(naturalWidth > naturalHeight)
+          }}
+          className={`w-full h-48 ${
+            isLandscapeThumb === null
+              ? 'object-contain invisible' // safe default before load
+              : isLandscapeThumb
+                ? 'object-fill'
+                : 'object-contain'
+          }`}
         />
       )}
 

--- a/frontend/src/components/EpisodeForm.jsx
+++ b/frontend/src/components/EpisodeForm.jsx
@@ -294,7 +294,7 @@ export default function EpisodeForm({ episode, onSave, onCancel }) {
             <img
               src={thumbnailPreview}
               alt="Thumbnail preview"
-              className="rounded-lg max-h-40 object-cover object-top border border-gray-700"
+              className="rounded-lg max-h-40 object-contain border border-gray-700"
             />
             <button
               type="button"

--- a/frontend/src/components/EpisodeList.jsx
+++ b/frontend/src/components/EpisodeList.jsx
@@ -35,6 +35,7 @@ export default function EpisodeList({ episodes, onEdit, onDelete, onTagClick, re
 
 function EpisodeCard({ episode, onEdit, onDelete, onTagClick, readOnly }) {
   const [showPlayer, setShowPlayer] = useState(false)
+  const [isLandscapeThumb, setIsLandscapeThumb] = useState(null) // null = not loaded yet
   const { vlcEnabled } = useAppConfig()
   const seriesLabel = typeof episode.series === 'string' ? episode.series : episode.series?.name
 
@@ -49,7 +50,17 @@ function EpisodeCard({ episode, onEdit, onDelete, onTagClick, readOnly }) {
         <img
           src={`${EPISODES_API}/${episode.id}/thumbnail`}
           alt={`${seriesLabel} thumbnail`}
-          className="w-full h-48 object-cover object-top"
+          onLoad={(e) => {
+            const { naturalWidth, naturalHeight } = e.currentTarget
+            setIsLandscapeThumb(naturalWidth > naturalHeight)
+          }}
+          className={`w-full h-48 ${
+            isLandscapeThumb === null
+              ? 'object-contain invisible' // safe default before load
+              : isLandscapeThumb
+                ? 'object-fill'
+                : 'object-contain'
+          }`}
         />
       )}
       {showPlayer && (

--- a/frontend/src/components/GenreForm.jsx
+++ b/frontend/src/components/GenreForm.jsx
@@ -117,7 +117,7 @@ export default function GenreForm({ genre, onSave, onCancel }) {
             <img
               src={thumbnailPreview}
               alt="Genre thumbnail preview"
-              className="rounded-lg max-h-40 object-cover object-top border border-gray-700"
+              className="rounded-lg max-h-40 object-contain border border-gray-700"
             />
             <button
               type="button"

--- a/frontend/src/components/GenreList.jsx
+++ b/frontend/src/components/GenreList.jsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 const GENRES_API = '/api/genres'
 
 export default function GenreList({ genres, onEdit, onDelete, onGenreClick, readOnly = false }) {
@@ -30,6 +31,7 @@ export default function GenreList({ genres, onEdit, onDelete, onGenreClick, read
 }
 
 function GenreCard({ genre, onEdit, onDelete, onGenreClick, readOnly }) {
+  const [isLandscapeThumb, setIsLandscapeThumb] = useState(null) // null = not loaded yet
   const isClickable = typeof onGenreClick === 'function'
 
   return (
@@ -43,7 +45,17 @@ function GenreCard({ genre, onEdit, onDelete, onGenreClick, readOnly }) {
         <img
           src={`${GENRES_API}/${genre.id}/thumbnail`}
           alt={`${genre.name} thumbnail`}
-          className="w-full h-48 object-cover object-top"
+          onLoad={(e) => {
+            const { naturalWidth, naturalHeight } = e.currentTarget
+            setIsLandscapeThumb(naturalWidth > naturalHeight)
+          }}
+          className={`w-full h-48 ${
+            isLandscapeThumb === null
+              ? 'object-contain invisible' // safe default before load
+              : isLandscapeThumb
+                ? 'object-fill'
+                : 'object-contain'
+          }`}
         />
       )}
 

--- a/frontend/src/components/MovieForm.jsx
+++ b/frontend/src/components/MovieForm.jsx
@@ -283,7 +283,7 @@ export default function MovieForm({ movie, onSave, onCancel }) {
             <img
               src={thumbnailPreview}
               alt="Thumbnail preview"
-              className="rounded-lg max-h-40 object-cover object-top border border-gray-700"
+              className="rounded-lg max-h-40 object-contain border border-gray-700"
             />
             <button
               type="button"

--- a/frontend/src/components/MovieList.jsx
+++ b/frontend/src/components/MovieList.jsx
@@ -28,6 +28,7 @@ export default function MovieList({ movies, onEdit, onDelete, onTagClick, readOn
 
 function MovieCard({ movie, onEdit, onDelete, onTagClick, readOnly }) {
   const [showPlayer, setShowPlayer] = useState(false)
+  const [isLandscapeThumb, setIsLandscapeThumb] = useState(null) // null = not loaded yet
   const { vlcEnabled } = useAppConfig()
   const genreLabel = typeof movie.genre === 'string' ? movie.genre : movie.genre?.name
 
@@ -37,7 +38,17 @@ function MovieCard({ movie, onEdit, onDelete, onTagClick, readOnly }) {
         <img
           src={`${MOVIES_API}/${movie.id}/thumbnail`}
           alt={`${movie.title} thumbnail`}
-          className="w-full h-48 object-cover object-top"
+          onLoad={(e) => {
+            const { naturalWidth, naturalHeight } = e.currentTarget
+            setIsLandscapeThumb(naturalWidth > naturalHeight)
+          }}
+          className={`w-full h-48 ${
+            isLandscapeThumb === null
+              ? 'object-contain invisible' // safe default before load
+              : isLandscapeThumb
+                ? 'object-fill'
+                : 'object-contain'
+          }`}
         />
       )}
       {showPlayer && (

--- a/frontend/src/components/MusicVideoForm.jsx
+++ b/frontend/src/components/MusicVideoForm.jsx
@@ -296,7 +296,7 @@ export default function MusicVideoForm({ musicVideo, onSave, onCancel }) {
             <img
               src={thumbnailPreview}
               alt="Thumbnail preview"
-              className="rounded-lg max-h-40 object-cover object-top border border-gray-700"
+              className="rounded-lg max-h-40 object-contain border border-gray-700"
             />
             <button
               type="button"

--- a/frontend/src/components/MusicVideoList.jsx
+++ b/frontend/src/components/MusicVideoList.jsx
@@ -35,6 +35,7 @@ export default function MusicVideoList({ musicVideos, onEdit, onDelete, onTagCli
 
 function MusicVideoCard({ musicVideo, onEdit, onDelete, onTagClick, readOnly }) {
   const [showPlayer, setShowPlayer] = useState(false)
+  const [isLandscapeThumb, setIsLandscapeThumb] = useState(null) // null = not loaded yet
   const { vlcEnabled } = useAppConfig()
   const artistLabel = typeof musicVideo.artist === 'string' ? musicVideo.artist : musicVideo.artist?.name
 
@@ -44,7 +45,17 @@ function MusicVideoCard({ musicVideo, onEdit, onDelete, onTagClick, readOnly }) 
         <img
           src={`${MUSIC_VIDEOS_API}/${musicVideo.id}/thumbnail`}
           alt={`${musicVideo.title} thumbnail`}
-          className="w-full h-48 object-cover object-top"
+          onLoad={(e) => {
+            const { naturalWidth, naturalHeight } = e.currentTarget
+            setIsLandscapeThumb(naturalWidth > naturalHeight)
+          }}
+          className={`w-full h-48 ${
+            isLandscapeThumb === null
+              ? 'object-contain invisible' // safe default before load
+              : isLandscapeThumb
+                ? 'object-fill'
+                : 'object-contain'
+          }`}
         />
       )}
       {showPlayer && (

--- a/frontend/src/components/SeriesForm.jsx
+++ b/frontend/src/components/SeriesForm.jsx
@@ -136,7 +136,7 @@ export default function SeriesForm({ series, onSave, onCancel }) {
             <img
               src={thumbnailPreview}
               alt="Series thumbnail preview"
-              className="rounded-lg max-h-40 object-cover object-top border border-gray-700"
+              className="rounded-lg max-h-40 object-contain border border-gray-700"
             />
             <button
               type="button"

--- a/frontend/src/components/SeriesList.jsx
+++ b/frontend/src/components/SeriesList.jsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 const SERIES_API = '/api/series'
 
 export default function SeriesList({ series, onEdit, onDelete, onSeriesClick, readOnly = false }) {
@@ -30,6 +31,7 @@ export default function SeriesList({ series, onEdit, onDelete, onSeriesClick, re
 }
 
 function SeriesCard({ series, onEdit, onDelete, onSeriesClick, readOnly }) {
+  const [isLandscapeThumb, setIsLandscapeThumb] = useState(null) // null = not loaded yet
   const isClickable = typeof onSeriesClick === 'function'
 
   return (
@@ -43,7 +45,17 @@ function SeriesCard({ series, onEdit, onDelete, onSeriesClick, readOnly }) {
         <img
           src={`${SERIES_API}/${series.id}/thumbnail`}
           alt={`${series.name} thumbnail`}
-          className="w-full h-48 object-cover object-top"
+          onLoad={(e) => {
+            const { naturalWidth, naturalHeight } = e.currentTarget
+            setIsLandscapeThumb(naturalWidth > naturalHeight)
+          }}
+          className={`w-full h-48 ${
+            isLandscapeThumb === null
+              ? 'object-contain invisible' // safe default before load
+              : isLandscapeThumb
+                ? 'object-fill'
+                : 'object-contain'
+          }`}
         />
       )}
 


### PR DESCRIPTION
This PR attempts to implement more predictable thumbnail rendering across the application. The Tailwind `object-cover` CSS class often results in surprising cropping, even when attempting to guide it with `object-top`. This PR introduces a new thumbnail policy for all media cards:

- if the thumbnail is portait-shaped (for example, a movie poster), it gets `object-contain` so that it is scaled down until it fits in the display area, even if this leaves horizontal margins on either side of the image.
- landscape thumbnails now get `object-fill` applied to them, which causes them to be stretched to fit the display area. This stretching may also be somewhat unexpected, but it's less egregious than cropping the thumbnail. 
- The existing user guidance of aiming for 2:1 aspect ratio thumbnails remains, as that is still a good choice.
- The edit forms unconditionally use `object-contain` so that the user can always see the entire thumbnail undistorted when initially uploading it.

Closes #62 