### PR TITLE
Issue #83 - fix logging and startup config

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -32,7 +32,7 @@ cd frontend && npm run dev            # dev server with proxy to localhost:8181
 java -jar backend/target/MovieNight-2.0-SNAPSHOT.jar
 
 # With a config file:
-MOVIE_NIGHT_CONFIG=/path/to/config.properties java -jar ...
+MOVIENIGHT_CONFIG_FILE=/path/to/config.properties java -jar ...
 ```
 
 Config file is a Java `.properties` file. Recognized keys: `port`, `dataDir`, `pageSize`, `apiBasePath`, `rangeLimitMB`.

--- a/backend/src/main/java/ca/corbett/movienight/Main.java
+++ b/backend/src/main/java/ca/corbett/movienight/Main.java
@@ -5,6 +5,11 @@ import ca.corbett.movienight.config.AppConfig;
 import ca.corbett.movienight.db.Database;
 
 import java.io.File;
+import java.io.IOException;
+import java.util.logging.FileHandler;
+import java.util.logging.Formatter;
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
 import java.util.logging.Logger;
 
 /**
@@ -14,56 +19,128 @@ import java.util.logging.Logger;
  */
 public class Main {
 
-    private static final Logger log = Logger.getLogger(Main.class.getName());
-
     public static void main(String[] args) throws Exception {
-        // 1. Load configuration
-        //    1a) if MOVIE_NIGHT_CONFIG env var is set, load from that file
-        //    1b) otherwise, use defaults
-        AppConfig config;
-        String configPath = System.getenv("MOVIE_NIGHT_CONFIG");
+        configureLogging();
+        Logger log = Logger.getLogger(Main.class.getName());
+
+        AppConfig config = loadAppConfig(log);
+        log.info(config.toString());
+
+        Database database = new Database(config);
+        database.open();
+        log.info("Database initialized and connected.");
+
+        ApiServer apiServer = ApiServer.create(config, database);
+        apiServer.start();
+        log.info("MovieNight started on port " + config.getPort());
+
+        // 4. Register shutdown hook for graceful teardown
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            log.info("Shutting down...");
+            apiServer.stop();
+            database.dispose();
+            log.info("Shutdown complete.");
+        }));
+
+        // Don't pollute the log file with this. This is just for console users who run the app directly.
+        System.out.println("Server is running. Press Ctrl+C to stop.");
+    }
+
+    /**
+     * Checks for MOVIENIGHT_CONFIG_FILE and attempts to load application configuration from
+     * the named file. If the environment variable is not set, or if loading fails, defaults will be used.
+     *
+     * @return A populated AppConfig instance, either loaded from file or with defaults.
+     */
+    public static AppConfig loadAppConfig(Logger log) {
+        AppConfig config = AppConfig.defaults();
+        String configPath = System.getenv(AppConfig.ENV_VAR_CONFIG);
         if (configPath != null) {
             File configFile = new File(configPath);
             if (!configFile.exists() || !configFile.isFile() || !configFile.canRead()) {
-                System.err.println("Invalid config file specified in MOVIE_NIGHT_CONFIG: " + configPath);
+                log.severe("Fatal: Invalid config file specified in " + AppConfig.ENV_VAR_CONFIG + ": " + configPath);
                 System.exit(1);
             }
             try {
                 config = AppConfig.fromFile(configFile);
-                System.out.println("Config loaded from " + configPath);
+                log.info("Config loaded from " + configPath);
             }
             catch (Exception ex) {
-                System.err.println("Failed to load config from " + configPath + ": " + ex.getMessage());
+                log.severe("Fatal: Failed to load config from " + configPath + ": " + ex.getMessage());
                 System.exit(1);
-                return; // unreachable but satisfies compiler
             }
         }
         else {
-            config = AppConfig.defaults();
-            System.out.println("No config file specified, using defaults.");
+            log.info("Hint: set " + AppConfig.ENV_VAR_CONFIG + " to set custom configuration. Using defaults.");
         }
-        System.out.println("Starting application...");
-        System.out.println("  Port: " + config.getPort());
-        System.out.println("  Database: " + config.getDbFile());
-        System.out.println("  API Base Path: " + config.getApiBasePath());
 
-        // 2. Initialize and open the database
-        Database database = new Database(config);
-        database.open();
-        System.out.println("Database initialized and connected.");
+        return config;
+    }
 
-        // 3. Create and start the API server
-        ApiServer apiServer = ApiServer.create(config, database);
-        apiServer.start();
+    /**
+     * If MOVIENIGHT_LOG_FILE is set to a valid file path, configures java.util.logging to write logs to that
+     * file in addition to the console. Otherwise, logging is stdout only.
+     */
+    public static void configureLogging() {
+        CustomLogFormatter customFormatter = new CustomLogFormatter();
 
-        // 4. Register shutdown hook for graceful teardown
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            System.out.println("Shutting down...");
-            apiServer.stop();
-            database.dispose();
-            System.out.println("Shutdown complete.");
-        }));
+        // Get the root logger (affects all loggers) and add our custom formatter:
+        Logger rootLogger = Logger.getLogger("");
+        for (Handler h : rootLogger.getHandlers()) {
+            h.setFormatter(customFormatter);
+        }
 
-        System.out.println("Server is running. Press Ctrl+C to stop.");
+        // It's not a fatal error if we were not given a log file. We'll just output a hint and go with console-only.
+        String logFile = System.getenv(AppConfig.ENV_VAR_LOG_FILE);
+        if (logFile == null || logFile.trim().isEmpty()) {
+            System.out.println("Hint: You can set "
+                                       + AppConfig.ENV_VAR_LOG_FILE
+                                       + " environment variable to enable file logging.");
+            return;
+        }
+
+        // If we were given a file, let's validate it and attempt to set up file logging.
+        // (this is in addition to console logging, not instead of it).
+        try {
+            // Ensure the parent directory exists
+            File logPath = new File(logFile);
+            File parentDir = logPath.getParentFile();
+            if (parentDir != null && !parentDir.exists()) {
+                if (!parentDir.mkdirs()) {
+                    throw new IOException("Failed to create log directory: " + parentDir.getAbsolutePath());
+                }
+            }
+
+            FileHandler fileHandler = new FileHandler(logFile, true);
+            fileHandler.setFormatter(customFormatter);
+            rootLogger.addHandler(fileHandler);
+
+            // Let console users know where they can find the log file:
+            System.out.println("File logging enabled: " + logFile);
+        }
+        catch (IOException | SecurityException e) {
+            // Again, not fatal if we couldn't get it set up. Just log a warning and move on.
+            System.err.println("Failed to initialize file logging: " + e.getMessage());
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * A custom log formatter that produces more human-friendly log messages.
+     */
+    public static class CustomLogFormatter extends Formatter {
+        @Override
+        public String format(LogRecord record) {
+            String thrown = "";
+            if (record.getThrown() != null) {
+                thrown = "\n" + record.getThrown();
+            }
+
+            return String.format("%1$tF %1$tr [%2$s] %3$s%4$s%n",
+                                 record.getMillis(),
+                                 record.getLevel().getName(),
+                                 formatMessage(record),
+                                 thrown);
+        }
     }
 }

--- a/backend/src/main/java/ca/corbett/movienight/Main.java
+++ b/backend/src/main/java/ca/corbett/movienight/Main.java
@@ -19,6 +19,8 @@ import java.util.logging.Logger;
  */
 public class Main {
 
+    private static FileHandler fileHandler = null;
+
     public static void main(String[] args) throws Exception {
         configureLogging();
         Logger log = Logger.getLogger(Main.class.getName());
@@ -39,7 +41,11 @@ public class Main {
             log.info("Shutting down...");
             apiServer.stop();
             database.dispose();
-            log.info("Shutdown complete.");
+            if (fileHandler != null) {
+                fileHandler.flush();
+                fileHandler.close();
+            }
+            System.out.println("Shutdown complete.");
         }));
 
         // Don't pollute the log file with this. This is just for console users who run the app directly.
@@ -55,7 +61,7 @@ public class Main {
     public static AppConfig loadAppConfig(Logger log) {
         AppConfig config = AppConfig.defaults();
         String configPath = System.getenv(AppConfig.ENV_VAR_CONFIG);
-        if (configPath != null) {
+        if (configPath != null && !configPath.trim().isEmpty()) {
             File configFile = new File(configPath);
             if (!configFile.exists() || !configFile.isFile() || !configFile.canRead()) {
                 log.severe("Fatal: Invalid config file specified in " + AppConfig.ENV_VAR_CONFIG + ": " + configPath);
@@ -111,7 +117,7 @@ public class Main {
                 }
             }
 
-            FileHandler fileHandler = new FileHandler(logFile, true);
+            fileHandler = new FileHandler(logFile, true);
             fileHandler.setFormatter(customFormatter);
             rootLogger.addHandler(fileHandler);
 
@@ -133,7 +139,9 @@ public class Main {
         public String format(LogRecord record) {
             String thrown = "";
             if (record.getThrown() != null) {
-                thrown = "\n" + record.getThrown();
+                for (StackTraceElement element : record.getThrown().getStackTrace()) {
+                    thrown += "\n\tat " + element.toString();
+                }
             }
 
             return String.format("%1$tF %1$tr [%2$s] %3$s%4$s%n",

--- a/backend/src/main/java/ca/corbett/movienight/api/handler/PlaylistHandler.java
+++ b/backend/src/main/java/ca/corbett/movienight/api/handler/PlaylistHandler.java
@@ -123,7 +123,7 @@ public class PlaylistHandler implements HttpHandler {
      */
     private boolean parseLocalParam(HttpExchange exchange) {
         Map<String, String> params = QueryParamParser.parse(exchange.getRequestURI().getQuery());
-        return QueryParamParser.parseBoolean(params, "local");
+        return QueryParamParser.parseBooleanOptional(params, "local").orElse(false);
     }
 
     private void handleGetPlaylist(HttpExchange exchange, String path, boolean isLocal) throws Exception {

--- a/backend/src/main/java/ca/corbett/movienight/config/AppConfig.java
+++ b/backend/src/main/java/ca/corbett/movienight/config/AppConfig.java
@@ -30,10 +30,20 @@ import java.util.logging.Logger;
  *     <li><b>apiBasePath</b>: the base path for all API endpoints (default: "/api/")</li>
  *     <li><b>rangeLimitMB</b>: the maximum length of an HTTP Range request in megabytes (default: 32)</li>
  * </ul>
+ * <p>
+ *     <b>IMPORTANT ENVIRONMENT VARIABLES:</b>
+ * </p>
+ * <ul>
+ *     <li><b>MOVIENIGHT_CONFIG_FILE</b>: points to a valid config file. Fatal if the file can't be read.</li>
+ *     <li><b>MOVIENIGHT_LOG_FILE</b>: optional path to a log file. If not set, logs will only go to the console.</li>
+ * </ul>
  *
  * @author <a href="https://github.com/scorbo2">scorbo2</a>
  */
 public final class AppConfig {
+
+    public static final String ENV_VAR_CONFIG = "MOVIENIGHT_CONFIG_FILE";
+    public static final String ENV_VAR_LOG_FILE = "MOVIENIGHT_LOG_FILE";
 
     private static final Logger log = Logger.getLogger(AppConfig.class.getName());
 
@@ -237,5 +247,18 @@ public final class AppConfig {
             throw new NumberFormatException("MB value must be a positive integer");
         }
         return mbValue;
+    }
+
+    @Override
+    public String toString() {
+        return "AppConfig{\n" +
+                "  port=" + port +
+                ",\n  dataDir=" + dataDir.toAbsolutePath() +
+                ",\n  dbFile=" + dbFile.toAbsolutePath() +
+                ",\n  thumbnailDir=" + thumbnailDir.toAbsolutePath() +
+                ",\n  defaultPageSize=" + defaultPageSize +
+                ",\n  apiBasePath='" + apiBasePath + '\'' +
+                ",\n  rangeLimitMB=" + rangeLimitMB +
+                '}';
     }
 }


### PR DESCRIPTION
This PR addresses issue #83 by introducing an optional `MOVIENIGHT_LOG_FILE` env var that, if set, will enable logging to the given file, in addition to console logging. Also renamed `MOVIE_NIGHT_CONFIG` to `MOVIENIGHT_CONFIG_FILE` for consistency. (v2 is not yet released, so no worries about migrating users from the old env var name). Improved startup logging to be more helpful.

Also found and fixed an unrelated bug from the previous ticket that insisted on the `local` parameter being mandatory for playlist generation. This was breaking the Api integration test. 
