### PR TITLE
Issue #66 edit dialog positioning

### DIFF
--- a/frontend/src/pages/MediaLibraryPage.jsx
+++ b/frontend/src/pages/MediaLibraryPage.jsx
@@ -753,21 +753,6 @@ export default function MediaLibraryPage({ mode }) {
             </div>
           )}
 
-          {isAdmin && showMovieForm && (
-            <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4">
-              <div className="bg-gray-900 border border-gray-700 rounded-xl shadow-2xl w-full max-w-lg">
-                <MovieForm
-                  movie={editingMovie}
-                  onSave={handleSaveMovie}
-                  onCancel={() => {
-                    setShowMovieForm(false)
-                    setEditingMovie(null)
-                  }}
-                />
-              </div>
-            </div>
-          )}
-
           {!selectedGenre && !movieSearchQuery && !movieTagQuery ? (
             genresLoading ? (
               <div className="text-center text-gray-400 py-16">Loading…</div>
@@ -881,21 +866,6 @@ export default function MediaLibraryPage({ mode }) {
           {episodesError && (
             <div className="bg-red-900/50 border border-red-700 text-red-300 px-4 py-3 rounded-lg mb-6">
               {episodesError}
-            </div>
-          )}
-
-          {isAdmin && showEpisodeForm && (
-            <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4">
-              <div className="bg-gray-900 border border-gray-700 rounded-xl shadow-2xl w-full max-w-lg overflow-y-auto max-h-[90vh]">
-                <EpisodeForm
-                  episode={editingEpisode}
-                  onSave={handleSaveEpisode}
-                  onCancel={() => {
-                    setShowEpisodeForm(false)
-                    setEditingEpisode(null)
-                  }}
-                />
-              </div>
             </div>
           )}
 
@@ -1106,21 +1076,6 @@ export default function MediaLibraryPage({ mode }) {
             </div>
           )}
 
-          {isAdmin && showMusicVideoForm && (
-            <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4">
-              <div className="bg-gray-900 border border-gray-700 rounded-xl shadow-2xl w-full max-w-lg overflow-y-auto max-h-[90vh]">
-                <MusicVideoForm
-                  musicVideo={editingMusicVideo}
-                  onSave={handleSaveMusicVideo}
-                  onCancel={() => {
-                    setShowMusicVideoForm(false)
-                    setEditingMusicVideo(null)
-                  }}
-                />
-              </div>
-            </div>
-          )}
-
           {!selectedArtist && !musicVideoTitleQuery && !musicVideoTagQuery ? (
             artistsLoading ? (
               <div className="text-center text-gray-400 py-16">Loading…</div>
@@ -1209,6 +1164,51 @@ export default function MediaLibraryPage({ mode }) {
         </>
       )}
       </div>
+
+      {isAdmin && showMovieForm && (
+        <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4">
+          <div className="bg-gray-900 border border-gray-700 rounded-xl shadow-2xl w-full max-w-lg overflow-y-auto max-h-[90vh]">
+            <MovieForm
+              movie={editingMovie}
+              onSave={handleSaveMovie}
+              onCancel={() => {
+                setShowMovieForm(false)
+                setEditingMovie(null)
+              }}
+            />
+          </div>
+        </div>
+      )}
+
+      {isAdmin && showEpisodeForm && (
+        <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4">
+          <div className="bg-gray-900 border border-gray-700 rounded-xl shadow-2xl w-full max-w-lg overflow-y-auto max-h-[90vh]">
+            <EpisodeForm
+              episode={editingEpisode}
+              onSave={handleSaveEpisode}
+              onCancel={() => {
+                setShowEpisodeForm(false)
+                setEditingEpisode(null)
+              }}
+            />
+          </div>
+        </div>
+      )}
+
+      {isAdmin && showMusicVideoForm && (
+        <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4">
+          <div className="bg-gray-900 border border-gray-700 rounded-xl shadow-2xl w-full max-w-lg overflow-y-auto max-h-[90vh]">
+            <MusicVideoForm
+              musicVideo={editingMusicVideo}
+              onSave={handleSaveMusicVideo}
+              onCancel={() => {
+                setShowMusicVideoForm(false)
+                setEditingMusicVideo(null)
+              }}
+            />
+          </div>
+        </div>
+      )}
     </>
   )
 }

--- a/frontend/src/pages/MediaLibraryPage.jsx
+++ b/frontend/src/pages/MediaLibraryPage.jsx
@@ -928,21 +928,6 @@ export default function MediaLibraryPage({ mode }) {
             </div>
           )}
 
-          {isAdmin && showGenreForm && (
-            <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4">
-              <div className="bg-gray-900 border border-gray-700 rounded-xl shadow-2xl w-full max-w-lg overflow-y-auto max-h-[90vh]">
-                <GenreForm
-                  genre={editingGenre}
-                  onSave={handleSaveGenre}
-                  onCancel={() => {
-                    setShowGenreForm(false)
-                    setEditingGenre(null)
-                  }}
-                />
-              </div>
-            </div>
-          )}
-
           {genresLoading ? (
             <div className="text-center text-gray-400 py-16">Loading…</div>
           ) : (
@@ -973,21 +958,6 @@ export default function MediaLibraryPage({ mode }) {
           {seriesError && (
             <div className="bg-red-900/50 border border-red-700 text-red-300 px-4 py-3 rounded-lg mb-6">
               {seriesError}
-            </div>
-          )}
-
-          {isAdmin && showSeriesForm && (
-            <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4">
-              <div className="bg-gray-900 border border-gray-700 rounded-xl shadow-2xl w-full max-w-lg overflow-y-auto max-h-[90vh]">
-                <SeriesForm
-                  series={editingSeries}
-                  onSave={handleSaveSeries}
-                  onCancel={() => {
-                    setShowSeriesForm(false)
-                    setEditingSeries(null)
-                  }}
-                />
-              </div>
             </div>
           )}
 
@@ -1133,21 +1103,6 @@ export default function MediaLibraryPage({ mode }) {
             </div>
           )}
 
-          {isAdmin && showArtistForm && (
-            <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4">
-              <div className="bg-gray-900 border border-gray-700 rounded-xl shadow-2xl w-full max-w-lg overflow-y-auto max-h-[90vh]">
-                <ArtistForm
-                  artist={editingArtist}
-                  onSave={handleSaveArtist}
-                  onCancel={() => {
-                    setShowArtistForm(false)
-                    setEditingArtist(null)
-                  }}
-                />
-              </div>
-            </div>
-          )}
-
           {artistsLoading ? (
             <div className="text-center text-gray-400 py-16">Loading…</div>
           ) : (
@@ -1204,6 +1159,51 @@ export default function MediaLibraryPage({ mode }) {
               onCancel={() => {
                 setShowMusicVideoForm(false)
                 setEditingMusicVideo(null)
+              }}
+            />
+          </div>
+        </div>
+      )}
+
+      {isAdmin && showGenreForm && (
+        <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4">
+          <div className="bg-gray-900 border border-gray-700 rounded-xl shadow-2xl w-full max-w-lg overflow-y-auto max-h-[90vh]">
+            <GenreForm
+              genre={editingGenre}
+              onSave={handleSaveGenre}
+              onCancel={() => {
+                setShowGenreForm(false)
+                setEditingGenre(null)
+              }}
+            />
+          </div>
+        </div>
+      )}
+
+      {isAdmin && showSeriesForm && (
+        <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4">
+          <div className="bg-gray-900 border border-gray-700 rounded-xl shadow-2xl w-full max-w-lg overflow-y-auto max-h-[90vh]">
+            <SeriesForm
+              series={editingSeries}
+              onSave={handleSaveSeries}
+              onCancel={() => {
+                setShowSeriesForm(false)
+                setEditingSeries(null)
+              }}
+            />
+          </div>
+        </div>
+      )}
+
+      {isAdmin && showArtistForm && (
+        <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4">
+          <div className="bg-gray-900 border border-gray-700 rounded-xl shadow-2xl w-full max-w-lg overflow-y-auto max-h-[90vh]">
+            <ArtistForm
+              artist={editingArtist}
+              onSave={handleSaveArtist}
+              onCancel={() => {
+                setShowArtistForm(false)
+                setEditingArtist(null)
               }}
             />
           </div>


### PR DESCRIPTION
All modal edit dialogs were direct children of the content block that was added for animation purposes for another ticket. This unfortunately caused these modal edit dialogs to center themselves over that div, even if that div was so long that it scrolled off the bottom of the screen.

This PR fixes the problem by extracting all modal edit dialogs out of that containing div, closer to the root of the component's return. A quick manual test confirms that this causes the dialogs to correctly center themselves in the browser window, regardless of the scroll position of the content div.

Additionally, found and fixed a bug specific to the Movie edit dialog, where overflow handling was not properly specified. This caused scrollbars to never appear even if the dialog was too large to fit in the browser window. Verified with manual test.

Closes #66 