### PR TITLE
Issue #74 - add back-end support for fully local option

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -20,6 +20,9 @@
 
     <properties>
         <java.version>17</java.version>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>

--- a/backend/src/main/java/ca/corbett/movienight/config/SecurityConfig.java
+++ b/backend/src/main/java/ca/corbett/movienight/config/SecurityConfig.java
@@ -49,6 +49,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers("/", "/frontend/**", "/favicon.svg", "/error").permitAll()
+                        .requestMatchers("/api/runtime-config/**").access(adminAccess)
                         .requestMatchers(HttpMethod.GET, "/api/files/**").access(adminAccess)
                         .requestMatchers(HttpMethod.GET, "/api/**").permitAll()
                         .requestMatchers("/admin", "/admin/**").access(adminAccess)

--- a/backend/src/main/java/ca/corbett/movienight/controller/EpisodeController.java
+++ b/backend/src/main/java/ca/corbett/movienight/controller/EpisodeController.java
@@ -2,6 +2,8 @@ package ca.corbett.movienight.controller;
 
 import ca.corbett.movienight.model.Episode;
 import ca.corbett.movienight.service.EpisodeService;
+import ca.corbett.movienight.service.MediaService;
+import ca.corbett.movienight.service.RuntimeConfigService;
 import ca.corbett.movienight.service.ThumbnailService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
