### PR TITLE
Issue #80 - fix bugs in thumbnail handling

### DIFF
--- a/backend/src/main/java/ca/corbett/movienight/api/handler/ThumbnailHandler.java
+++ b/backend/src/main/java/ca/corbett/movienight/api/handler/ThumbnailHandler.java
@@ -21,6 +21,7 @@ import java.net.HttpURLConnection;
 import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Map;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 /**
@@ -41,6 +42,8 @@ import java.util.stream.Collectors;
  * @author <a href="https://github.com/scorbo2">scorbo2</a>
  */
 public final class ThumbnailHandler implements HttpHandler {
+
+    private static final Logger log = Logger.getLogger(ThumbnailHandler.class.getName());
 
     private final AppConfig appConfig;
     private final Database database;
@@ -91,6 +94,7 @@ public final class ThumbnailHandler implements HttpHandler {
 
     private void handleGet(HttpExchange exchange, String path) throws Exception {
         String basePath = appConfig.getApiBasePath() + "thumbnails";
+        log.info("Handling GET thumbnail request for path: " + path);
 
         if (path.startsWith(basePath + "/media-items/")) {
             handleGetMediaItemThumbnail(exchange, path);
@@ -139,6 +143,7 @@ public final class ThumbnailHandler implements HttpHandler {
 
     private void handleCreate(HttpExchange exchange, String path) throws Exception {
         String basePath = appConfig.getApiBasePath() + "thumbnails";
+        log.info("Handling POST thumbnail request for path: " + path);
 
         if (path.startsWith(basePath + "/media-items/")) {
             handleCreateMediaItemThumbnail(exchange, path);
@@ -185,6 +190,7 @@ public final class ThumbnailHandler implements HttpHandler {
 
     private void handleReplace(HttpExchange exchange, String path) throws Exception {
         String basePath = appConfig.getApiBasePath() + "thumbnails";
+        log.info("Handling PUT thumbnail request for path: " + path);
 
         if (path.startsWith(basePath + "/media-items/")) {
             handleReplaceMediaItemThumbnail(exchange, path);
@@ -231,6 +237,7 @@ public final class ThumbnailHandler implements HttpHandler {
 
     private void handleDelete(HttpExchange exchange, String path) throws Exception {
         String basePath = appConfig.getApiBasePath() + "thumbnails";
+        log.info("Handling DELETE thumbnail request for path: " + path);
 
         if (path.startsWith(basePath + "/media-items/")) {
             handleDeleteMediaItemThumbnail(exchange, path);
@@ -407,16 +414,18 @@ public final class ThumbnailHandler implements HttpHandler {
      * Returns null if the part is not a file part.
      */
     private Map.Entry<String, byte[]> parseMultipartPart(String part) {
+        int endOffset = 4;
         int headerEndIndex = part.indexOf("\r\n\r\n");
         if (headerEndIndex == -1) {
             headerEndIndex = part.indexOf("\n\n");
             if (headerEndIndex == -1) {
                 return null;
             }
+            endOffset = 2;
         }
 
         String headers = part.substring(0, headerEndIndex);
-        String content = part.substring(headerEndIndex + 4);
+        String content = part.substring(headerEndIndex + endOffset);
 
         // Check if this is a file part (has Content-Disposition with filename)
         if (!headers.contains("Content-Disposition") || !headers.contains("filename")) {
@@ -458,12 +467,14 @@ public final class ThumbnailHandler implements HttpHandler {
     }
 
     /**
-     * Writes an image response with Content-Type: image/jpeg.
+     * Writes an image response with an appropriate Content-Type (either image/jpeg or image/png).
      */
     private void writeImageResponse(HttpExchange exchange, BufferedImage image) throws IOException {
-        byte[] bytes = toJpegBytes(image);
+        byte[] bytes = toImageBytes(image);
 
-        exchange.getResponseHeaders().set("Content-Type", "image/jpeg");
+        String mimeType = image.getColorModel().hasAlpha() ? "image/png" : "image/jpeg";
+
+        exchange.getResponseHeaders().set("Content-Type", mimeType);
         exchange.sendResponseHeaders(HttpURLConnection.HTTP_OK, bytes.length);
 
         try (java.io.OutputStream os = exchange.getResponseBody()) {
@@ -472,11 +483,16 @@ public final class ThumbnailHandler implements HttpHandler {
     }
 
     /**
-     * Converts a BufferedImage to JPEG bytes.
+     * Converts a BufferedImage to bytes in the appropriate format.
+     * Most of the time, this will return a jpg image.
+     * If the given BufferedImage has an alpha channel, we will write it as PNG instead.
      */
-    private byte[] toJpegBytes(BufferedImage image) throws IOException {
+    private byte[] toImageBytes(BufferedImage image) throws IOException {
         java.io.ByteArrayOutputStream baos = new java.io.ByteArrayOutputStream();
-        ImageIO.write(image, "jpg", baos);
+        String formatName = image.getColorModel().hasAlpha() ? "png" : "jpg";
+        if (!ImageIO.write(image, formatName, baos)) {
+            throw new IOException("Failed to write image in format: " + formatName);
+        }
         return baos.toByteArray();
     }
 

--- a/backend/src/main/java/ca/corbett/movienight/api/util/ThumbnailUtil.java
+++ b/backend/src/main/java/ca/corbett/movienight/api/util/ThumbnailUtil.java
@@ -6,6 +6,7 @@ import ca.corbett.movienight.model.MediaItem;
 
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 
@@ -66,7 +67,8 @@ public class ThumbnailUtil {
 
     /**
      * Stores the given thumbnail image for the given MediaItem in the configured thumbnail directory.
-     * Note that the save format will always be JPEG, regardless of the original image format.
+     * The save format will be JPEG for any image that has no alpha channel (regardless of input format).
+     * For images with alpha channel, we will save as PNG instead to preserve the transparency.
      * Any previously stored thumbnail for this MediaItem will be overwritten.
      */
     public static void storeThumbnail(MediaItem mediaItem, BufferedImage image, AppConfig appConfig)
@@ -109,7 +111,8 @@ public class ThumbnailUtil {
 
     /**
      * Stores the given thumbnail image for the given MediaGroup in the configured thumbnail directory.
-     * Note that the save format will always be JPEG, regardless of the original image format.
+     * The save format will be JPEG for any image that has no alpha channel (regardless of input format).
+     * For images with alpha channel, we will save as  PNG instead to preserve the transparency.
      * Any previously stored thumbnail for this MediaGroup will be overwritten.
      */
     public static void storeThumbnail(MediaGroup mediaGroup, BufferedImage image, AppConfig appConfig)
@@ -172,11 +175,50 @@ public class ThumbnailUtil {
         return null;
     }
 
+    /**
+     * Thumbnails are generally stored as jpeg images regardless of the uploaded format.
+     * The exception is if we detect an alpha channel, we will attempt to save as PNG instead.
+     * If ImageIO fails to write the image in the expected format, an IOException will be thrown.
+     *
+     * @param something A model object whose class will be used as a basis for the thumbnail filename.
+     * @param id        The numeric id of the model object in question, also used in the thumbnail filename.
+     * @param image     Any non-null BufferedImage. If it's transparent, we write PNG, else we write JPEG.
+     * @param appConfig Contains the location of our data directory (more specifically, our thumbnail dir).
+     * @throws IOException If the write fails for any reason.
+     */
     private static void storeThumbnail(Object something, long id, BufferedImage image, AppConfig appConfig)
             throws IOException {
+        if (image == null) {
+            throw new IOException("Cannot store null image as thumbnail");
+        }
         Path thumbDir = appConfig.getThumbnailDir();
         String className = something.getClass().getSimpleName();
-        Path outputPath = thumbDir.resolve(className + "_" + id + ".jpg");
-        ImageIO.write(image, "jpg", outputPath.toFile());
+        String formatName = image.getColorModel().hasAlpha() ? "png" : "jpg";
+
+        // The thumbnail write is not guaranteed to succeed!
+        // But, we will nonetheless delete any existing thumbnails before proceeding.
+        // If our write succeeds, there will be exactly one thumbnail for this model object.
+        // If our write fails, we have "un-set" the thumbnail for that model object.
+        // Perhaps not ideal, but simple and deterministic.
+        File[] existingFiles = {
+                thumbDir.resolve(className + "_" + id + ".jpg").toFile(),
+                thumbDir.resolve(className + "_" + id + ".jpeg").toFile(),
+                thumbDir.resolve(className + "_" + id + ".png").toFile()
+        };
+        for (File file : existingFiles) {
+            if (file.exists()) {
+                if (!file.delete()) {
+                    throw new IOException("Failed to delete existing thumbnail file: " + file.getAbsolutePath());
+                }
+            }
+        }
+
+        // Now we try to create the new thumbnail file.
+        // We know the input image is valid because we've already parsed it.
+        // At this point, it can only fail if there's no writer for JPG or PNG, which is unlikely.
+        Path outputPath = thumbDir.resolve(className + "_" + id + "." + formatName);
+        if (!ImageIO.write(image, formatName, outputPath.toFile())) {
+            throw new IOException("Failed to write thumbnail image as " + formatName);
+        }
     }
 }

--- a/backend/src/main/java/ca/corbett/movienight/api/util/ThumbnailUtil.java
+++ b/backend/src/main/java/ca/corbett/movienight/api/util/ThumbnailUtil.java
@@ -112,7 +112,7 @@ public class ThumbnailUtil {
     /**
      * Stores the given thumbnail image for the given MediaGroup in the configured thumbnail directory.
      * The save format will be JPEG for any image that has no alpha channel (regardless of input format).
-     * For images with alpha channel, we will save as  PNG instead to preserve the transparency.
+     * For images with alpha channel, we will save as PNG instead to preserve the transparency.
      * Any previously stored thumbnail for this MediaGroup will be overwritten.
      */
     public static void storeThumbnail(MediaGroup mediaGroup, BufferedImage image, AppConfig appConfig)


### PR DESCRIPTION
This PR addresses issue #80 by fixing several bugs in the backend thumbnail handling code:

1. Added logging for easier debugging.
2. Fixed a potential off-by-two bug when parsing multipart file uploads.
3. Added support for transparent PNGs for uploaded thumbnails.
4. Removed the hard assumption that all thumbnails will be JPEGs.
5. Handle cleanup of stale thumbnail files when uploading new thumbnails.
6. Better error handling in general (checking return from `ImageIO.write()`)
7. Updated javadocs as needed to accurately reflect the above.

No frontend changes! The frontend is already doing exactly what it should be doing for this.
