### PR TITLE
Issue #64 - media prefix

### DIFF
--- a/backend/src/main/java/ca/corbett/movienight/config/SecurityConfig.java
+++ b/backend/src/main/java/ca/corbett/movienight/config/SecurityConfig.java
@@ -49,7 +49,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers("/", "/frontend/**", "/favicon.svg", "/error").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/api/files").access(adminAccess)
+                        .requestMatchers(HttpMethod.GET, "/api/files/**").access(adminAccess)
                         .requestMatchers(HttpMethod.GET, "/api/**").permitAll()
                         .requestMatchers("/admin", "/admin/**").access(adminAccess)
                         .requestMatchers(HttpMethod.POST, "/api/**").access(adminAccess)

--- a/backend/src/main/java/ca/corbett/movienight/controller/FileBrowserController.java
+++ b/backend/src/main/java/ca/corbett/movienight/controller/FileBrowserController.java
@@ -1,5 +1,10 @@
 package ca.corbett.movienight.controller;
 
+import ca.corbett.movienight.service.MediaService;
+import jakarta.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -8,7 +13,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.io.File;
-import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -22,33 +26,63 @@ import java.util.Map;
 @CrossOrigin(origins = "http://localhost:5173")
 public class FileBrowserController {
 
-    @GetMapping
-    public ResponseEntity<Map<String, Object>> listFiles(
-            @RequestParam(defaultValue = "/") String path) {
+    private static final Logger log = LoggerFactory.getLogger(FileBrowserController.class);
 
-        File dir;
-        try {
-            dir = new File(path).getCanonicalFile();
-        } catch (IOException e) {
-            dir = new File(File.separator);
+    @Value("${movienight.prefix.movies:/}")
+    private String movieDirectory;
+    private File resolvedMovieDirectory;
+
+    @Value("${movienight.prefix.episodes:/}")
+    private String episodeDirectory;
+    private File resolvedEpisodeDirectory;
+
+    @Value("${movienight.prefix.music:/}")
+    private String musicVideoDirectory;
+    private File resolvedMusicVideoDirectory;
+
+    /**
+     * We'll check to ensure we got valid values for our media directories,
+     * and resolve them to actual filesystem paths for use later.
+     * This allows us to fail fast if our configuration is invalid,
+     * and also allows us to avoid having to do this on every findById request.
+     */
+    @PostConstruct
+    public void resolveMediaDirectories() {
+        resolvedMovieDirectory = MediaService.resolveMediaDirectory(movieDirectory, "movienight.prefix.movies");
+        resolvedEpisodeDirectory = MediaService.resolveMediaDirectory(episodeDirectory, "movienight.prefix.episodes");
+        resolvedMusicVideoDirectory = MediaService.resolveMediaDirectory(musicVideoDirectory,
+                                                                         "movienight.prefix.music");
+    }
+
+    /**
+     * Provides a chrooted view of the given mediaDir, starting at the given optional path.
+     * The path is relative to the given mediaDir. We will not provide options for navigating
+     * outside of mediaDir.
+     */
+    private ResponseEntity<Map<String, Object>> listFilesInternal(File mediaDir, String path) {
+        if (path.startsWith(mediaDir.getAbsolutePath())) {
+            path = path.substring(mediaDir.getAbsolutePath().length());
         }
+        log.info("Listing files in media directory: {}, path: {}", mediaDir.getAbsolutePath(), path);
+        File currentDir = new File(mediaDir, path);
 
         // The UI might give us a file. Not a problem: just use its parent directory.
-        if (dir.isFile()) {
-            dir = dir.getParentFile() == null ? new File(File.separator) : dir.getParentFile();
+        if (currentDir.isFile()) {
+            currentDir = mediaDir.getParentFile() == null ? mediaDir : currentDir.getParentFile();
         }
 
-        if (!dir.exists() || !dir.isDirectory()) {
-            // Fall back to filesystem root
-            dir = new File(File.separator);
+        if (!currentDir.exists() || !currentDir.isDirectory()) {
+            // Fall back to our chroot
+            currentDir = mediaDir;
         }
 
-        String canonicalPath = dir.getAbsolutePath();
-        File parentDir = dir.getParentFile();
-        String parentPath = (parentDir != null) ? parentDir.getAbsolutePath() : canonicalPath;
+        boolean isRoot = currentDir.getAbsolutePath().equals(mediaDir.getAbsolutePath());
+        String canonicalPath = currentDir.getAbsolutePath();
+        File parentDir = isRoot ? null : currentDir.getParentFile();
+        String parentPath = (parentDir != null) ? parentDir.getAbsolutePath() : null;
 
         List<Map<String, String>> entries = new ArrayList<>();
-        File[] children = dir.listFiles();
+        File[] children = currentDir.listFiles();
         if (children != null) {
             Arrays.sort(children, Comparator
                     .comparing((File f) -> !f.isDirectory())
@@ -71,8 +105,28 @@ public class FileBrowserController {
 
         Map<String, Object> result = new HashMap<>();
         result.put("path", canonicalPath);
-        result.put("parent", parentPath);
+        if (!isRoot) {
+            result.put("parent", parentPath);
+        }
         result.put("entries", entries);
         return ResponseEntity.ok(result);
+    }
+
+    @GetMapping("/movies")
+    public ResponseEntity<Map<String, Object>> listMovieFiles(
+            @RequestParam(defaultValue = "/") String path) {
+        return listFilesInternal(resolvedMovieDirectory, path);
+    }
+
+    @GetMapping("/episodes")
+    public ResponseEntity<Map<String, Object>> listEpisodeFiles(
+            @RequestParam(defaultValue = "/") String path) {
+        return listFilesInternal(resolvedEpisodeDirectory, path);
+    }
+
+    @GetMapping("/music")
+    public ResponseEntity<Map<String, Object>> listMusicVideoFiles(
+            @RequestParam(defaultValue = "/") String path) {
+        return listFilesInternal(resolvedMusicVideoDirectory, path);
     }
 }

--- a/backend/src/main/java/ca/corbett/movienight/model/Episode.java
+++ b/backend/src/main/java/ca/corbett/movienight/model/Episode.java
@@ -69,6 +69,10 @@ public class Episode {
     @Column(name = "tag")
     private List<String> tags = new ArrayList<>();
 
+    /**
+     * This path is relative to the configured media directory for this media type!
+     * See application.properties for the "movienight.prefix.*" properties.
+     */
     @NotBlank
     @Column(nullable = false)
     private String videoFilePath;

--- a/backend/src/main/java/ca/corbett/movienight/model/Movie.java
+++ b/backend/src/main/java/ca/corbett/movienight/model/Movie.java
@@ -67,6 +67,10 @@ public class Movie {
     @Column(name = "tag")
     private List<String> tags = new ArrayList<>();
 
+    /**
+     * This path is relative to the configured media directory for this media type!
+     * See application.properties for the "movienight.prefix.*" properties.
+     */
     @NotBlank
     @Column(nullable = false)
     private String videoFilePath;

--- a/backend/src/main/java/ca/corbett/movienight/model/MusicVideo.java
+++ b/backend/src/main/java/ca/corbett/movienight/model/MusicVideo.java
@@ -73,6 +73,10 @@ public class MusicVideo {
     @Column(name = "tag")
     private List<String> tags = new ArrayList<>();
 
+    /**
+     * This path is relative to the configured media directory for this media type!
+     * See application.properties for the "movienight.prefix.*" properties.
+     */
     @NotBlank
     @Column(nullable = false)
     private String videoFilePath;

--- a/backend/src/main/java/ca/corbett/movienight/service/EpisodeService.java
+++ b/backend/src/main/java/ca/corbett/movienight/service/EpisodeService.java
@@ -24,6 +24,9 @@ public class EpisodeService {
     private final EpisodeRepository episodeRepository;
     private final ThumbnailService thumbnailService;
 
+    @Value("${movienight.prefix.episodes:/}")
+    private String episodeDirectory;
+
     public EpisodeService(EpisodeRepository episodeRepository, ThumbnailService thumbnailService) {
         this.episodeRepository = episodeRepository;
         this.thumbnailService = thumbnailService;
@@ -34,6 +37,8 @@ public class EpisodeService {
     }
 
     public Episode saveEpisode(Episode episode) {
+        episode.setVideoFilePath(episode.getVideoFilePath()); // goofy, but forces validation and path resolution
+        episode.setVideoFilePath(MediaService.resolveFilePath(episodeDirectory, episode.getVideoFilePath()));
         return populateTransientFields(episodeRepository.save(episode));
     }
 
@@ -50,7 +55,7 @@ public class EpisodeService {
             ep.setEpisode(updatedEpisode.getEpisode());
             ep.setDescription(updatedEpisode.getDescription());
             ep.setTags(updatedEpisode.getTags());
-            ep.setVideoFilePath(updatedEpisode.getVideoFilePath());
+            ep.setVideoFilePath(MediaService.resolveFilePath(episodeDirectory, updatedEpisode.getVideoFilePath()));
             return populateTransientFields(episodeRepository.save(ep));
         }).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Episode not found with id: " + id));
     }

--- a/backend/src/main/java/ca/corbett/movienight/service/EpisodeService.java
+++ b/backend/src/main/java/ca/corbett/movienight/service/EpisodeService.java
@@ -37,7 +37,6 @@ public class EpisodeService {
     }
 
     public Episode saveEpisode(Episode episode) {
-        episode.setVideoFilePath(episode.getVideoFilePath()); // goofy, but forces validation and path resolution
         episode.setVideoFilePath(MediaService.resolveFilePath(episodeDirectory, episode.getVideoFilePath()));
         return populateTransientFields(episodeRepository.save(episode));
     }

--- a/backend/src/main/java/ca/corbett/movienight/service/MediaService.java
+++ b/backend/src/main/java/ca/corbett/movienight/service/MediaService.java
@@ -79,6 +79,10 @@ public class MediaService {
             if (mediaDirectory == null || mediaDirectory.isBlank()) {
                 mediaDirectory = "/";
             }
+            if (!mediaDirectory.endsWith(File.separator)) {
+                mediaDirectory += File.separator;
+            }
+            // TODO: should probably normalize to guard against malicious input like "../../../etc/passwd"...
             if (videoFilePath.startsWith(mediaDirectory)) {
                 videoFilePath = videoFilePath.substring(mediaDirectory.length());
             }

--- a/backend/src/main/java/ca/corbett/movienight/service/MediaService.java
+++ b/backend/src/main/java/ca/corbett/movienight/service/MediaService.java
@@ -171,7 +171,7 @@ public class MediaService {
      */
     public static File resolveMediaDirectory(String directory, String propName) {
         if (directory == null || directory.isBlank()) {
-            logger.warn("movienight.prefix.movies is not set or is blank. Defaulting to root directory.");
+            logger.warn("{} is not set or is blank (value: {}). Defaulting to root directory.", propName, directory);
             directory = "/";
         }
         File resolvedDirectory = new File(directory).getAbsoluteFile();

--- a/backend/src/main/java/ca/corbett/movienight/service/MediaService.java
+++ b/backend/src/main/java/ca/corbett/movienight/service/MediaService.java
@@ -6,12 +6,15 @@ import ca.corbett.movienight.model.MusicVideo;
 import ca.corbett.movienight.repository.EpisodeRepository;
 import ca.corbett.movienight.repository.MovieRepository;
 import ca.corbett.movienight.repository.MusicVideoRepository;
+import jakarta.annotation.PostConstruct;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.io.File;
 import java.time.LocalDate;
 
 @Service
@@ -25,6 +28,18 @@ public class MediaService {
     private final MovieRepository movieRepository;
     private final EpisodeRepository episodeRepository;
     private final MusicVideoRepository musicVideoRepository;
+
+    @Value("${movienight.prefix.movies:/}")
+    private String movieDirectory;
+    private File resolvedMovieDirectory;
+
+    @Value("${movienight.prefix.episodes:/}")
+    private String episodeDirectory;
+    private File resolvedEpisodeDirectory;
+
+    @Value("${movienight.prefix.music:/}")
+    private String musicVideoDirectory;
+    private File resolvedMusicVideoDirectory;
 
     public MediaService(MovieService movieService,
                         EpisodeService episodeService,
@@ -41,7 +56,39 @@ public class MediaService {
     }
 
     /**
-     * Returns the absolute video file path for an encoded media ID.
+     * We'll check to ensure we got valid values for our media directories,
+     * and resolve them to actual filesystem paths for use later.
+     * This allows us to fail fast if our configuration is invalid,
+     * and also allows us to avoid having to do this on every findById request.
+     */
+    @PostConstruct
+    public void resolveMediaDirectories() {
+        resolvedMovieDirectory = resolveMediaDirectory(movieDirectory, "movienight.prefix.movies");
+        resolvedEpisodeDirectory = resolveMediaDirectory(episodeDirectory, "movienight.prefix.episodes");
+        resolvedMusicVideoDirectory = resolveMediaDirectory(musicVideoDirectory, "movienight.prefix.music");
+        logger.info("Resolved media directories - movies: {}, episodes: {}, music videos: {}",
+                    resolvedMovieDirectory, resolvedEpisodeDirectory, resolvedMusicVideoDirectory);
+    }
+
+    /**
+     * Given a media directory and a video file path, returns the resolved file path relative to the media directory.
+     * Example: "/my/movies/Bladerunner.mp4" -> "Bladerunner.mp4" if mediaDirectory is "/my/movies/"
+     */
+    public static String resolveFilePath(String mediaDirectory, String videoFilePath) {
+        if (videoFilePath != null && !videoFilePath.isBlank()) {
+            if (mediaDirectory == null || mediaDirectory.isBlank()) {
+                mediaDirectory = "/";
+            }
+            if (videoFilePath.startsWith(mediaDirectory)) {
+                videoFilePath = videoFilePath.substring(mediaDirectory.length());
+            }
+        }
+        return videoFilePath;
+    }
+
+
+    /**
+     * Returns the resolved absolute video file path for an encoded media ID.
      * The id must be "M" followed by a numeric movie ID, "E" followed by a numeric episode ID,
      * or "V" followed by a numeric music video ID.
      * <p>
@@ -55,6 +102,13 @@ public class MediaService {
      * layer, to avoid the filesystem overhead that the services will incur when they go to
      * update the thumbnail on save. Since we know the thumbnail won't change when just updating
      * the last watched date, we can skip that overhead.
+     * </p>
+     * <p>
+     * Model objects store media file paths relative to the configured media directory.
+     * For example, a model object file path might be "bladerunner.mp4". We resolve this by
+     * using the configured media directory for that type of media. For example, if our movie
+     * prefix is "/mnt/storage/videos/movies", then the resolved path for "bladerunner.mp4" would be
+     * "/mnt/storage/videos/movies/bladerunner.mp4".
      * </p>
      *
      * @param encodedId encoded media ID, e.g. "M31", "E77", or "V12"
@@ -84,7 +138,7 @@ public class MediaService {
             movie.setWatchedRecently(true); // Set manually, since we know it's "true" even without date math
             movieRepository.save(movie); // Save via repository to avoid unnecessary filesystem overhead in the service
             logger.debug("Resolved media id {} to movie file path: {}", encodedId, path);
-            return path;
+            return new File(resolvedMovieDirectory, path).getAbsolutePath();
         } else if (type == 'E') {
             Episode episode = episodeService.requireEpisode(numericId);
             String path = episode.getVideoFilePath();
@@ -92,7 +146,7 @@ public class MediaService {
             episode.setWatchedRecently(true);
             episodeRepository.save(episode);
             logger.debug("Resolved media id {} to episode file path: {}", encodedId, path);
-            return path;
+            return new File(resolvedEpisodeDirectory, path).getAbsolutePath();
         } else if (type == 'V') {
             MusicVideo musicVideo = musicVideoService.requireMusicVideo(numericId);
             String path = musicVideo.getVideoFilePath();
@@ -100,10 +154,48 @@ public class MediaService {
             musicVideo.setWatchedRecently(true);
             musicVideoRepository.save(musicVideo);
             logger.debug("Resolved media id {} to music video file path: {}", encodedId, path);
-            return path;
+            return new File(resolvedMusicVideoDirectory, path).getAbsolutePath();
         } else {
             logger.warn("Unknown media type prefix '{}' in id: {}", type, encodedId);
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Unknown media type in id: " + encodedId);
         }
+    }
+
+    /**
+     * Verifies that the named directory exists and is readable, and returns a File object
+     * representing it if so. The propName parameter is used for logging purposes if something goes wrong.
+     * <p>
+     * Note: if the given directory is null or blank, we default to "/" as a fallback.
+     * A warning will be logged in this case.
+     * </p>
+     */
+    public static File resolveMediaDirectory(String directory, String propName) {
+        if (directory == null || directory.isBlank()) {
+            logger.warn("movienight.prefix.movies is not set or is blank. Defaulting to root directory.");
+            directory = "/";
+        }
+        File resolvedDirectory = new File(directory).getAbsoluteFile();
+        if (!resolvedDirectory.exists() || !resolvedDirectory.isDirectory() || !resolvedDirectory.canRead()) {
+            logger.error("Resolved {} directory does not exist or is not a readable directory: {}",
+                         propName, resolvedDirectory);
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
+                                              "Can't read " + propName + " directory: " + resolvedDirectory);
+        }
+        return resolvedDirectory;
+    }
+
+    public void setMovieDirectory(String movieDirectory) {
+        this.movieDirectory = movieDirectory;
+        resolveMediaDirectories();
+    }
+
+    public void setEpisodeDirectory(String episodeDirectory) {
+        this.episodeDirectory = episodeDirectory;
+        resolveMediaDirectories();
+    }
+
+    public void setMusicVideoDirectory(String musicVideoDirectory) {
+        this.musicVideoDirectory = musicVideoDirectory;
+        resolveMediaDirectories();
     }
 }

--- a/backend/src/main/java/ca/corbett/movienight/service/MovieService.java
+++ b/backend/src/main/java/ca/corbett/movienight/service/MovieService.java
@@ -25,6 +25,9 @@ public class MovieService {
     private final MovieRepository movieRepository;
     private final ThumbnailService thumbnailService;
 
+    @Value("${movienight.prefix.movies:/}")
+    private String movieDirectory;
+
     public MovieService(MovieRepository movieRepository, ThumbnailService thumbnailService) {
         this.movieRepository = movieRepository;
         this.thumbnailService = thumbnailService;
@@ -44,6 +47,7 @@ public class MovieService {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Movie genre is required.");
         }
 
+        movie.setVideoFilePath(MediaService.resolveFilePath(movieDirectory, movie.getVideoFilePath()));
         return populateTransientFields(movieRepository.save(movie));
     }
 
@@ -59,7 +63,7 @@ public class MovieService {
             movie.setGenre(updatedMovie.getGenre());
             movie.setDescription(updatedMovie.getDescription());
             movie.setTags(updatedMovie.getTags());
-            movie.setVideoFilePath(updatedMovie.getVideoFilePath());
+            movie.setVideoFilePath(MediaService.resolveFilePath(movieDirectory, movie.getVideoFilePath()));
             return populateTransientFields(movieRepository.save(movie));
         }).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Movie not found with id: " + id));
     }

--- a/backend/src/main/java/ca/corbett/movienight/service/MovieService.java
+++ b/backend/src/main/java/ca/corbett/movienight/service/MovieService.java
@@ -63,7 +63,7 @@ public class MovieService {
             movie.setGenre(updatedMovie.getGenre());
             movie.setDescription(updatedMovie.getDescription());
             movie.setTags(updatedMovie.getTags());
-            movie.setVideoFilePath(MediaService.resolveFilePath(movieDirectory, movie.getVideoFilePath()));
+            movie.setVideoFilePath(MediaService.resolveFilePath(movieDirectory, updatedMovie.getVideoFilePath()));
             return populateTransientFields(movieRepository.save(movie));
         }).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Movie not found with id: " + id));
     }

--- a/backend/src/main/java/ca/corbett/movienight/service/MusicVideoService.java
+++ b/backend/src/main/java/ca/corbett/movienight/service/MusicVideoService.java
@@ -24,6 +24,9 @@ public class MusicVideoService {
     private final MusicVideoRepository musicVideoRepository;
     private final ThumbnailService thumbnailService;
 
+    @Value("${movienight.prefix.music:/}")
+    private String musicVideoDirectory;
+
     public MusicVideoService(MusicVideoRepository musicVideoRepository, ThumbnailService thumbnailService) {
         this.musicVideoRepository = musicVideoRepository;
         this.thumbnailService = thumbnailService;
@@ -41,6 +44,7 @@ public class MusicVideoService {
         if (musicVideo.getArtist() == null) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Music video artist is required.");
         }
+        musicVideo.setVideoFilePath(MediaService.resolveFilePath(musicVideoDirectory, musicVideo.getVideoFilePath()));
         return populateTransientFields(musicVideoRepository.save(musicVideo));
     }
 
@@ -56,7 +60,8 @@ public class MusicVideoService {
             mv.setYear(updatedMusicVideo.getYear());
             mv.setDescription(updatedMusicVideo.getDescription());
             mv.setTags(updatedMusicVideo.getTags());
-            mv.setVideoFilePath(updatedMusicVideo.getVideoFilePath());
+            mv.setVideoFilePath(
+                    MediaService.resolveFilePath(musicVideoDirectory, updatedMusicVideo.getVideoFilePath()));
             return populateTransientFields(musicVideoRepository.save(mv));
         }).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
                                                          "Music video not found with id: " + id));

--- a/backend/src/main/resources/application-dev.properties
+++ b/backend/src/main/resources/application-dev.properties
@@ -9,3 +9,7 @@ movienight.data-dir=
 # Credentials for basic auth access to the admin API in dev:
 movienight.admin.username=${MOVIENIGHT_ADMIN_USERNAME:admin}
 movienight.admin.password=${MOVIENIGHT_ADMIN_PASSWORD:password}
+
+movienight.prefix.movies=/home/scorbett/tmp/music
+movienight.prefix.episodes=/home/scorbett/tmp/music
+movienight.prefix.music=/home/scorbett/tmp/music

--- a/backend/src/main/resources/application-dev.properties
+++ b/backend/src/main/resources/application-dev.properties
@@ -9,7 +9,3 @@ movienight.data-dir=
 # Credentials for basic auth access to the admin API in dev:
 movienight.admin.username=${MOVIENIGHT_ADMIN_USERNAME:admin}
 movienight.admin.password=${MOVIENIGHT_ADMIN_PASSWORD:password}
-
-movienight.prefix.movies=/home/scorbett/tmp/music
-movienight.prefix.episodes=/home/scorbett/tmp/music
-movienight.prefix.music=/home/scorbett/tmp/music

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -46,3 +46,22 @@ movienight.max-range-request-size-mb=32
 #   2. The browser must be configured to launch VLC when a .m3u file is downloaded
 # If enabled, this supplements the inline video player, it doesn't replace it.
 movienight.enable-vlc-integration=false
+
+# Here you can set directory prefixes for your media collections.
+# All paths will be stored in MovieNight relative to these prefixes.
+#   Example prefix: /mnt/storage/videos
+#   Example movie path: Movies/SciFi/bladerunner.mp4
+#   Full file path: /mnt/storage/videos/Movies/SciFi/bladerunner.mp4
+#   But MovieNight only needs to store the path relative to the prefix.
+#
+# This allows you to rename or move your mount point without breaking MovieNight's database,
+# just as long as the relative paths remain the same within that mount point.
+#
+# MovieNight does not write anything to these directories!
+# It's fine to provide read-only mount points.
+#
+# Note that the client-side file browser will effectively be chrooted to the supplied prefix.
+# This can be used to prevent the client-side browser from seeing the entire server filesystem.
+movienight.prefix.movies=/
+movienight.prefix.episodes=/
+movienight.prefix.music=/

--- a/backend/src/test/java/ca/corbett/movienight/MediaServiceTest.java
+++ b/backend/src/test/java/ca/corbett/movienight/MediaServiceTest.java
@@ -1,9 +1,12 @@
 package ca.corbett.movienight;
 
+import ca.corbett.movienight.model.Artist;
 import ca.corbett.movienight.model.Episode;
 import ca.corbett.movienight.model.Genre;
 import ca.corbett.movienight.model.Movie;
+import ca.corbett.movienight.model.MusicVideo;
 import ca.corbett.movienight.model.Series;
+import ca.corbett.movienight.repository.ArtistRepository;
 import ca.corbett.movienight.repository.EpisodeRepository;
 import ca.corbett.movienight.repository.GenreRepository;
 import ca.corbett.movienight.repository.MovieRepository;
@@ -15,12 +18,15 @@ import ca.corbett.movienight.service.MovieService;
 import ca.corbett.movienight.service.MusicVideoService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.web.server.ResponseStatusException;
+
+import java.io.File;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -33,7 +39,10 @@ import static org.mockito.Mockito.when;
         "spring.datasource.url=jdbc:sqlite::memory:",
         "spring.datasource.driver-class-name=org.sqlite.JDBC",
         "spring.jpa.database-platform=org.hibernate.community.dialect.SQLiteDialect",
-        "spring.jpa.hibernate.ddl-auto=create-drop"
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "movienight.prefix.movies=/movies",
+        "movienight.prefix.episodes=/episodes",
+        "movienight.prefix.music=/music"
 })
 class MediaServiceTest {
 
@@ -49,6 +58,9 @@ class MediaServiceTest {
     private GenreRepository genreRepository;
 
     @Autowired
+    private ArtistRepository artistRepository;
+
+    @Autowired
     private MovieRepository movieRepository;
 
     @Autowired
@@ -57,6 +69,9 @@ class MediaServiceTest {
     @Autowired
     private MusicVideoRepository musicVideoRepository;
 
+    @TempDir
+    File tempDir;
+
     @BeforeEach
     void setUp() {
         movieService = mock(MovieService.class);
@@ -64,6 +79,15 @@ class MediaServiceTest {
         musicVideoService = mock(MusicVideoService.class);
         mediaService = new MediaService(movieService, episodeService, musicVideoService,
                                         movieRepository, episodeRepository, musicVideoRepository);
+        File moviesDir = new File(tempDir, "movies");
+        File episodesDir = new File(tempDir, "episodes");
+        File musicDir = new File(tempDir, "music");
+        moviesDir.mkdirs();
+        episodesDir.mkdirs();
+        musicDir.mkdirs();
+        mediaService.setMovieDirectory(moviesDir.getAbsolutePath());
+        mediaService.setEpisodeDirectory(episodesDir.getAbsolutePath());
+        mediaService.setMusicVideoDirectory(musicDir.getAbsolutePath());
     }
 
     @Test
@@ -71,12 +95,12 @@ class MediaServiceTest {
         Genre drama = new Genre("Drama", "");
         genreRepository.save(drama);
         Movie movie = new Movie("Test Movie", 2024, drama, "A test.", null);
-        movie.setVideoFilePath("/movies/test_movie.mp4");
+        movie.setVideoFilePath("test_movie.mp4");
         movie = movieRepository.save(movie);
         when(movieService.requireMovie(movie.getId())).thenReturn(movie);
 
         String path = mediaService.findById("M" + movie.getId());
-        assertThat(path).isEqualTo("/movies/test_movie.mp4");
+        assertThat(path).isEqualTo(new File(tempDir, "movies/test_movie.mp4").getAbsolutePath());
 
         // Also verify that the side effect of the mediaService.findById set a lastWatchedDate and saved it.
         Movie actual = movieRepository.findById(movie.getId()).orElseThrow();
@@ -88,15 +112,32 @@ class MediaServiceTest {
         Series series = new Series("Test Series", "A test series.");
         seriesRepository.save(series);
         Episode episode = new Episode(series, "Pilot", 1, 1, "First episode.", null);
-        episode.setVideoFilePath("/episodes/s01e01.mp4");
+        episode.setVideoFilePath("s01e01.mp4");
         episode = episodeRepository.save(episode);
         when(episodeService.requireEpisode(episode.getId())).thenReturn(episode);
 
         String path = mediaService.findById("E" + episode.getId());
-        assertThat(path).isEqualTo("/episodes/s01e01.mp4");
+        assertThat(path).isEqualTo(new File(tempDir, "episodes/s01e01.mp4").getAbsolutePath());
 
         // Also verify that the side effect of the mediaService.findById set a lastWatchedDate and saved it.
         Episode actual = episodeRepository.findById(episode.getId()).orElseThrow();
+        assertThat(actual.getLastWatchedDate()).isNotNull();
+    }
+
+    @Test
+    void resolvesMusicVideoId() {
+        Artist artist = new Artist("Test Artist", "A test artist.");
+        artistRepository.save(artist);
+        MusicVideo musicVideo = new MusicVideo("Test Song", artist, "Test Album", 1995, "A test song.", null);
+        musicVideo.setVideoFilePath("test_song.mp4");
+        musicVideo = musicVideoRepository.save(musicVideo);
+        when(musicVideoService.requireMusicVideo(musicVideo.getId())).thenReturn(musicVideo);
+
+        String path = mediaService.findById("V" + musicVideo.getId());
+        assertThat(path).isEqualTo(new File(tempDir, "music/test_song.mp4").getAbsolutePath());
+
+        // Also verify that the side effect of the mediaService.findById set a lastWatchedDate and saved it.
+        MusicVideo actual = musicVideoRepository.findById(musicVideo.getId()).orElseThrow();
         assertThat(actual.getLastWatchedDate()).isNotNull();
     }
 

--- a/backend/src/test/java/ca/corbett/movienight/MusicVideoRepositoryTest.java
+++ b/backend/src/test/java/ca/corbett/movienight/MusicVideoRepositoryTest.java
@@ -31,7 +31,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
         "spring.datasource.driver-class-name=org.sqlite.JDBC",
         "spring.jpa.database-platform=org.hibernate.community.dialect.SQLiteDialect",
         "spring.jpa.hibernate.ddl-auto=create-drop",
-        "movienight.recently-watched-days=5" // This is ignored because we create the service ourselves here
+        "movienight.recently-watched-days=5", // This is ignored because we create the service ourselves here
+        "movienight.prefix.music=/music"
 })
 class MusicVideoRepositoryTest {
 

--- a/frontend/src/components/EpisodeForm.jsx
+++ b/frontend/src/components/EpisodeForm.jsx
@@ -380,6 +380,7 @@ export default function EpisodeForm({ episode, onSave, onCancel }) {
 
     {showFileBrowser && (
       <FileBrowserModal
+        mediaType="episodes"
         initialPath={form.videoFilePath || initialBrowsePath}
         onSelect={(path) => {
           const normalizedPath = typeof path === 'string' ? path.trim() : ''

--- a/frontend/src/components/EpisodeForm.jsx
+++ b/frontend/src/components/EpisodeForm.jsx
@@ -3,7 +3,7 @@ import FileBrowserModal from './FileBrowserModal'
 
 const EPISODES_API = '/api/episodes'
 const SERIES_API = '/api/series'
-const LAST_DIR_KEY = 'movienight:lastBrowseDir'
+const LAST_DIR_KEY = 'movienight:lastEpisodesBrowseDir'
 
 const EMPTY_FORM = {
   seriesId: '',

--- a/frontend/src/components/FileBrowserModal.jsx
+++ b/frontend/src/components/FileBrowserModal.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from 'react'
 
-const FILES_API = '/api/files'
+const FILES_API = '/api/files/'
 const LAST_DIR_KEY = 'movienight:lastBrowseDir'
 
 const VIDEO_EXTENSIONS = new Set([
@@ -14,7 +14,7 @@ function isVideoFile(name) {
   return VIDEO_EXTENSIONS.has(ext)
 }
 
-export default function FileBrowserModal({ initialPath, onSelect, onClose }) {
+export default function FileBrowserModal({ mediaType, initialPath, onSelect, onClose }) {
   const [currentPath, setCurrentPath] = useState(initialPath || '/')
   const [parentPath, setParentPath] = useState('/')
   const [entries, setEntries] = useState([])
@@ -26,7 +26,7 @@ export default function FileBrowserModal({ initialPath, onSelect, onClose }) {
     setLoading(true)
     setError(null)
     try {
-      const res = await fetch(`${FILES_API}?path=${encodeURIComponent(path)}`)
+      const res = await fetch(`${FILES_API}${mediaType}?path=${encodeURIComponent(path)}`)
       if (!res.ok) throw new Error(`Failed to list directory (${res.status})`)
       const data = await res.json()
       setCurrentPath(data.path)
@@ -98,15 +98,17 @@ export default function FileBrowserModal({ initialPath, onSelect, onClose }) {
         </form>
 
         {/* Navigation */}
-        <div className="px-5 py-2 border-b border-gray-700">
-          <button
-            onClick={() => loadDirectory(parentPath)}
-            disabled={currentPath === parentPath}
-            className="text-indigo-400 hover:text-indigo-300 text-sm disabled:opacity-40 disabled:cursor-not-allowed"
-          >
-            ↑ Parent directory
-          </button>
-        </div>
+        {parentPath && (
+            <div className="px-5 py-2 border-b border-gray-700">
+              <button
+                onClick={() => loadDirectory(parentPath)}
+                disabled={currentPath === parentPath}
+                className="text-indigo-400 hover:text-indigo-300 text-sm disabled:opacity-40 disabled:cursor-not-allowed"
+              >
+                ↑ Parent directory
+              </button>
+            </div>
+        )}
 
         {/* File listing */}
         <div className="flex-1 overflow-y-auto px-5 py-2">

--- a/frontend/src/components/FileBrowserModal.jsx
+++ b/frontend/src/components/FileBrowserModal.jsx
@@ -1,7 +1,11 @@
 import { useState, useEffect, useCallback } from 'react'
 
 const FILES_API = '/api/files/'
-const LAST_DIR_KEY = 'movienight:lastBrowseDir'
+const LAST_DIR_KEY = new Map([
+    ['movies', 'movienight:lastMoviesBrowseDir'],
+    ['episodes', 'movienight:lastEpisodesBrowseDir'],
+    ['music', 'movienight:lastMusicBrowseDir']
+])
 
 const VIDEO_EXTENSIONS = new Set([
   'mp4', 'mkv', 'avi', 'mov', 'wmv', 'flv', 'webm', 'm4v', 'mpg', 'mpeg', 'ts', 'm2ts',
@@ -21,6 +25,7 @@ export default function FileBrowserModal({ mediaType, initialPath, onSelect, onC
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState(null)
   const [pathInput, setPathInput] = useState(initialPath || '/')
+  const lastDirKey = LAST_DIR_KEY.get(mediaType)
 
   const loadDirectory = useCallback(async (path) => {
     setLoading(true)
@@ -31,7 +36,9 @@ export default function FileBrowserModal({ mediaType, initialPath, onSelect, onC
       const data = await res.json()
       setCurrentPath(data.path)
       try {
-        sessionStorage.setItem(LAST_DIR_KEY, data.path)
+          if (lastDirKey) {
+              sessionStorage.setItem(lastDirKey, data.path)
+          }
       } catch {
         // Ignore storage persistence failures so browsing still works.
       }

--- a/frontend/src/components/FileBrowserModal.jsx
+++ b/frontend/src/components/FileBrowserModal.jsx
@@ -43,7 +43,7 @@ export default function FileBrowserModal({ mediaType, initialPath, onSelect, onC
     } finally {
       setLoading(false)
     }
-  }, [])
+  }, [mediaType])
 
   useEffect(() => {
     loadDirectory(initialPath || '/')

--- a/frontend/src/components/MovieForm.jsx
+++ b/frontend/src/components/MovieForm.jsx
@@ -369,6 +369,7 @@ export default function MovieForm({ movie, onSave, onCancel }) {
 
     {showFileBrowser && (
       <FileBrowserModal
+        mediaType="movies"
         initialPath={form.videoFilePath || initialBrowsePath}
         onSelect={(path) => {
           const normalizedPath = path.trim()

--- a/frontend/src/components/MovieForm.jsx
+++ b/frontend/src/components/MovieForm.jsx
@@ -3,7 +3,7 @@ import FileBrowserModal from './FileBrowserModal'
 
 const MOVIES_API = '/api/movies'
 const GENRES_API = '/api/genres'
-const LAST_DIR_KEY = 'movienight:lastBrowseDir'
+const LAST_DIR_KEY = 'movienight:lastMoviesBrowseDir'
 
 const EMPTY_FORM = {
   id: null,

--- a/frontend/src/components/MusicVideoForm.jsx
+++ b/frontend/src/components/MusicVideoForm.jsx
@@ -3,7 +3,7 @@ import FileBrowserModal from './FileBrowserModal'
 
 const MUSIC_VIDEOS_API = '/api/music-videos'
 const ARTISTS_API = '/api/artists'
-const LAST_DIR_KEY = 'movienight:lastBrowseDir'
+const LAST_DIR_KEY = 'movienight:lastMusicBrowseDir'
 
 const EMPTY_FORM = {
   id: null,

--- a/frontend/src/components/MusicVideoForm.jsx
+++ b/frontend/src/components/MusicVideoForm.jsx
@@ -382,6 +382,7 @@ export default function MusicVideoForm({ musicVideo, onSave, onCancel }) {
 
     {showFileBrowser && (
       <FileBrowserModal
+        mediaType="music"
         initialPath={form.videoFilePath || initialBrowsePath}
         onSelect={(path) => {
           const normalizedPath = typeof path === 'string' ? path.trim() : ''


### PR DESCRIPTION
This PR addresses issue #64 by changing the way the application stores media file locations. Previously, all movies, music videos, and episodes would store the absolute file path of their media file. We now store only relative file paths. Three new configuration properties have been introduced:

```
movienight.prefix.movies=/
movienight.prefix.episodes=/
movienight.prefix.music=/
```

These represent the directories on disk where media files of that type are located. This allows mount points to be renamed or moved without breaking anything in MovieNight, as long as these config properties are kept updated.

A secondary benefit of this change is that we can now "chroot" the client-side file browser modal to lock it into the appropriate media directory. This prevents client-side browsing of the entire server file system.

Closes #64 
