### PR TITLE
Issue #33 implement the back-end for a playlist enqueue mechanism

### DIFF
--- a/backend/src/main/java/ca/corbett/movienight/controller/EpisodeController.java
+++ b/backend/src/main/java/ca/corbett/movienight/controller/EpisodeController.java
@@ -2,7 +2,6 @@ package ca.corbett.movienight.controller;
 
 import ca.corbett.movienight.model.Episode;
 import ca.corbett.movienight.service.EpisodeService;
-import ca.corbett.movienight.service.MediaService;
 import ca.corbett.movienight.service.ThumbnailService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
@@ -25,8 +24,8 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.io.File;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 
 @RestController
@@ -34,12 +33,10 @@ import java.util.List;
 @CrossOrigin(origins = "http://localhost:5173")
 public class EpisodeController {
 
-    private final MediaService mediaService;
     private final EpisodeService episodeService;
     private final ThumbnailService thumbnailService;
 
-    public EpisodeController(MediaService mediaService, EpisodeService episodeService, ThumbnailService thumbnailService) {
-        this.mediaService = mediaService;
+    public EpisodeController(EpisodeService episodeService, ThumbnailService thumbnailService) {
         this.episodeService = episodeService;
         this.thumbnailService = thumbnailService;
     }
@@ -63,22 +60,20 @@ public class EpisodeController {
     public ResponseEntity<String> getPlaylist(@RequestParam(required = false) Long seriesId,
                                               @RequestParam(required = false) String seriesName,
                                               @RequestParam(required = false) Integer season,
-                                              @RequestParam(required = false) Integer episodeId,
+                                              @RequestParam(required = false) Integer episode,
                                               @RequestParam(required = false) String tag,
                                               HttpServletRequest request) {
-        List<Episode> episodes = episodeService.searchEpisodes(seriesId, seriesName, season, episodeId, tag);
+        List<Episode> episodes = episodeService.searchEpisodes(seriesId, seriesName, season, episode, tag);
         StringBuilder m3u = new StringBuilder();
         m3u.append("#EXTM3U\n");
-        for (Episode episode : episodes) {
-            String filePath = mediaService.findById(Long.toString(episode.getId()));
-            Path videoPath = Paths.get(filePath);
-            String fileName = videoPath.getFileName().toString();
+        for (Episode theEpisode : episodes) {
+            String fileName = new File(theEpisode.getVideoFilePath()).getName();
 
             // Build the stream URL pointing back to our existing streaming endpoint:
             String streamUrl = request.getScheme() + "://" +
                     request.getServerName() + ":" +
                     request.getServerPort() +
-                    "/api/stream/" + episode.getId();
+                    "/api/stream/E" + theEpisode.getId();
 
             // The M3U format is very straightforward:
             m3u.append("#EXTINF:-1,");

--- a/backend/src/main/java/ca/corbett/movienight/controller/EpisodeController.java
+++ b/backend/src/main/java/ca/corbett/movienight/controller/EpisodeController.java
@@ -2,10 +2,13 @@ package ca.corbett.movienight.controller;
 
 import ca.corbett.movienight.model.Episode;
 import ca.corbett.movienight.service.EpisodeService;
+import ca.corbett.movienight.service.MediaService;
 import ca.corbett.movienight.service.ThumbnailService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import org.springframework.core.io.PathResource;
 import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -23,6 +26,7 @@ import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 
 @RestController
@@ -30,14 +34,19 @@ import java.util.List;
 @CrossOrigin(origins = "http://localhost:5173")
 public class EpisodeController {
 
+    private final MediaService mediaService;
     private final EpisodeService episodeService;
     private final ThumbnailService thumbnailService;
 
-    public EpisodeController(EpisodeService episodeService, ThumbnailService thumbnailService) {
+    public EpisodeController(MediaService mediaService, EpisodeService episodeService, ThumbnailService thumbnailService) {
+        this.mediaService = mediaService;
         this.episodeService = episodeService;
         this.thumbnailService = thumbnailService;
     }
 
+    /**
+     * Returns a list of all episodes that match the provided (optional) search criteria.
+     */
     @GetMapping
     public List<Episode> getAllEpisodes(@RequestParam(required = false) Long seriesId,
                                         @RequestParam(required = false) String seriesName,
@@ -45,6 +54,45 @@ public class EpisodeController {
                                         @RequestParam(required = false) Integer episode,
                                         @RequestParam(required = false) String tag) {
         return episodeService.searchEpisodes(seriesId, seriesName, season, episode, tag);
+    }
+
+    /**
+     * Returns an m3u playlist containing all episodes that match the provided (optional) search criteria.
+     */
+    @GetMapping("/playlist")
+    public ResponseEntity<String> getPlaylist(@RequestParam(required = false) Long seriesId,
+                                              @RequestParam(required = false) String seriesName,
+                                              @RequestParam(required = false) Integer season,
+                                              @RequestParam(required = false) Integer episodeId,
+                                              @RequestParam(required = false) String tag,
+                                              HttpServletRequest request) {
+        List<Episode> episodes = episodeService.searchEpisodes(seriesId, seriesName, season, episodeId, tag);
+        StringBuilder m3u = new StringBuilder();
+        m3u.append("#EXTM3U\n");
+        for (Episode episode : episodes) {
+            String filePath = mediaService.findById(Long.toString(episode.getId()));
+            Path videoPath = Paths.get(filePath);
+            String fileName = videoPath.getFileName().toString();
+
+            // Build the stream URL pointing back to our existing streaming endpoint:
+            String streamUrl = request.getScheme() + "://" +
+                    request.getServerName() + ":" +
+                    request.getServerPort() +
+                    "/api/stream/" + episode.getId();
+
+            // The M3U format is very straightforward:
+            m3u.append("#EXTINF:-1,");
+            m3u.append(fileName);
+            m3u.append("\n");
+            m3u.append(streamUrl);
+            m3u.append("\n");
+        }
+
+        // VLC will be able to stream directly from our existing streaming endpoint:
+        return ResponseEntity.ok()
+                             .header(HttpHeaders.CONTENT_TYPE, "audio/x-mpegurl")
+                             .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"stream.m3u\"")
+                             .body(m3u.toString());
     }
 
     @GetMapping("/{id}")

--- a/backend/src/main/java/ca/corbett/movienight/controller/MovieController.java
+++ b/backend/src/main/java/ca/corbett/movienight/controller/MovieController.java
@@ -1,11 +1,14 @@
 package ca.corbett.movienight.controller;
 
 import ca.corbett.movienight.model.Movie;
+import ca.corbett.movienight.service.MediaService;
 import ca.corbett.movienight.service.MovieService;
 import ca.corbett.movienight.service.ThumbnailService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import org.springframework.core.io.PathResource;
 import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -23,6 +26,7 @@ import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 
 @RestController
@@ -30,19 +34,61 @@ import java.util.List;
 @CrossOrigin(origins = "http://localhost:5173")
 public class MovieController {
 
+    private final MediaService mediaService;
     private final MovieService movieService;
     private final ThumbnailService thumbnailService;
 
-    public MovieController(MovieService movieService, ThumbnailService thumbnailService) {
+    public MovieController(MediaService mediaService, MovieService movieService, ThumbnailService thumbnailService) {
+        this.mediaService = mediaService;
         this.movieService = movieService;
         this.thumbnailService = thumbnailService;
     }
 
+    /**
+     * Returns a list of all movies that match the provided (optional) search criteria.
+     */
     @GetMapping
     public List<Movie> getAllMovies(@RequestParam(required = false) String title,
                                    @RequestParam(required = false) String tag,
                                    @RequestParam(required = false) Long genreId) {
         return movieService.searchMovies(title, tag, genreId);
+    }
+
+    /**
+     * Returns an m3u playlist containing all movies that match the provided (optional) search criteria.
+     */
+    @GetMapping("/playlist")
+    public ResponseEntity<String> getPlaylist(@RequestParam(required = false) String title,
+                                              @RequestParam(required = false) String tag,
+                                              @RequestParam(required = false) Long genreId,
+                                              HttpServletRequest request) {
+        List<Movie> movies = movieService.searchMovies(title, tag, genreId);
+        StringBuilder m3u = new StringBuilder();
+        m3u.append("#EXTM3U\n");
+        for (Movie movie : movies) {
+            String filePath = mediaService.findById(Long.toString(movie.getId()));
+            Path videoPath = Paths.get(filePath);
+            String fileName = videoPath.getFileName().toString();
+
+            // Build the stream URL pointing back to our existing streaming endpoint:
+            String streamUrl = request.getScheme() + "://" +
+                    request.getServerName() + ":" +
+                    request.getServerPort() +
+                    "/api/stream/" + movie.getId();
+
+            // The M3U format is very straightforward:
+            m3u.append("#EXTINF:-1,");
+            m3u.append(fileName);
+            m3u.append("\n");
+            m3u.append(streamUrl);
+            m3u.append("\n");
+        }
+
+        // VLC will be able to stream directly from our existing streaming endpoint:
+        return ResponseEntity.ok()
+                             .header(HttpHeaders.CONTENT_TYPE, "audio/x-mpegurl")
+                             .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"stream.m3u\"")
+                             .body(m3u.toString());
     }
 
     @GetMapping("/{id}")

--- a/backend/src/main/java/ca/corbett/movienight/controller/MovieController.java
+++ b/backend/src/main/java/ca/corbett/movienight/controller/MovieController.java
@@ -1,7 +1,6 @@
 package ca.corbett.movienight.controller;
 
 import ca.corbett.movienight.model.Movie;
-import ca.corbett.movienight.service.MediaService;
 import ca.corbett.movienight.service.MovieService;
 import ca.corbett.movienight.service.ThumbnailService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -25,8 +24,8 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.io.File;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 
 @RestController
@@ -34,12 +33,10 @@ import java.util.List;
 @CrossOrigin(origins = "http://localhost:5173")
 public class MovieController {
 
-    private final MediaService mediaService;
     private final MovieService movieService;
     private final ThumbnailService thumbnailService;
 
-    public MovieController(MediaService mediaService, MovieService movieService, ThumbnailService thumbnailService) {
-        this.mediaService = mediaService;
+    public MovieController(MovieService movieService, ThumbnailService thumbnailService) {
         this.movieService = movieService;
         this.thumbnailService = thumbnailService;
     }
@@ -66,15 +63,13 @@ public class MovieController {
         StringBuilder m3u = new StringBuilder();
         m3u.append("#EXTM3U\n");
         for (Movie movie : movies) {
-            String filePath = mediaService.findById(Long.toString(movie.getId()));
-            Path videoPath = Paths.get(filePath);
-            String fileName = videoPath.getFileName().toString();
+            String fileName = new File(movie.getVideoFilePath()).getName();
 
             // Build the stream URL pointing back to our existing streaming endpoint:
             String streamUrl = request.getScheme() + "://" +
                     request.getServerName() + ":" +
                     request.getServerPort() +
-                    "/api/stream/" + movie.getId();
+                    "/api/stream/M" + movie.getId();
 
             // The M3U format is very straightforward:
             m3u.append("#EXTINF:-1,");

--- a/backend/src/main/java/ca/corbett/movienight/controller/MusicVideoController.java
+++ b/backend/src/main/java/ca/corbett/movienight/controller/MusicVideoController.java
@@ -1,7 +1,6 @@
 package ca.corbett.movienight.controller;
 
 import ca.corbett.movienight.model.MusicVideo;
-import ca.corbett.movienight.service.MediaService;
 import ca.corbett.movienight.service.MusicVideoService;
 import ca.corbett.movienight.service.ThumbnailService;
 import jakarta.servlet.http.HttpServletRequest;
@@ -25,8 +24,8 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.io.File;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 
 @RestController
@@ -34,12 +33,10 @@ import java.util.List;
 @CrossOrigin(origins = "http://localhost:5173")
 public class MusicVideoController {
 
-    private final MediaService mediaService;
     private final MusicVideoService musicVideoService;
     private final ThumbnailService thumbnailService;
 
-    public MusicVideoController(MediaService mediaService, MusicVideoService musicVideoService, ThumbnailService thumbnailService) {
-        this.mediaService = mediaService;
+    public MusicVideoController(MusicVideoService musicVideoService, ThumbnailService thumbnailService) {
         this.musicVideoService = musicVideoService;
         this.thumbnailService = thumbnailService;
     }
@@ -66,15 +63,13 @@ public class MusicVideoController {
         StringBuilder m3u = new StringBuilder();
         m3u.append("#EXTM3U\n");
         for (MusicVideo musicVideo : musicVideos) {
-            String filePath = mediaService.findById(Long.toString(musicVideo.getId()));
-            Path videoPath = Paths.get(filePath);
-            String fileName = videoPath.getFileName().toString();
+            String fileName = new File(musicVideo.getVideoFilePath()).getName();
 
             // Build the stream URL pointing back to our existing streaming endpoint:
             String streamUrl = request.getScheme() + "://" +
                     request.getServerName() + ":" +
                     request.getServerPort() +
-                    "/api/stream/" + musicVideo.getId();
+                    "/api/stream/V" + musicVideo.getId();
 
             // The M3U format is very straightforward:
             m3u.append("#EXTINF:-1,");

--- a/backend/src/main/java/ca/corbett/movienight/controller/MusicVideoController.java
+++ b/backend/src/main/java/ca/corbett/movienight/controller/MusicVideoController.java
@@ -1,11 +1,14 @@
 package ca.corbett.movienight.controller;
 
 import ca.corbett.movienight.model.MusicVideo;
+import ca.corbett.movienight.service.MediaService;
 import ca.corbett.movienight.service.MusicVideoService;
 import ca.corbett.movienight.service.ThumbnailService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import org.springframework.core.io.PathResource;
 import org.springframework.core.io.Resource;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -23,6 +26,7 @@ import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 
 @RestController
@@ -30,19 +34,61 @@ import java.util.List;
 @CrossOrigin(origins = "http://localhost:5173")
 public class MusicVideoController {
 
+    private final MediaService mediaService;
     private final MusicVideoService musicVideoService;
     private final ThumbnailService thumbnailService;
 
-    public MusicVideoController(MusicVideoService musicVideoService, ThumbnailService thumbnailService) {
+    public MusicVideoController(MediaService mediaService, MusicVideoService musicVideoService, ThumbnailService thumbnailService) {
+        this.mediaService = mediaService;
         this.musicVideoService = musicVideoService;
         this.thumbnailService = thumbnailService;
     }
 
+    /**
+     * Returns a list of all music videos that match the provided (optional) search criteria.
+     */
     @GetMapping
     public List<MusicVideo> getAllMusicVideos(@RequestParam(required = false) String title,
                                               @RequestParam(required = false) String tag,
                                               @RequestParam(required = false) Long artistId) {
         return musicVideoService.searchMusicVideos(title, tag, artistId);
+    }
+
+    /**
+     * Returns an m3u playlist containing all musicVideos that match the provided (optional) search criteria.
+     */
+    @GetMapping("/playlist")
+    public ResponseEntity<String> getPlaylist(@RequestParam(required = false) String title,
+                                              @RequestParam(required = false) String tag,
+                                              @RequestParam(required = false) Long artistId,
+                                              HttpServletRequest request) {
+        List<MusicVideo> musicVideos = musicVideoService.searchMusicVideos(title, tag, artistId);
+        StringBuilder m3u = new StringBuilder();
+        m3u.append("#EXTM3U\n");
+        for (MusicVideo musicVideo : musicVideos) {
+            String filePath = mediaService.findById(Long.toString(musicVideo.getId()));
+            Path videoPath = Paths.get(filePath);
+            String fileName = videoPath.getFileName().toString();
+
+            // Build the stream URL pointing back to our existing streaming endpoint:
+            String streamUrl = request.getScheme() + "://" +
+                    request.getServerName() + ":" +
+                    request.getServerPort() +
+                    "/api/stream/" + musicVideo.getId();
+
+            // The M3U format is very straightforward:
+            m3u.append("#EXTINF:-1,");
+            m3u.append(fileName);
+            m3u.append("\n");
+            m3u.append(streamUrl);
+            m3u.append("\n");
+        }
+
+        // VLC will be able to stream directly from our existing streaming endpoint:
+        return ResponseEntity.ok()
+                             .header(HttpHeaders.CONTENT_TYPE, "audio/x-mpegurl")
+                             .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"stream.m3u\"")
+                             .body(m3u.toString());
     }
 
     @GetMapping("/{id}")


### PR DESCRIPTION
This PR implements back-end support for a new playlist/enqueue mechanism. Previously, only individual media items could be downloaded in a playlist, via the "Watch in VLC" button. This PR introduces a new `playlist` endpoint for movies, episodes, and music videos, that will allow for the creation of a "Watch all in VLC" button to be displayed at the top of each search results page. 

Note: this PR **only** implements the back-end of this feature. The UI change to surface this to the user will be done in a separate PR.

Closes #33 