@@ -34,10 +36,17 @@ import java.util.List;
 public class EpisodeController {
 
     private final EpisodeService episodeService;
+    private final MediaService mediaService;
+    private final RuntimeConfigService runtimeConfigService;
     private final ThumbnailService thumbnailService;
 
-    public EpisodeController(EpisodeService episodeService, ThumbnailService thumbnailService) {
+    public EpisodeController(EpisodeService episodeService,
+                             MediaService mediaService,
+                             RuntimeConfigService runtimeConfigService,
+                             ThumbnailService thumbnailService) {
         this.episodeService = episodeService;
+        this.mediaService = mediaService;
+        this.runtimeConfigService = runtimeConfigService;
         this.thumbnailService = thumbnailService;
     }
 
@@ -68,18 +77,15 @@ public class EpisodeController {
         m3u.append("#EXTM3U\n");
         for (Episode theEpisode : episodes) {
             String fileName = new File(theEpisode.getVideoFilePath()).getName();
-
-            // Build the stream URL pointing back to our existing streaming endpoint:
-            String streamUrl = request.getScheme() + "://" +
-                    request.getServerName() + ":" +
-                    request.getServerPort() +
-                    "/api/stream/E" + theEpisode.getId();
+            String playlistTarget = runtimeConfigService.isFullyLocal()
+                    ? mediaService.resolveEpisodeFilePath(theEpisode.getVideoFilePath())
+                    : buildStreamUrl(request, "E" + theEpisode.getId());
 
             // The M3U format is very straightforward:
             m3u.append("#EXTINF:-1,");
             m3u.append(fileName);
             m3u.append("\n");
-            m3u.append(streamUrl);
+            m3u.append(playlistTarget);
             m3u.append("\n");
         }
 
@@ -88,6 +94,13 @@ public class EpisodeController {
                              .header(HttpHeaders.CONTENT_TYPE, "audio/x-mpegurl")
                              .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"stream.m3u\"")
                              .body(m3u.toString());
+    }
+
+    private String buildStreamUrl(HttpServletRequest request, String encodedId) {
+        return request.getScheme() + "://" +
+                request.getServerName() + ":" +
+                request.getServerPort() +
+                "/api/stream/" + encodedId;
     }
 
     @GetMapping("/{id}")

--- a/backend/src/main/java/ca/corbett/movienight/controller/MovieController.java
+++ b/backend/src/main/java/ca/corbett/movienight/controller/MovieController.java
@@ -1,7 +1,9 @@
 package ca.corbett.movienight.controller;
 
 import ca.corbett.movienight.model.Movie;
+import ca.corbett.movienight.service.MediaService;
 import ca.corbett.movienight.service.MovieService;
+import ca.corbett.movienight.service.RuntimeConfigService;
 import ca.corbett.movienight.service.ThumbnailService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
@@ -34,10 +36,17 @@ import java.util.List;
 public class MovieController {
 
     private final MovieService movieService;
+    private final MediaService mediaService;
+    private final RuntimeConfigService runtimeConfigService;
     private final ThumbnailService thumbnailService;
 
-    public MovieController(MovieService movieService, ThumbnailService thumbnailService) {
+    public MovieController(MovieService movieService,
+                           MediaService mediaService,
+                           RuntimeConfigService runtimeConfigService,
+                           ThumbnailService thumbnailService) {
         this.movieService = movieService;
+        this.mediaService = mediaService;
+        this.runtimeConfigService = runtimeConfigService;
         this.thumbnailService = thumbnailService;
     }
 
@@ -64,18 +73,15 @@ public class MovieController {
         m3u.append("#EXTM3U\n");
         for (Movie movie : movies) {
             String fileName = new File(movie.getVideoFilePath()).getName();
-
-            // Build the stream URL pointing back to our existing streaming endpoint:
-            String streamUrl = request.getScheme() + "://" +
-                    request.getServerName() + ":" +
-                    request.getServerPort() +
-                    "/api/stream/M" + movie.getId();
+            String playlistTarget = runtimeConfigService.isFullyLocal()
+                    ? mediaService.resolveMovieFilePath(movie.getVideoFilePath())
+                    : buildStreamUrl(request, "M" + movie.getId());
 
             // The M3U format is very straightforward:
             m3u.append("#EXTINF:-1,");
             m3u.append(fileName);
             m3u.append("\n");
-            m3u.append(streamUrl);
+            m3u.append(playlistTarget);
             m3u.append("\n");
         }
 
@@ -84,6 +90,13 @@ public class MovieController {
                              .header(HttpHeaders.CONTENT_TYPE, "audio/x-mpegurl")
                              .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"stream.m3u\"")
                              .body(m3u.toString());
+    }
+
+    private String buildStreamUrl(HttpServletRequest request, String encodedId) {
+        return request.getScheme() + "://" +
+                request.getServerName() + ":" +
+                request.getServerPort() +
+                "/api/stream/" + encodedId;
     }
 
     @GetMapping("/{id}")

--- a/backend/src/main/java/ca/corbett/movienight/controller/MusicVideoController.java
+++ b/backend/src/main/java/ca/corbett/movienight/controller/MusicVideoController.java
@@ -1,7 +1,9 @@
 package ca.corbett.movienight.controller;
 
 import ca.corbett.movienight.model.MusicVideo;
+import ca.corbett.movienight.service.MediaService;
 import ca.corbett.movienight.service.MusicVideoService;
+import ca.corbett.movienight.service.RuntimeConfigService;
 import ca.corbett.movienight.service.ThumbnailService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
@@ -34,10 +36,17 @@ import java.util.List;
 public class MusicVideoController {
 
     private final MusicVideoService musicVideoService;
+    private final MediaService mediaService;
+    private final RuntimeConfigService runtimeConfigService;
     private final ThumbnailService thumbnailService;
 
-    public MusicVideoController(MusicVideoService musicVideoService, ThumbnailService thumbnailService) {
+    public MusicVideoController(MusicVideoService musicVideoService,
+                                MediaService mediaService,
+                                RuntimeConfigService runtimeConfigService,
+                                ThumbnailService thumbnailService) {
         this.musicVideoService = musicVideoService;
+        this.mediaService = mediaService;
+        this.runtimeConfigService = runtimeConfigService;
         this.thumbnailService = thumbnailService;
     }
 
@@ -64,18 +73,15 @@ public class MusicVideoController {
         m3u.append("#EXTM3U\n");
         for (MusicVideo musicVideo : musicVideos) {
             String fileName = new File(musicVideo.getVideoFilePath()).getName();
-
-            // Build the stream URL pointing back to our existing streaming endpoint:
-            String streamUrl = request.getScheme() + "://" +
-                    request.getServerName() + ":" +
-                    request.getServerPort() +
-                    "/api/stream/V" + musicVideo.getId();
+            String playlistTarget = runtimeConfigService.isFullyLocal()
+                    ? mediaService.resolveMusicVideoFilePath(musicVideo.getVideoFilePath())
+                    : buildStreamUrl(request, "V" + musicVideo.getId());
 
             // The M3U format is very straightforward:
             m3u.append("#EXTINF:-1,");
             m3u.append(fileName);
             m3u.append("\n");
-            m3u.append(streamUrl);
+            m3u.append(playlistTarget);
             m3u.append("\n");
         }
 
@@ -84,6 +90,13 @@ public class MusicVideoController {
                              .header(HttpHeaders.CONTENT_TYPE, "audio/x-mpegurl")
                              .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"stream.m3u\"")
                              .body(m3u.toString());
+    }
+
+    private String buildStreamUrl(HttpServletRequest request, String encodedId) {
+        return request.getScheme() + "://" +
+                request.getServerName() + ":" +
+                request.getServerPort() +
+                "/api/stream/" + encodedId;
     }
 
     @GetMapping("/{id}")

--- a/backend/src/main/java/ca/corbett/movienight/controller/RuntimeConfigController.java
+++ b/backend/src/main/java/ca/corbett/movienight/controller/RuntimeConfigController.java
@@ -1,4 +1,5 @@
 package ca.corbett.movienight.controller;
+
 import ca.corbett.movienight.service.RuntimeConfigService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -9,18 +10,22 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
+
 @RestController
 @RequestMapping("/api/runtime-config")
 @CrossOrigin(origins = "http://localhost:5173")
 public class RuntimeConfigController {
     private final RuntimeConfigService runtimeConfigService;
+
     public RuntimeConfigController(RuntimeConfigService runtimeConfigService) {
         this.runtimeConfigService = runtimeConfigService;
     }
+
     @GetMapping("/fully-local")
     public FullyLocalResponse getFullyLocal() {
         return new FullyLocalResponse(runtimeConfigService.isFullyLocal());
     }
+
     @PutMapping("/fully-local")
     public ResponseEntity<FullyLocalResponse> setFullyLocal(@RequestBody FullyLocalUpdateRequest request) {
         if (request == null || request.fullyLocal() == null) {
@@ -29,8 +34,10 @@ public class RuntimeConfigController {
         boolean currentValue = runtimeConfigService.setFullyLocal(request.fullyLocal());
         return ResponseEntity.ok(new FullyLocalResponse(currentValue));
     }
+
     public record FullyLocalResponse(boolean fullyLocal) {
     }
+
     public record FullyLocalUpdateRequest(Boolean fullyLocal) {
     }
 }

--- a/backend/src/main/java/ca/corbett/movienight/controller/RuntimeConfigController.java
+++ b/backend/src/main/java/ca/corbett/movienight/controller/RuntimeConfigController.java
@@ -1,0 +1,36 @@
+package ca.corbett.movienight.controller;
+import ca.corbett.movienight.service.RuntimeConfigService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+@RestController
+@RequestMapping("/api/runtime-config")
+@CrossOrigin(origins = "http://localhost:5173")
+public class RuntimeConfigController {
+    private final RuntimeConfigService runtimeConfigService;
+    public RuntimeConfigController(RuntimeConfigService runtimeConfigService) {
+        this.runtimeConfigService = runtimeConfigService;
+    }
+    @GetMapping("/fully-local")
+    public FullyLocalResponse getFullyLocal() {
+        return new FullyLocalResponse(runtimeConfigService.isFullyLocal());
+    }
+    @PutMapping("/fully-local")
+    public ResponseEntity<FullyLocalResponse> setFullyLocal(@RequestBody FullyLocalUpdateRequest request) {
+        if (request == null || request.fullyLocal() == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "fullyLocal is required");
+        }
+        boolean currentValue = runtimeConfigService.setFullyLocal(request.fullyLocal());
+        return ResponseEntity.ok(new FullyLocalResponse(currentValue));
+    }
+    public record FullyLocalResponse(boolean fullyLocal) {
+    }
+    public record FullyLocalUpdateRequest(Boolean fullyLocal) {
+    }
+}

--- a/backend/src/main/java/ca/corbett/movienight/controller/StreamController.java
+++ b/backend/src/main/java/ca/corbett/movienight/controller/StreamController.java
@@ -1,6 +1,7 @@
 package ca.corbett.movienight.controller;
 
 import ca.corbett.movienight.service.MediaService;
+import ca.corbett.movienight.service.RuntimeConfigService;
 import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
@@ -37,6 +38,7 @@ public class StreamController {
     private static final MediaType DEFAULT_VIDEO_MEDIA_TYPE = MediaType.parseMediaType("video/mp4");
 
     private final MediaService mediaService;
+    private final RuntimeConfigService runtimeConfigService;
 
     @Value("${movienight.max-range-request-size-mb:32}")
     private int rangeRequestMaxChunkMB;
@@ -44,8 +46,9 @@ public class StreamController {
     @Value("${movienight.enable-vlc-integration:false}")
     private boolean enableVlcIntegration;
 
-    public StreamController(MediaService mediaService) {
+    public StreamController(MediaService mediaService, RuntimeConfigService runtimeConfigService) {
         this.mediaService = mediaService;
+        this.runtimeConfigService = runtimeConfigService;
     }
 
     @PostConstruct
@@ -186,20 +189,23 @@ public class StreamController {
                                               "Video file not found for media id: " + id);
         }
 
-        // Build the stream URL pointing back to our existing streaming endpoint:
-        String streamUrl = request.getScheme() + "://" +
-                request.getServerName() + ":" +
-                request.getServerPort() +
-                "/api/stream/" + id;
+        String playlistTarget = runtimeConfigService.isFullyLocal() ? filePath : buildStreamUrl(id, request);
 
         // The M3U format is very straightforward:
-        String m3u = "#EXTM3U\n#EXTINF:-1," + fileName + "\n" + streamUrl + "\n";
+        String m3u = "#EXTM3U\n#EXTINF:-1," + fileName + "\n" + playlistTarget + "\n";
 
         // VLC will be able to stream directly from our existing streaming endpoint:
         return ResponseEntity.ok()
                              .header(HttpHeaders.CONTENT_TYPE, "audio/x-mpegurl")
                              .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"stream.m3u\"")
                              .body(m3u);
+    }
+
+    private String buildStreamUrl(String id, HttpServletRequest request) {
+        return request.getScheme() + "://" +
+                request.getServerName() + ":" +
+                request.getServerPort() +
+                "/api/stream/" + id;
     }
 
     /**

--- a/backend/src/main/java/ca/corbett/movienight/service/MediaService.java
+++ b/backend/src/main/java/ca/corbett/movienight/service/MediaService.java
@@ -142,7 +142,7 @@ public class MediaService {
             movie.setWatchedRecently(true); // Set manually, since we know it's "true" even without date math
             movieRepository.save(movie); // Save via repository to avoid unnecessary filesystem overhead in the service
             logger.debug("Resolved media id {} to movie file path: {}", encodedId, path);
-            return new File(resolvedMovieDirectory, path).getAbsolutePath();
+            return resolveMovieFilePath(path);
         } else if (type == 'E') {
             Episode episode = episodeService.requireEpisode(numericId);
             String path = episode.getVideoFilePath();
@@ -150,7 +150,7 @@ public class MediaService {
             episode.setWatchedRecently(true);
             episodeRepository.save(episode);
             logger.debug("Resolved media id {} to episode file path: {}", encodedId, path);
-            return new File(resolvedEpisodeDirectory, path).getAbsolutePath();
+            return resolveEpisodeFilePath(path);
         } else if (type == 'V') {
             MusicVideo musicVideo = musicVideoService.requireMusicVideo(numericId);
             String path = musicVideo.getVideoFilePath();
@@ -158,11 +158,23 @@ public class MediaService {
             musicVideo.setWatchedRecently(true);
             musicVideoRepository.save(musicVideo);
             logger.debug("Resolved media id {} to music video file path: {}", encodedId, path);
-            return new File(resolvedMusicVideoDirectory, path).getAbsolutePath();
+            return resolveMusicVideoFilePath(path);
         } else {
             logger.warn("Unknown media type prefix '{}' in id: {}", type, encodedId);
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Unknown media type in id: " + encodedId);
         }
+    }
+
+    public String resolveMovieFilePath(String videoFilePath) {
+        return resolveAbsolutePath(resolvedMovieDirectory, videoFilePath);
+    }
+
+    public String resolveEpisodeFilePath(String videoFilePath) {
+        return resolveAbsolutePath(resolvedEpisodeDirectory, videoFilePath);
+    }
+
+    public String resolveMusicVideoFilePath(String videoFilePath) {
+        return resolveAbsolutePath(resolvedMusicVideoDirectory, videoFilePath);
     }
 
     /**
@@ -186,6 +198,10 @@ public class MediaService {
                                               "Can't read " + propName + " directory: " + resolvedDirectory);
         }
         return resolvedDirectory;
+    }
+
+    private String resolveAbsolutePath(File mediaDirectory, String videoFilePath) {
+        return new File(mediaDirectory, videoFilePath).getAbsolutePath();
     }
 
     public void setMovieDirectory(String movieDirectory) {

--- a/backend/src/main/java/ca/corbett/movienight/service/RuntimeConfigService.java
+++ b/backend/src/main/java/ca/corbett/movienight/service/RuntimeConfigService.java
@@ -1,0 +1,36 @@
+package ca.corbett.movienight.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@Service
+public class RuntimeConfigService {
+
+    private static final Logger logger = LoggerFactory.getLogger(RuntimeConfigService.class);
+
+    private final AtomicBoolean fullyLocal;
+
+    public RuntimeConfigService(@Value("${movienight.fully_local:false}") boolean fullyLocalDefault) {
+        this.fullyLocal = new AtomicBoolean(fullyLocalDefault);
+        logger.info("Runtime config initialized: movienight.fully_local={}", fullyLocalDefault);
+    }
+
+    public boolean isFullyLocal() {
+        return fullyLocal.get();
+    }
+
+    public boolean setFullyLocal(boolean newValue) {
+        boolean previousValue = fullyLocal.getAndSet(newValue);
+        if (previousValue != newValue) {
+            logger.info("Runtime config updated: movienight.fully_local {} -> {}", previousValue, newValue);
+        } else {
+            logger.debug("Runtime config unchanged: movienight.fully_local remains {}", newValue);
+        }
+        return newValue;
+    }
+}
+

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -47,6 +47,12 @@ movienight.max-range-request-size-mb=32
 # If enabled, this supplements the inline video player, it doesn't replace it.
 movienight.enable-vlc-integration=false
 
+# Controls whether playlist files should point to MovieNight streaming URLs or to
+# absolute filesystem paths. This property only provides the startup default; the
+# live value can be changed later via the admin runtime-config API.
+# This is only used if enable-vlc-integration is true.
+movienight.fully_local=false
+
 # Here you can set directory prefixes for your media collections.
 # All paths will be stored in MovieNight relative to these prefixes.
 #   Example prefix: /mnt/storage/videos

--- a/backend/src/test/java/ca/corbett/movienight/EpisodeRepositoryTest.java
+++ b/backend/src/test/java/ca/corbett/movienight/EpisodeRepositoryTest.java
@@ -124,7 +124,7 @@ class EpisodeRepositoryTest {
         Specification<Episode> spec = (root, query, cb) ->
                 cb.equal(root.get("series"), dexter);
         Sort sort = Sort.by(Sort.Direction.ASC, "season")
-                .and(Sort.by(Sort.Direction.ASC, "episode"));
+                        .and(Sort.by(Sort.Direction.ASC, "episode"));
 
         List<Episode> results = episodeRepository.findAll(spec, sort);
         assertThat(results).hasSize(4);

--- a/backend/src/test/java/ca/corbett/movienight/MediaServiceTest.java
+++ b/backend/src/test/java/ca/corbett/movienight/MediaServiceTest.java
@@ -166,7 +166,7 @@ class MediaServiceTest {
     void throwsBadRequestForNullId() {
         assertThatThrownBy(() -> mediaService.findById(null))
                 .isInstanceOf(ResponseStatusException.class)
-                .satisfies(e -> assertThat(((ResponseStatusException) e).getStatusCode().value())
+                .satisfies(e -> assertThat(((ResponseStatusException)e).getStatusCode().value())
                         .isEqualTo(HttpStatus.BAD_REQUEST.value()));
     }
 
@@ -174,7 +174,7 @@ class MediaServiceTest {
     void throwsBadRequestForTooShortId() {
         assertThatThrownBy(() -> mediaService.findById("M"))
                 .isInstanceOf(ResponseStatusException.class)
-                .satisfies(e -> assertThat(((ResponseStatusException) e).getStatusCode().value())
+                .satisfies(e -> assertThat(((ResponseStatusException)e).getStatusCode().value())
                         .isEqualTo(HttpStatus.BAD_REQUEST.value()));
     }
 
@@ -182,7 +182,7 @@ class MediaServiceTest {
     void throwsBadRequestForNonNumericId() {
         assertThatThrownBy(() -> mediaService.findById("Mabc"))
                 .isInstanceOf(ResponseStatusException.class)
-                .satisfies(e -> assertThat(((ResponseStatusException) e).getStatusCode().value())
+                .satisfies(e -> assertThat(((ResponseStatusException)e).getStatusCode().value())
                         .isEqualTo(HttpStatus.BAD_REQUEST.value()));
     }
 
@@ -190,7 +190,7 @@ class MediaServiceTest {
     void throwsBadRequestForUnknownTypePrefix() {
         assertThatThrownBy(() -> mediaService.findById("X99"))
                 .isInstanceOf(ResponseStatusException.class)
-                .satisfies(e -> assertThat(((ResponseStatusException) e).getStatusCode().value())
+                .satisfies(e -> assertThat(((ResponseStatusException)e).getStatusCode().value())
                         .isEqualTo(HttpStatus.BAD_REQUEST.value()));
     }
 
@@ -201,7 +201,7 @@ class MediaServiceTest {
 
         assertThatThrownBy(() -> mediaService.findById("M999"))
                 .isInstanceOf(ResponseStatusException.class)
-                .satisfies(e -> assertThat(((ResponseStatusException) e).getStatusCode().value())
+                .satisfies(e -> assertThat(((ResponseStatusException)e).getStatusCode().value())
                         .isEqualTo(HttpStatus.NOT_FOUND.value()));
     }
 
@@ -212,7 +212,7 @@ class MediaServiceTest {
 
         assertThatThrownBy(() -> mediaService.findById("E888"))
                 .isInstanceOf(ResponseStatusException.class)
-                .satisfies(e -> assertThat(((ResponseStatusException) e).getStatusCode().value())
+                .satisfies(e -> assertThat(((ResponseStatusException)e).getStatusCode().value())
                         .isEqualTo(HttpStatus.NOT_FOUND.value()));
     }
 }

--- a/backend/src/test/java/ca/corbett/movienight/MediaServiceTest.java
+++ b/backend/src/test/java/ca/corbett/movienight/MediaServiceTest.java
@@ -142,6 +142,27 @@ class MediaServiceTest {
     }
 
     @Test
+    void resolvesMovieFilePathWithoutUpdatingWatchState() {
+        String path = mediaService.resolveMovieFilePath("nested/test_movie.mp4");
+
+        assertThat(path).isEqualTo(new File(tempDir, "movies/nested/test_movie.mp4").getAbsolutePath());
+    }
+
+    @Test
+    void resolvesEpisodeFilePathWithoutUpdatingWatchState() {
+        String path = mediaService.resolveEpisodeFilePath("shows/season1/s01e01.mp4");
+
+        assertThat(path).isEqualTo(new File(tempDir, "episodes/shows/season1/s01e01.mp4").getAbsolutePath());
+    }
+
+    @Test
+    void resolvesMusicVideoFilePathWithoutUpdatingWatchState() {
+        String path = mediaService.resolveMusicVideoFilePath("artists/test_song.mp4");
+
+        assertThat(path).isEqualTo(new File(tempDir, "music/artists/test_song.mp4").getAbsolutePath());
+    }
+
+    @Test
     void throwsBadRequestForNullId() {
         assertThatThrownBy(() -> mediaService.findById(null))
                 .isInstanceOf(ResponseStatusException.class)

--- a/backend/src/test/java/ca/corbett/movienight/MovieRepositoryTest.java
+++ b/backend/src/test/java/ca/corbett/movienight/MovieRepositoryTest.java
@@ -149,7 +149,7 @@ class MovieRepositoryTest {
         // title contains "action", tag contains "blockbuster" → only m1
         Specification<Movie> spec = Specification
                 .<Movie>where((root, query, cb) ->
-                        cb.like(cb.lower(root.get("title")), "%action%"))
+                                      cb.like(cb.lower(root.get("title")), "%action%"))
                 .and((root, query, cb) -> {
                     query.distinct(true);
                     Join<Movie, String> tagsJoin = root.join("tags", JoinType.INNER);

--- a/backend/src/test/java/ca/corbett/movienight/MusicVideoRepositoryTest.java
+++ b/backend/src/test/java/ca/corbett/movienight/MusicVideoRepositoryTest.java
@@ -160,11 +160,11 @@ class MusicVideoRepositoryTest {
         List<MusicVideo> radioheadVideos = musicVideoRepository.findByArtist(radiohead);
 
         assertThat(beatlesVideos).hasSize(2)
-                .extracting(MusicVideo::getTitle)
-                .containsExactlyInAnyOrder("Come Together", "Hey Jude");
+                                 .extracting(MusicVideo::getTitle)
+                                 .containsExactlyInAnyOrder("Come Together", "Hey Jude");
         assertThat(queenVideos).hasSize(1)
-                .extracting(MusicVideo::getTitle)
-                .containsExactly("Bohemian Rhapsody");
+                               .extracting(MusicVideo::getTitle)
+                               .containsExactly("Bohemian Rhapsody");
         assertThat(radioheadVideos).isEmpty();
     }
 
@@ -183,7 +183,7 @@ class MusicVideoRepositoryTest {
         // title contains "come", tag contains "rock" → only mv1
         Specification<MusicVideo> spec = Specification
                 .<MusicVideo>where((root, query, cb) ->
-                        cb.like(cb.lower(root.get("title")), "%come%"))
+                                           cb.like(cb.lower(root.get("title")), "%come%"))
                 .and((root, query, cb) -> {
                     query.distinct(true);
                     Join<MusicVideo, String> tagsJoin = root.join("tags", JoinType.INNER);

--- a/backend/src/test/java/ca/corbett/movienight/RuntimeConfigControllerTest.java
+++ b/backend/src/test/java/ca/corbett/movienight/RuntimeConfigControllerTest.java
@@ -44,42 +44,42 @@ class RuntimeConfigControllerTest {
     @Test
     void getFullyLocal_returnsCurrentState() throws Exception {
         mockMvc.perform(get("/api/runtime-config/fully-local")
-                        .with(remoteAddr("127.0.0.1"))
-                        .with(httpBasic("admin", "secret")))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.fullyLocal").value(false));
+                                .with(remoteAddr("127.0.0.1"))
+                                .with(httpBasic("admin", "secret")))
+               .andExpect(status().isOk())
+               .andExpect(jsonPath("$.fullyLocal").value(false));
     }
 
     @Test
     void putFullyLocal_updatesCurrentState() throws Exception {
         mockMvc.perform(put("/api/runtime-config/fully-local")
-                        .with(remoteAddr("127.0.0.1"))
-                        .with(httpBasic("admin", "secret"))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {
-                                  "fullyLocal": true
-                                }
-                                """))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.fullyLocal").value(true));
+                                .with(remoteAddr("127.0.0.1"))
+                                .with(httpBasic("admin", "secret"))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                                                 {
+                                                   "fullyLocal": true
+                                                 }
+                                                 """))
+               .andExpect(status().isOk())
+               .andExpect(jsonPath("$.fullyLocal").value(true));
 
         mockMvc.perform(get("/api/runtime-config/fully-local")
-                        .with(remoteAddr("127.0.0.1"))
-                        .with(httpBasic("admin", "secret")))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.fullyLocal").value(true));
+                                .with(remoteAddr("127.0.0.1"))
+                                .with(httpBasic("admin", "secret")))
+               .andExpect(status().isOk())
+               .andExpect(jsonPath("$.fullyLocal").value(true));
     }
 
     @Test
     void putFullyLocal_requiresField() throws Exception {
         mockMvc.perform(put("/api/runtime-config/fully-local")
-                        .with(remoteAddr("127.0.0.1"))
-                        .with(httpBasic("admin", "secret"))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{}"))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.message").value("fullyLocal is required"));
+                                .with(remoteAddr("127.0.0.1"))
+                                .with(httpBasic("admin", "secret"))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("{}"))
+               .andExpect(status().isBadRequest())
+               .andExpect(jsonPath("$.message").value("fullyLocal is required"));
     }
 
     private static RequestPostProcessor remoteAddr(String remoteAddress) {

--- a/backend/src/test/java/ca/corbett/movienight/RuntimeConfigControllerTest.java
+++ b/backend/src/test/java/ca/corbett/movienight/RuntimeConfigControllerTest.java
@@ -1,0 +1,92 @@
+package ca.corbett.movienight;
+
+import ca.corbett.movienight.service.RuntimeConfigService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:sqlite:file:runtime-config-tests?mode=memory&cache=shared",
+        "spring.datasource.driver-class-name=org.sqlite.JDBC",
+        "spring.jpa.database-platform=org.hibernate.community.dialect.SQLiteDialect",
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "movienight.data-dir=",
+        "movienight.admin.username=admin",
+        "movienight.admin.password=secret"
+})
+class RuntimeConfigControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private RuntimeConfigService runtimeConfigService;
+
+    @BeforeEach
+    void setUp() {
+        runtimeConfigService.setFullyLocal(false);
+    }
+
+    @Test
+    void getFullyLocal_returnsCurrentState() throws Exception {
+        mockMvc.perform(get("/api/runtime-config/fully-local")
+                        .with(remoteAddr("127.0.0.1"))
+                        .with(httpBasic("admin", "secret")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.fullyLocal").value(false));
+    }
+
+    @Test
+    void putFullyLocal_updatesCurrentState() throws Exception {
+        mockMvc.perform(put("/api/runtime-config/fully-local")
+                        .with(remoteAddr("127.0.0.1"))
+                        .with(httpBasic("admin", "secret"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "fullyLocal": true
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.fullyLocal").value(true));
+
+        mockMvc.perform(get("/api/runtime-config/fully-local")
+                        .with(remoteAddr("127.0.0.1"))
+                        .with(httpBasic("admin", "secret")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.fullyLocal").value(true));
+    }
+
+    @Test
+    void putFullyLocal_requiresField() throws Exception {
+        mockMvc.perform(put("/api/runtime-config/fully-local")
+                        .with(remoteAddr("127.0.0.1"))
+                        .with(httpBasic("admin", "secret"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("fullyLocal is required"));
+    }
+
+    private static RequestPostProcessor remoteAddr(String remoteAddress) {
+        return request -> {
+            request.setRemoteAddr(remoteAddress);
+            return request;
+        };
+    }
+}
+

--- a/backend/src/test/java/ca/corbett/movienight/SecurityIntegrationTest.java
+++ b/backend/src/test/java/ca/corbett/movienight/SecurityIntegrationTest.java
@@ -14,6 +14,7 @@ import static org.hamcrest.Matchers.not;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -50,6 +51,45 @@ class SecurityIntegrationTest {
                         .with(remoteAddr("127.0.0.1"))
                         .with(httpBasic("admin", "secret")))
                 .andExpect(status().isOk());
+    }
+
+    @Test
+    void runtimeConfigEndpointsRequireLocalhostAndAuth() throws Exception {
+        mockMvc.perform(get("/api/runtime-config/fully-local")
+                        .with(remoteAddr("127.0.0.1")))
+                .andExpect(status().isUnauthorized());
+
+        mockMvc.perform(get("/api/runtime-config/fully-local")
+                        .with(remoteAddr("192.168.1.50"))
+                        .with(httpBasic("admin", "secret")))
+                .andExpect(status().isForbidden());
+
+        mockMvc.perform(get("/api/runtime-config/fully-local")
+                        .with(remoteAddr("127.0.0.1"))
+                        .with(httpBasic("admin", "secret")))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.fullyLocal").value(false));
+
+        mockMvc.perform(put("/api/runtime-config/fully-local")
+                        .with(remoteAddr("127.0.0.1"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"fullyLocal\":true}"))
+                .andExpect(status().isUnauthorized());
+
+        mockMvc.perform(put("/api/runtime-config/fully-local")
+                        .with(remoteAddr("192.168.1.50"))
+                        .with(httpBasic("admin", "secret"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"fullyLocal\":true}"))
+                .andExpect(status().isForbidden());
+
+        mockMvc.perform(put("/api/runtime-config/fully-local")
+                        .with(remoteAddr("127.0.0.1"))
+                        .with(httpBasic("admin", "secret"))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"fullyLocal\":true}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.fullyLocal").value(true));
     }
 
     @Test

--- a/backend/src/test/java/ca/corbett/movienight/SecurityIntegrationTest.java
+++ b/backend/src/test/java/ca/corbett/movienight/SecurityIntegrationTest.java
@@ -38,58 +38,58 @@ class SecurityIntegrationTest {
     @Test
     void publicReadEndpointsRemainOpen() throws Exception {
         mockMvc.perform(get("/api/movies"))
-                .andExpect(status().isOk())
-                .andExpect(header().string("X-Correlation-Id", not(blankOrNullString())));
+               .andExpect(status().isOk())
+               .andExpect(header().string("X-Correlation-Id", not(blankOrNullString())));
     }
 
     @Test
     void adminRouteRequiresBasicAuthFromLocalhost() throws Exception {
         mockMvc.perform(get("/admin").with(remoteAddr("127.0.0.1")))
-                .andExpect(status().isUnauthorized());
+               .andExpect(status().isUnauthorized());
 
         mockMvc.perform(get("/admin")
-                        .with(remoteAddr("127.0.0.1"))
-                        .with(httpBasic("admin", "secret")))
-                .andExpect(status().isOk());
+                                .with(remoteAddr("127.0.0.1"))
+                                .with(httpBasic("admin", "secret")))
+               .andExpect(status().isOk());
     }
 
     @Test
     void runtimeConfigEndpointsRequireLocalhostAndAuth() throws Exception {
         mockMvc.perform(get("/api/runtime-config/fully-local")
-                        .with(remoteAddr("127.0.0.1")))
-                .andExpect(status().isUnauthorized());
+                                .with(remoteAddr("127.0.0.1")))
+               .andExpect(status().isUnauthorized());
 
         mockMvc.perform(get("/api/runtime-config/fully-local")
-                        .with(remoteAddr("192.168.1.50"))
-                        .with(httpBasic("admin", "secret")))
-                .andExpect(status().isForbidden());
+                                .with(remoteAddr("192.168.1.50"))
+                                .with(httpBasic("admin", "secret")))
+               .andExpect(status().isForbidden());
 
         mockMvc.perform(get("/api/runtime-config/fully-local")
-                        .with(remoteAddr("127.0.0.1"))
-                        .with(httpBasic("admin", "secret")))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.fullyLocal").value(false));
+                                .with(remoteAddr("127.0.0.1"))
+                                .with(httpBasic("admin", "secret")))
+               .andExpect(status().isOk())
+               .andExpect(jsonPath("$.fullyLocal").value(false));
 
         mockMvc.perform(put("/api/runtime-config/fully-local")
-                        .with(remoteAddr("127.0.0.1"))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"fullyLocal\":true}"))
-                .andExpect(status().isUnauthorized());
+                                .with(remoteAddr("127.0.0.1"))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("{\"fullyLocal\":true}"))
+               .andExpect(status().isUnauthorized());
 
         mockMvc.perform(put("/api/runtime-config/fully-local")
-                        .with(remoteAddr("192.168.1.50"))
-                        .with(httpBasic("admin", "secret"))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"fullyLocal\":true}"))
-                .andExpect(status().isForbidden());
+                                .with(remoteAddr("192.168.1.50"))
+                                .with(httpBasic("admin", "secret"))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("{\"fullyLocal\":true}"))
+               .andExpect(status().isForbidden());
 
         mockMvc.perform(put("/api/runtime-config/fully-local")
-                        .with(remoteAddr("127.0.0.1"))
-                        .with(httpBasic("admin", "secret"))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"fullyLocal\":true}"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.fullyLocal").value(true));
+                                .with(remoteAddr("127.0.0.1"))
+                                .with(httpBasic("admin", "secret"))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("{\"fullyLocal\":true}"))
+               .andExpect(status().isOk())
+               .andExpect(jsonPath("$.fullyLocal").value(true));
     }
 
     @Test
@@ -107,49 +107,49 @@ class SecurityIntegrationTest {
                 """;
 
         mockMvc.perform(post("/api/movies")
-                        .with(remoteAddr("127.0.0.1"))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(movieJson))
-                .andExpect(status().isUnauthorized());
+                                .with(remoteAddr("127.0.0.1"))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(movieJson))
+               .andExpect(status().isUnauthorized());
 
         mockMvc.perform(post("/api/movies")
-                        .with(remoteAddr("192.168.1.50"))
-                        .with(httpBasic("admin", "secret"))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(movieJson))
-                .andExpect(status().isForbidden());
+                                .with(remoteAddr("192.168.1.50"))
+                                .with(httpBasic("admin", "secret"))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(movieJson))
+               .andExpect(status().isForbidden());
 
         mockMvc.perform(post("/api/movies")
-                        .with(remoteAddr("127.0.0.1"))
-                        .with(httpBasic("admin", "secret"))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(movieJson))
-                .andExpect(status().isCreated());
+                                .with(remoteAddr("127.0.0.1"))
+                                .with(httpBasic("admin", "secret"))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(movieJson))
+               .andExpect(status().isCreated());
     }
 
     @Test
     void echoesIncomingCorrelationId() throws Exception {
         mockMvc.perform(get("/api/movies")
-                        .header("X-Correlation-Id", "test-correlation-id"))
-                .andExpect(status().isOk())
-                .andExpect(header().string("X-Correlation-Id", "test-correlation-id"));
+                                .header("X-Correlation-Id", "test-correlation-id"))
+               .andExpect(status().isOk())
+               .andExpect(header().string("X-Correlation-Id", "test-correlation-id"));
     }
 
     @Test
     void validationErrorsUseStandardErrorResponse() throws Exception {
         mockMvc.perform(post("/api/movies")
-                        .with(remoteAddr("127.0.0.1"))
-                        .with(httpBasic("admin", "secret"))
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("{}"))
-                .andExpect(status().isBadRequest())
-                .andExpect(header().string("X-Correlation-Id", not(blankOrNullString())))
-                .andExpect(jsonPath("$.status").value(400))
-                .andExpect(jsonPath("$.error").value("Bad Request"))
-                .andExpect(jsonPath("$.message").value("Validation failed"))
-                .andExpect(jsonPath("$.path").value("/api/movies"))
-                .andExpect(jsonPath("$.correlationId").value(not(blankOrNullString())))
-                .andExpect(jsonPath("$.details[0]").exists());
+                                .with(remoteAddr("127.0.0.1"))
+                                .with(httpBasic("admin", "secret"))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("{}"))
+               .andExpect(status().isBadRequest())
+               .andExpect(header().string("X-Correlation-Id", not(blankOrNullString())))
+               .andExpect(jsonPath("$.status").value(400))
+               .andExpect(jsonPath("$.error").value("Bad Request"))
+               .andExpect(jsonPath("$.message").value("Validation failed"))
+               .andExpect(jsonPath("$.path").value("/api/movies"))
+               .andExpect(jsonPath("$.correlationId").value(not(blankOrNullString())))
+               .andExpect(jsonPath("$.details[0]").exists());
     }
 
     private static RequestPostProcessor remoteAddr(String remoteAddress) {

--- a/backend/src/test/java/ca/corbett/movienight/SecurityIntegrationWithoutLocalhostOnlyTest.java
+++ b/backend/src/test/java/ca/corbett/movienight/SecurityIntegrationWithoutLocalhostOnlyTest.java
@@ -10,7 +10,10 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.RequestPostProcessor;
 
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
@@ -75,6 +78,23 @@ public class SecurityIntegrationWithoutLocalhostOnlyTest {
                                 .content(movieJson))
                .andExpect(status().isUnauthorized());
     }
+
+                                    @Test
+                                    void runtimeConfigEndpointsAllowAnyRemoteAddressWithAuth() throws Exception {
+                                        mockMvc.perform(get("/api/runtime-config/fully-local")
+                                                        .with(remoteAddr("192.168.1.50"))
+                                                        .with(httpBasic("admin", "secret")))
+                                                .andExpect(status().isOk())
+                                                .andExpect(jsonPath("$.fullyLocal").value(false));
+
+                                        mockMvc.perform(put("/api/runtime-config/fully-local")
+                                                        .with(remoteAddr("192.168.1.50"))
+                                                        .with(httpBasic("admin", "secret"))
+                                                        .contentType(MediaType.APPLICATION_JSON)
+                                                        .content("{\"fullyLocal\":true}"))
+                                                .andExpect(status().isOk())
+                                                .andExpect(jsonPath("$.fullyLocal").value(true));
+                                    }
 
     private static RequestPostProcessor remoteAddr(String remoteAddress) {
         return request -> {

--- a/backend/src/test/java/ca/corbett/movienight/SecurityIntegrationWithoutLocalhostOnlyTest.java
+++ b/backend/src/test/java/ca/corbett/movienight/SecurityIntegrationWithoutLocalhostOnlyTest.java
@@ -79,22 +79,18 @@ public class SecurityIntegrationWithoutLocalhostOnlyTest {
                .andExpect(status().isUnauthorized());
     }
 
-                                    @Test
-                                    void runtimeConfigEndpointsAllowAnyRemoteAddressWithAuth() throws Exception {
-                                        mockMvc.perform(get("/api/runtime-config/fully-local")
-                                                        .with(remoteAddr("192.168.1.50"))
-                                                        .with(httpBasic("admin", "secret")))
-                                                .andExpect(status().isOk())
-                                                .andExpect(jsonPath("$.fullyLocal").value(false));
+    @Test
+    void runtimeConfigEndpointsAllowAnyRemoteAddressWithAuth() throws Exception {
+        mockMvc.perform(get("/api/runtime-config/fully-local").with(remoteAddr("192.168.1.50"))
+                                                              .with(httpBasic("admin", "secret")))
+               .andExpect(status().isOk()).andExpect(jsonPath("$.fullyLocal").value(false));
 
-                                        mockMvc.perform(put("/api/runtime-config/fully-local")
-                                                        .with(remoteAddr("192.168.1.50"))
-                                                        .with(httpBasic("admin", "secret"))
-                                                        .contentType(MediaType.APPLICATION_JSON)
-                                                        .content("{\"fullyLocal\":true}"))
-                                                .andExpect(status().isOk())
-                                                .andExpect(jsonPath("$.fullyLocal").value(true));
-                                    }
+        mockMvc.perform(put("/api/runtime-config/fully-local").with(remoteAddr("192.168.1.50"))
+                                                              .with(httpBasic("admin", "secret"))
+                                                              .contentType(MediaType.APPLICATION_JSON)
+                                                              .content("{\"fullyLocal\":true}"))
+               .andExpect(status().isOk()).andExpect(jsonPath("$.fullyLocal").value(true));
+    }
 
     private static RequestPostProcessor remoteAddr(String remoteAddress) {
         return request -> {

--- a/backend/src/test/java/ca/corbett/movienight/StreamControllerTest.java
+++ b/backend/src/test/java/ca/corbett/movienight/StreamControllerTest.java
@@ -67,69 +67,69 @@ class StreamControllerTest {
     @Test
     void fullFileRequest_returns200() throws Exception {
         mockMvc.perform(get("/api/stream/M1"))
-                .andExpect(status().isOk());
+               .andExpect(status().isOk());
     }
 
     @Test
     void fullFileRequest_hasAcceptRangesHeader() throws Exception {
         mockMvc.perform(get("/api/stream/M1"))
-                .andExpect(status().isOk())
-                .andExpect(header().string("Accept-Ranges", "bytes"));
+               .andExpect(status().isOk())
+               .andExpect(header().string("Accept-Ranges", "bytes"));
     }
 
     @Test
     void fullFileRequest_hasVideoMp4ContentType() throws Exception {
         mockMvc.perform(get("/api/stream/M1"))
-                .andExpect(status().isOk())
-                .andExpect(content().contentTypeCompatibleWith("video/mp4"));
+               .andExpect(status().isOk())
+               .andExpect(content().contentTypeCompatibleWith("video/mp4"));
     }
 
     @Test
     void fullFileRequest_returnsEntireFileBody() throws Exception {
         mockMvc.perform(get("/api/stream/M1"))
-                .andExpect(status().isOk())
-                .andExpect(content().bytes(VIDEO_CONTENT));
+               .andExpect(status().isOk())
+               .andExpect(content().bytes(VIDEO_CONTENT));
     }
 
     @Test
     void rangeRequest_returns206() throws Exception {
         mockMvc.perform(get("/api/stream/M1")
-                        .header("Range", "bytes=0-9"))
-                .andExpect(status().isPartialContent());
+                                .header("Range", "bytes=0-9"))
+               .andExpect(status().isPartialContent());
     }
 
     @Test
     void rangeRequest_hasAcceptRangesHeader() throws Exception {
         mockMvc.perform(get("/api/stream/M1")
-                        .header("Range", "bytes=0-9"))
-                .andExpect(status().isPartialContent())
-                .andExpect(header().string("Accept-Ranges", "bytes"));
+                                .header("Range", "bytes=0-9"))
+               .andExpect(status().isPartialContent())
+               .andExpect(header().string("Accept-Ranges", "bytes"));
     }
 
     @Test
     void rangeRequest_hasContentRangeHeader() throws Exception {
         mockMvc.perform(get("/api/stream/M1")
-                        .header("Range", "bytes=0-9"))
-                .andExpect(status().isPartialContent())
-                .andExpect(header().string("Content-Range",
-                        containsString("bytes 0-9/" + VIDEO_CONTENT.length)));
+                                .header("Range", "bytes=0-9"))
+               .andExpect(status().isPartialContent())
+               .andExpect(header().string("Content-Range",
+                                          containsString("bytes 0-9/" + VIDEO_CONTENT.length)));
     }
 
     @Test
     void rangeRequest_returnsCorrectBytes() throws Exception {
         mockMvc.perform(get("/api/stream/M1")
-                        .header("Range", "bytes=0-9"))
-                .andExpect(status().isPartialContent())
-                .andExpect(content().bytes("ABCDEFGHIJ".getBytes()));
+                                .header("Range", "bytes=0-9"))
+               .andExpect(status().isPartialContent())
+               .andExpect(content().bytes("ABCDEFGHIJ".getBytes()));
     }
 
     @Test
     void rangeRequest_midFile_returnsCorrectBytes() throws Exception {
         // bytes=10-14 → "KLMNO"
         mockMvc.perform(get("/api/stream/M1")
-                        .header("Range", "bytes=10-14"))
-                .andExpect(status().isPartialContent())
-                .andExpect(content().bytes("KLMNO".getBytes()));
+                                .header("Range", "bytes=10-14"))
+               .andExpect(status().isPartialContent())
+               .andExpect(content().bytes("KLMNO".getBytes()));
     }
 
     @Test
@@ -138,7 +138,7 @@ class StreamControllerTest {
         when(mediaService.findById("M2")).thenReturn(nonexistent.toString());
 
         mockMvc.perform(get("/api/stream/M2"))
-                .andExpect(status().isNotFound());
+               .andExpect(status().isNotFound());
     }
 
     @Test
@@ -147,7 +147,7 @@ class StreamControllerTest {
                 .thenThrow(new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid media id: bad"));
 
         mockMvc.perform(get("/api/stream/bad"))
-                .andExpect(status().isBadRequest());
+               .andExpect(status().isBadRequest());
     }
 
     @Test
@@ -156,52 +156,52 @@ class StreamControllerTest {
                 .thenThrow(new ResponseStatusException(HttpStatus.NOT_FOUND, "Movie not found with id: 999"));
 
         mockMvc.perform(get("/api/stream/M999"))
-                .andExpect(status().isNotFound());
+               .andExpect(status().isNotFound());
     }
 
     @Test
     void rangeRequest_openEnded_returnsBytesToEndOfFile() throws Exception {
         mockMvc.perform(get("/api/stream/M1")
-                        .header("Range", "bytes=10-"))
-                .andExpect(status().isPartialContent())
-                .andExpect(header().string("Content-Range",
-                        containsString("bytes 10-25/" + VIDEO_CONTENT.length)))
-                .andExpect(content().bytes("KLMNOPQRSTUVWXYZ".getBytes()));
+                                .header("Range", "bytes=10-"))
+               .andExpect(status().isPartialContent())
+               .andExpect(header().string("Content-Range",
+                                          containsString("bytes 10-25/" + VIDEO_CONTENT.length)))
+               .andExpect(content().bytes("KLMNOPQRSTUVWXYZ".getBytes()));
     }
 
     @Test
     void rangeRequest_suffix_returnsLastBytes() throws Exception {
         mockMvc.perform(get("/api/stream/M1")
-                        .header("Range", "bytes=-5"))
-                .andExpect(status().isPartialContent())
-                .andExpect(header().string("Content-Range",
-                        containsString("bytes 21-25/" + VIDEO_CONTENT.length)))
-                .andExpect(content().bytes("VWXYZ".getBytes()));
+                                .header("Range", "bytes=-5"))
+               .andExpect(status().isPartialContent())
+               .andExpect(header().string("Content-Range",
+                                          containsString("bytes 21-25/" + VIDEO_CONTENT.length)))
+               .andExpect(content().bytes("VWXYZ".getBytes()));
     }
 
     @Test
     void rangeRequest_outOfBounds_returns416() throws Exception {
         mockMvc.perform(get("/api/stream/M1")
-                        .header("Range", "bytes=999-1000"))
-                .andExpect(status().isRequestedRangeNotSatisfiable())
-                .andExpect(header().string("Content-Range", "bytes */" + VIDEO_CONTENT.length));
+                                .header("Range", "bytes=999-1000"))
+               .andExpect(status().isRequestedRangeNotSatisfiable())
+               .andExpect(header().string("Content-Range", "bytes */" + VIDEO_CONTENT.length));
     }
 
     @Test
     void rangeRequest_hasExpectedContentLength() throws Exception {
         mockMvc.perform(get("/api/stream/M1")
-                        .header("Range", "bytes=10-14"))
-                .andExpect(status().isPartialContent())
-                .andExpect(header().string("Content-Length", "5"));
+                                .header("Range", "bytes=10-14"))
+               .andExpect(status().isPartialContent())
+               .andExpect(header().string("Content-Length", "5"));
     }
 
     @Test
     void playlistRequest_returnsStreamingUrlWhenFullyLocalDisabled() throws Exception {
         mockMvc.perform(get("/api/stream/M1/playlist")
-                        .with(server("media.local", 9090)))
-                .andExpect(status().isOk())
-                .andExpect(header().string("Content-Type", "audio/x-mpegurl"))
-                .andExpect(content().string("#EXTM3U\n#EXTINF:-1,test.mp4\nhttp://media.local:9090/api/stream/M1\n"));
+                                .with(server("media.local", 9090)))
+               .andExpect(status().isOk())
+               .andExpect(header().string("Content-Type", "audio/x-mpegurl"))
+               .andExpect(content().string("#EXTM3U\n#EXTINF:-1,test.mp4\nhttp://media.local:9090/api/stream/M1\n"));
     }
 
     @Test
@@ -209,10 +209,10 @@ class StreamControllerTest {
         runtimeConfigService.setFullyLocal(true);
 
         mockMvc.perform(get("/api/stream/M1/playlist")
-                        .with(server("media.local", 9090)))
-                .andExpect(status().isOk())
-                .andExpect(header().string("Content-Type", "audio/x-mpegurl"))
-                .andExpect(content().string("#EXTM3U\n#EXTINF:-1,test.mp4\n" + videoFile + "\n"));
+                                .with(server("media.local", 9090)))
+               .andExpect(status().isOk())
+               .andExpect(header().string("Content-Type", "audio/x-mpegurl"))
+               .andExpect(content().string("#EXTM3U\n#EXTINF:-1,test.mp4\n" + videoFile + "\n"));
     }
 
     @Test

--- a/backend/src/test/java/ca/corbett/movienight/StreamControllerTest.java
+++ b/backend/src/test/java/ca/corbett/movienight/StreamControllerTest.java
@@ -2,6 +2,7 @@ package ca.corbett.movienight;
 
 import ca.corbett.movienight.controller.StreamController;
 import ca.corbett.movienight.service.MediaService;
+import ca.corbett.movienight.service.RuntimeConfigService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -44,6 +45,9 @@ class StreamControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
+    @Autowired
+    private RuntimeConfigService runtimeConfigService;
+
     @MockBean
     private MediaService mediaService;
 
@@ -57,6 +61,7 @@ class StreamControllerTest {
         videoFile = tempDir.resolve("test.mp4");
         Files.write(videoFile, VIDEO_CONTENT);
         when(mediaService.findById("M1")).thenReturn(videoFile.toString());
+        runtimeConfigService.setFullyLocal(false);
     }
 
     @Test
@@ -191,6 +196,26 @@ class StreamControllerTest {
     }
 
     @Test
+    void playlistRequest_returnsStreamingUrlWhenFullyLocalDisabled() throws Exception {
+        mockMvc.perform(get("/api/stream/M1/playlist")
+                        .with(server("media.local", 9090)))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Content-Type", "audio/x-mpegurl"))
+                .andExpect(content().string("#EXTM3U\n#EXTINF:-1,test.mp4\nhttp://media.local:9090/api/stream/M1\n"));
+    }
+
+    @Test
+    void playlistRequest_returnsAbsolutePathWhenFullyLocalEnabled() throws Exception {
+        runtimeConfigService.setFullyLocal(true);
+
+        mockMvc.perform(get("/api/stream/M1/playlist")
+                        .with(server("media.local", 9090)))
+                .andExpect(status().isOk())
+                .andExpect(header().string("Content-Type", "audio/x-mpegurl"))
+                .andExpect(content().string("#EXTM3U\n#EXTINF:-1,test.mp4\n" + videoFile + "\n"));
+    }
+
+    @Test
     void getPrintableSize_returnsFormattedSizeStrings() {
         // GIVEN various byte values
         // WHEN we call getPrintableSize on the StreamController
@@ -203,5 +228,14 @@ class StreamControllerTest {
         assertEquals("1.5 MB", StreamController.getPrintableSize(1024 * 1024 + 512 * 1024));
         assertEquals("1.0 GB", StreamController.getPrintableSize(1024L * 1024 * 1024));
         assertEquals("2.5 GB", StreamController.getPrintableSize(2L * 1024 * 1024 * 1024 + 512L * 1024 * 1024));
+    }
+
+    private static org.springframework.test.web.servlet.request.RequestPostProcessor server(String serverName, int serverPort) {
+        return request -> {
+            request.setScheme("http");
+            request.setServerName(serverName);
+            request.setServerPort(serverPort);
+            return request;
+        };
     }
 }

--- a/backend/src/test/java/ca/corbett/movienight/ThumbnailServiceTest.java
+++ b/backend/src/test/java/ca/corbett/movienight/ThumbnailServiceTest.java
@@ -106,7 +106,7 @@ class ThumbnailServiceTest {
         // Only one thumbnail should exist after replacement
         int count = 0;
         for (String ext : new String[]{"jpg", "jpeg", "png"}) {
-            if (Files.exists(tempDir.resolve("movies").resolve("3." + ext))) count++;
+            if (Files.exists(tempDir.resolve("movies").resolve("3." + ext))) { count++; }
         }
         assertThat(count).isEqualTo(1);
         assertThat(thumbnailService.hasThumbnail("movies", 3L)).isTrue();
@@ -115,7 +115,7 @@ class ThumbnailServiceTest {
     @Test
     void rejectsInvalidImageData() {
         MockMultipartFile garbage = new MockMultipartFile("file", "bad.jpg", "image/jpeg",
-                "this is not an image".getBytes());
+                                                          "this is not an image".getBytes());
         assertThatThrownBy(() -> thumbnailService.saveThumbnail(garbage, "movies", 4L))
                 .hasMessageContaining("Unable to read image");
     }


### PR DESCRIPTION
This PR adds back-end support for the "fully local" playlist option described in issue #74 - if enabled (default false), this new option will cause all of the getPlaylist endpoints to return m3u playlists with fully-qualified filenames in it, instead of http streaming URLs. This is intended for the use case where the client browser is on the same physical machine as the server, or where the client browser has access to the same filesystem as the server.

This PR covers the back-end changes only! The UI changes will be handled in a separate PR.
