### PR TITLE
Issue #78 - implement local VLC option

### DIFF
--- a/backend/src/main/java/ca/corbett/movienight/api/handler/PlaylistHandler.java
+++ b/backend/src/main/java/ca/corbett/movienight/api/handler/PlaylistHandler.java
@@ -40,6 +40,14 @@ import java.util.logging.Logger;
  *     consisting of all media items in the media group with the given ID. Note that only
  *     direct child items of the given group are returned - this is not a recursive search.</li>
  * </ul>
+ * <p>
+ *     An optional query parameter <code>?local=true</code> can be added to any of the above routes to
+ *     indicate that the generated playlist should return direct filesystem paths instead of streaming URLs.
+ *     This is intended for the case where the browser is being used on the same machine as the server (or where
+ *     both client machine and server machine have access to the same shared filesystem). Player performance
+ *     will be much improved in this case, since there is no http streaming involved. The default is false,
+ *     meaning that streaming URLs will be used in the generated playlist.
+ * </p>
  *
  * @author <a href="https://github.com/scorbo2">scorbo2</a>
  */
@@ -51,6 +59,7 @@ public class PlaylistHandler implements HttpHandler {
     private final Database database;
     private final MediaGroupService mediaGroupService;
     private final AppConfig appConfig;
+    private boolean isLocal;
 
     public PlaylistHandler(Database database, MediaGroupService mediaGroupService,
                            ResponseWriter responseWriter, RequestParser requestParser,
@@ -60,6 +69,7 @@ public class PlaylistHandler implements HttpHandler {
         this.responseWriter = responseWriter;
         this.requestParser = requestParser;
         this.appConfig = appConfig;
+        this.isLocal = false;
     }
 
     public static class PlaylistMediaItemIdsRequest {
@@ -75,6 +85,7 @@ public class PlaylistHandler implements HttpHandler {
         try {
             String method = exchange.getRequestMethod();
             String path = exchange.getRequestURI().getPath();
+            isLocal = parseLocalParam(exchange);
 
             if ("GET".equals(method)) {
                 handleGetPlaylist(exchange, path);
@@ -102,6 +113,25 @@ public class PlaylistHandler implements HttpHandler {
             var mapped = ExceptionMapper.map(e);
             responseWriter.writeJson(exchange, (int)mapped[0], mapped[1]);
         }
+    }
+
+    /**
+     * Looks for a query parameter "local" in the request URI, and returns true if
+     * found and if the value is "true" (case-insensitive).
+     * If the parameter is not found, or if it has any other value, returns false.
+     * See class javadocs for a description of what this parameter does.
+     */
+    private boolean parseLocalParam(HttpExchange exchange) {
+        String query = exchange.getRequestURI().getQuery();
+        if (query != null) {
+            for (String param : query.split("&")) {
+                String[] parts = param.split("=");
+                if (parts.length == 2 && "local".equals(parts[0]) && "true".equalsIgnoreCase(parts[1])) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     private void handleGetPlaylist(HttpExchange exchange, String path) throws Exception {
@@ -157,7 +187,7 @@ public class PlaylistHandler implements HttpHandler {
             throw new Database.NotFoundException("Media item not found with ID: " + itemId);
         }
 
-        String playlist = generatePlaylist(List.of(item), appConfig, getServerName(exchange));
+        String playlist = generatePlaylist(List.of(item), appConfig, getServerName(exchange), isLocal);
         responseWriter.writeText(exchange, HttpURLConnection.HTTP_OK, playlist);
     }
 
@@ -184,7 +214,7 @@ public class PlaylistHandler implements HttpHandler {
             throw new Database.NotFoundException("Media item not found with ID: " + itemId);
         }
 
-        String playlist = generatePlaylist(List.of(item), appConfig, getServerName(exchange));
+        String playlist = generatePlaylist(List.of(item), appConfig, getServerName(exchange), isLocal);
         responseWriter.writeText(exchange, HttpURLConnection.HTTP_OK, playlist);
     }
 
@@ -201,7 +231,7 @@ public class PlaylistHandler implements HttpHandler {
         }
 
         List<MediaItem> items = database.getMediaItemsByGroupId(groupId);
-        String playlist = generatePlaylist(items, appConfig, getServerName(exchange));
+        String playlist = generatePlaylist(items, appConfig, getServerName(exchange), isLocal);
         responseWriter.writeText(exchange, HttpURLConnection.HTTP_OK, playlist);
     }
 
@@ -223,7 +253,7 @@ public class PlaylistHandler implements HttpHandler {
             }
         }
 
-        String playlist = generatePlaylist(items, appConfig, getServerName(exchange));
+        String playlist = generatePlaylist(items, appConfig, getServerName(exchange), isLocal);
         responseWriter.writeText(exchange, HttpURLConnection.HTTP_OK, playlist);
     }
 
@@ -249,9 +279,10 @@ public class PlaylistHandler implements HttpHandler {
      * @param mediaItems A List of at least one MediaItem to include in the playlist.
      * @param appConfig  Contains our server port and our data directory.
      * @param serverName The server name or IP address to use in the streaming URLs in the playlist.
+     * @param isLocal   If true, the playlist will contain direct filesystem paths instead of streaming URLs.
      * @return An m3u playlist as a String. May be empty if mediaItems was empty, or if it contained no valid MediaItems.
      */
-    public static String generatePlaylist(List<MediaItem> mediaItems, AppConfig appConfig, String serverName) {
+    public static String generatePlaylist(List<MediaItem> mediaItems, AppConfig appConfig, String serverName, boolean isLocal) {
         StringBuilder m3u = new StringBuilder();
         m3u.append("#EXTM3U\n");
         for (MediaItem mediaItem : mediaItems) {
@@ -270,7 +301,14 @@ public class PlaylistHandler implements HttpHandler {
                     ? mediaItem.getTitle()
                     : "Untitled Media Item " + mediaItem.getId();
             m3u.append("#EXTINF:-1,").append(itemTitle).append("\n");
-            m3u.append(buildStreamUrl(mediaItem, serverName, appConfig));
+            if (isLocal) {
+                // Browser is on the same machine or has access to the same shared filesystem:
+                m3u.append(mediaFile.getAbsolutePath());
+            }
+            else {
+                // Browser is remote, needs to stream over HTTP:
+                m3u.append(buildStreamUrl(mediaItem, serverName, appConfig));
+            }
             m3u.append("\n");
         }
         return m3u.toString();

--- a/backend/src/main/java/ca/corbett/movienight/api/handler/PlaylistHandler.java
+++ b/backend/src/main/java/ca/corbett/movienight/api/handler/PlaylistHandler.java
@@ -1,6 +1,7 @@
 package ca.corbett.movienight.api.handler;
 
 import ca.corbett.movienight.api.util.ExceptionMapper;
+import ca.corbett.movienight.api.util.QueryParamParser;
 import ca.corbett.movienight.api.util.RequestParser;
 import ca.corbett.movienight.api.util.ResponseWriter;
 import ca.corbett.movienight.config.AppConfig;
@@ -14,6 +15,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.util.List;
+import java.util.Map;
 import java.util.logging.Logger;
 
 /**
@@ -59,7 +61,6 @@ public class PlaylistHandler implements HttpHandler {
     private final Database database;
     private final MediaGroupService mediaGroupService;
     private final AppConfig appConfig;
-    private boolean isLocal;
 
     public PlaylistHandler(Database database, MediaGroupService mediaGroupService,
                            ResponseWriter responseWriter, RequestParser requestParser,
@@ -69,7 +70,6 @@ public class PlaylistHandler implements HttpHandler {
         this.responseWriter = responseWriter;
         this.requestParser = requestParser;
         this.appConfig = appConfig;
-        this.isLocal = false;
     }
 
     public static class PlaylistMediaItemIdsRequest {
@@ -85,13 +85,13 @@ public class PlaylistHandler implements HttpHandler {
         try {
             String method = exchange.getRequestMethod();
             String path = exchange.getRequestURI().getPath();
-            isLocal = parseLocalParam(exchange);
+            boolean isLocal = parseLocalParam(exchange);
 
             if ("GET".equals(method)) {
-                handleGetPlaylist(exchange, path);
+                handleGetPlaylist(exchange, path, isLocal);
             }
             else if ("POST".equals(method)) {
-                handlePostPlaylist(exchange, path);
+                handlePostPlaylist(exchange, path, isLocal);
             }
             else {
                 exchange.getResponseHeaders().set("Content-Type", "application/json; charset=utf-8");
@@ -122,19 +122,11 @@ public class PlaylistHandler implements HttpHandler {
      * See class javadocs for a description of what this parameter does.
      */
     private boolean parseLocalParam(HttpExchange exchange) {
-        String query = exchange.getRequestURI().getQuery();
-        if (query != null) {
-            for (String param : query.split("&")) {
-                String[] parts = param.split("=");
-                if (parts.length == 2 && "local".equals(parts[0]) && "true".equalsIgnoreCase(parts[1])) {
-                    return true;
-                }
-            }
-        }
-        return false;
+        Map<String, String> params = QueryParamParser.parse(exchange.getRequestURI().getQuery());
+        return QueryParamParser.parseBoolean(params, "local");
     }
 
-    private void handleGetPlaylist(HttpExchange exchange, String path) throws Exception {
+    private void handleGetPlaylist(HttpExchange exchange, String path, boolean isLocal) throws Exception {
         String prefix = appConfig.getApiBasePath() + "playlist/";
         if (!path.startsWith(prefix)) {
             throw new IllegalArgumentException("Invalid path: " + path);
@@ -142,20 +134,20 @@ public class PlaylistHandler implements HttpHandler {
         String remainder = path.substring(prefix.length());
 
         if ("media-item".equals(remainder)) {
-            handleSingleMediaItemPlaylist(exchange);
+            handleSingleMediaItemPlaylist(exchange, isLocal);
         }
         else if (remainder.startsWith("media-item/")) {
-            handleSingleMediaItemPlaylistById(exchange, remainder.substring("media-item/".length()));
+            handleSingleMediaItemPlaylistById(exchange, remainder.substring("media-item/".length()), isLocal);
         }
         else if (remainder.startsWith("media-group/")) {
-            handleMediaGroupPlaylist(exchange, remainder.substring("media-group/".length()));
+            handleMediaGroupPlaylist(exchange, remainder.substring("media-group/".length()), isLocal);
         }
         else {
             throw new IllegalArgumentException("Unknown playlist route: " + remainder);
         }
     }
 
-    private void handlePostPlaylist(HttpExchange exchange, String path) throws Exception {
+    private void handlePostPlaylist(HttpExchange exchange, String path, boolean isLocal) throws Exception {
         String prefix = appConfig.getApiBasePath() + "playlist/";
         if (!path.startsWith(prefix)) {
             throw new IllegalArgumentException("Invalid path: " + path);
@@ -163,14 +155,15 @@ public class PlaylistHandler implements HttpHandler {
         String remainder = path.substring(prefix.length());
 
         if ("media-item".equals(remainder)) {
-            handleMultiMediaItemPlaylist(exchange);
+            handleMultiMediaItemPlaylist(exchange, isLocal);
         }
         else {
             throw new IllegalArgumentException("Unknown playlist route: " + remainder);
         }
     }
 
-    private void handleSingleMediaItemPlaylistById(HttpExchange exchange, String idStr) throws Exception {
+    private void handleSingleMediaItemPlaylistById(HttpExchange exchange, String idStr, boolean isLocal)
+            throws Exception {
         int itemId;
         try {
             itemId = Integer.parseInt(idStr);
@@ -191,7 +184,7 @@ public class PlaylistHandler implements HttpHandler {
         responseWriter.writeText(exchange, HttpURLConnection.HTTP_OK, playlist);
     }
 
-    private void handleSingleMediaItemPlaylist(HttpExchange exchange) throws Exception {
+    private void handleSingleMediaItemPlaylist(HttpExchange exchange, boolean isLocal) throws Exception {
         String path = exchange.getRequestURI().getPath();
         String prefix = appConfig.getApiBasePath() + "playlist/media-item";
         String idStr = path.substring(prefix.length()).replace("/", "");
@@ -218,7 +211,7 @@ public class PlaylistHandler implements HttpHandler {
         responseWriter.writeText(exchange, HttpURLConnection.HTTP_OK, playlist);
     }
 
-    private void handleMediaGroupPlaylist(HttpExchange exchange, String groupIdStr) throws Exception {
+    private void handleMediaGroupPlaylist(HttpExchange exchange, String groupIdStr, boolean isLocal) throws Exception {
         long groupId;
         try {
             groupId = Long.parseLong(groupIdStr);
@@ -235,7 +228,7 @@ public class PlaylistHandler implements HttpHandler {
         responseWriter.writeText(exchange, HttpURLConnection.HTTP_OK, playlist);
     }
 
-    private void handleMultiMediaItemPlaylist(HttpExchange exchange) throws Exception {
+    private void handleMultiMediaItemPlaylist(HttpExchange exchange, boolean isLocal) throws Exception {
         if (!requestParser.hasBody(exchange)) {
             throw new IllegalArgumentException("Request body is required");
         }

--- a/backend/src/test/java/ca/corbett/movienight/api/ApiIntegrationTest.java
+++ b/backend/src/test/java/ca/corbett/movienight/api/ApiIntegrationTest.java
@@ -1585,6 +1585,30 @@ class ApiIntegrationTest {
     }
 
     @Test
+    void playlist_singleMediaItemLocal_returns200WithM3uAndLocalFilePaths() throws Exception {
+        long groupId = createTestGroup("Group", null);
+        long itemId = createTestItem(groupId, "Test Movie", "/test-movie.mkv");
+
+        // Create the actual media file on disk
+        Path mediaFile = tempDir.resolve("test-movie.mkv");
+        Files.writeString(mediaFile, "fake video content");
+
+        HttpResponse<String> response = sendRequest(
+                HttpRequest.newBuilder()
+                           .uri(URI.create(BASE_URL + "/playlist/media-item/" + itemId + "?local=true"))
+                           .GET()
+                           .build()
+        );
+
+        assertEquals(200, response.statusCode());
+        assertEquals("text/plain; charset=utf-8", response.headers().firstValue("Content-Type").orElse(""));
+        String body = response.body();
+        assertTrue(body.startsWith("#EXTM3U"));
+        assertTrue(body.contains("#EXTINF:-1,Test Movie"));
+        assertTrue(body.contains(mediaFile.toAbsolutePath().toString()));
+    }
+
+    @Test
     void playlist_singleMediaItem_nonexistent_returns404() throws Exception {
         HttpResponse<String> response = sendRequest(
                 HttpRequest.newBuilder()

--- a/frontend/src/browse/BrowseHeader.tsx
+++ b/frontend/src/browse/BrowseHeader.tsx
@@ -1,5 +1,7 @@
+import { useState } from 'react';
 import { Link, NavLink } from 'react-router-dom';
 import { Button } from '../components/ui/Button';
+import { getPlaylistLocalPreference, setPlaylistLocalPreference } from '../lib/playlist';
 import { useTheme } from '../theme/ThemeProvider';
 
 function ThemeToggle(): JSX.Element {
@@ -9,6 +11,27 @@ function ThemeToggle(): JSX.Element {
     <Button variant="secondary" size="sm" onClick={toggleTheme}>
       {theme === 'light' ? 'Dark mode' : 'Light mode'}
     </Button>
+  );
+}
+
+function PlaylistLocalToggle(): JSX.Element {
+  const [isLocal, setIsLocal] = useState<boolean>(() => getPlaylistLocalPreference());
+
+  const onChange = (nextValue: boolean): void => {
+    setIsLocal(nextValue);
+    setPlaylistLocalPreference(nextValue);
+  };
+
+  return (
+    <label className="flex items-center gap-2 text-sm text-content-secondary" htmlFor="playlist-local-toggle">
+      <input
+        id="playlist-local-toggle"
+        type="checkbox"
+        checked={isLocal}
+        onChange={(event) => onChange(event.currentTarget.checked)}
+      />
+      Local VLC paths
+    </label>
   );
 }
 
@@ -30,6 +53,7 @@ export function BrowseHeader(): JSX.Element {
           </nav>
         </div>
         <div className="flex items-center gap-3">
+          <PlaylistLocalToggle />
           <Link to="/admin" className="text-sm font-medium text-content-secondary">
             Admin
           </Link>

--- a/frontend/src/browse/pages/GroupDetailPage.tsx
+++ b/frontend/src/browse/pages/GroupDetailPage.tsx
@@ -14,6 +14,7 @@ import { Thumbnail } from '../../components/shared/Thumbnail';
 import { Button } from '../../components/ui/Button';
 import { Card } from '../../components/ui/Card';
 import { Skeleton } from '../../components/ui/Skeleton';
+import { addPlaylistLocalQuery } from '../../lib/playlist';
 import { getNullableStringParam, getPositiveIntParam, setParam } from '../../lib/url';
 
 export function GroupDetailPage(): JSX.Element {
@@ -90,7 +91,7 @@ export function GroupDetailPage(): JSX.Element {
             </div>
             <div className="flex flex-wrap gap-3">
               <Button
-                onClick={() => window.location.assign(buildApiUrl(`playlist/media-group/${groupId}`))}
+                onClick={() => window.location.assign(buildApiUrl(addPlaylistLocalQuery(`playlist/media-group/${groupId}`)))}
                 disabled={(itemCountQuery.data?.totalCount ?? 0) === 0}
               >
                 Watch all in VLC

--- a/frontend/src/browse/pages/ItemDetailPage.tsx
+++ b/frontend/src/browse/pages/ItemDetailPage.tsx
@@ -12,6 +12,7 @@ import { Thumbnail } from '../../components/shared/Thumbnail';
 import { Button } from '../../components/ui/Button';
 import { Card } from '../../components/ui/Card';
 import { Skeleton } from '../../components/ui/Skeleton';
+import { addPlaylistLocalQuery } from '../../lib/playlist';
 
 export function ItemDetailPage(): JSX.Element {
   const { itemId: itemIdParam } = useParams();
@@ -75,7 +76,7 @@ export function ItemDetailPage(): JSX.Element {
               <Button onClick={() => setShowPlayer((current) => !current)}>
                 {showPlayer ? 'Hide player' : 'Watch now'}
               </Button>
-              <Button variant="secondary" onClick={() => window.location.assign(buildApiUrl(`playlist/media-item/${item.id}`))}>
+              <Button variant="secondary" onClick={() => window.location.assign(buildApiUrl(addPlaylistLocalQuery(`playlist/media-item/${item.id}`)))}>
                 Watch in VLC
               </Button>
             </div>

--- a/frontend/src/lib/playlist.ts
+++ b/frontend/src/lib/playlist.ts
@@ -1,0 +1,18 @@
+const PLAYLIST_LOCAL_STORAGE_KEY = 'movienight-playlist-local';
+
+export function getPlaylistLocalPreference(): boolean {
+  return window.localStorage.getItem(PLAYLIST_LOCAL_STORAGE_KEY) === 'true';
+}
+
+export function setPlaylistLocalPreference(isLocal: boolean): void {
+  window.localStorage.setItem(PLAYLIST_LOCAL_STORAGE_KEY, String(isLocal));
+}
+
+export function addPlaylistLocalQuery(path: string): string {
+  if (!getPlaylistLocalPreference()) {
+    return path;
+  }
+
+  return path.includes('?') ? `${path}&local=true` : `${path}?local=true`;
+}
+


### PR DESCRIPTION
This PR addresses issue #78 by re-introducing the "local VLC" option from the v1 codebase, but with an important distinction: in V1, the "local VLC" option was a server-side option, and applied to all clients. This new option for the v2 release makes this a client-side option, which makes much more sense. If the client browser is running on the same physical machine as the server, or if it has access to the same shared network drive, the user can select the "Local VLC" option. This causes all generated VLC playlists to contain local filesystem paths instead of HTTP streaming URLs, thereby greatly increasing performance in that case.

The default for this option is false, as it was in the v1 code. All playlists will contain streaming URLs unless the user selects the "local" option.
