### PR TITLE
Issue #86 file browser

### DIFF
--- a/backend/src/main/java/ca/corbett/movienight/api/ApiServer.java
+++ b/backend/src/main/java/ca/corbett/movienight/api/ApiServer.java
@@ -77,7 +77,7 @@ public final class ApiServer {
         RequestParser requestParser = new RequestParser(objectMapper);
 
         MediaGroupService mediaGroupService = new MediaGroupService(database, config.getPageSize());
-        MediaItemService mediaItemService = new MediaItemService(database, config.getPageSize());
+        MediaItemService mediaItemService = new MediaItemService(database, config);
 
         String basePath = config.getApiBasePath();
         int defaultPageSize = config.getPageSize();

--- a/backend/src/main/java/ca/corbett/movienight/api/ApiServer.java
+++ b/backend/src/main/java/ca/corbett/movienight/api/ApiServer.java
@@ -1,6 +1,7 @@
 package ca.corbett.movienight.api;
 
 import ca.corbett.movienight.api.dto.ErrorResponse;
+import ca.corbett.movienight.api.handler.FileBrowserHandler;
 import ca.corbett.movienight.api.handler.HealthHandler;
 import ca.corbett.movienight.api.handler.MediaGroupHandler;
 import ca.corbett.movienight.api.handler.MediaItemHandler;
@@ -105,6 +106,9 @@ public final class ApiServer {
 
         // Register playlist endpoints
         apiServer.registerPlaylistEndpoints(mediaItemService, mediaGroupService);
+
+        // Register file browser endpoint:
+        apiServer.registerFileBrowserEndpoint();
 
         // Mount the router at the API base path (more specific path first)
         server.createContext(basePath, apiServer::handleAll);
@@ -309,6 +313,15 @@ public final class ApiServer {
         router.register(route, handler);
     }
 
+    private void registerFileBrowserEndpoint() {
+        Route route;
+        FileBrowserHandler handler = new FileBrowserHandler(appConfig, responseWriter);
+
+        // GET /api/files[?path=...] — list files in media directory
+        route = new Route("GET", appConfig.getApiBasePath() + "files");
+        router.register(route, handler);
+    }
+
     /**
      * Handles all requests under the API base path, delegating to the router
      * and wrapping errors in JSON error responses.
@@ -349,7 +362,6 @@ public final class ApiServer {
      */
     public void start() {
         server.start();
-        log.info("API server started on port " + server.getAddress().getPort());
     }
 
     /**

--- a/backend/src/main/java/ca/corbett/movienight/api/handler/FileBrowserHandler.java
+++ b/backend/src/main/java/ca/corbett/movienight/api/handler/FileBrowserHandler.java
@@ -95,11 +95,18 @@ public class FileBrowserHandler implements HttpHandler {
     private Path resolvePathParameter(HttpExchange exchange) {
         String query = exchange.getRequestURI().getQuery();
         Map<String, String> params = QueryParamParser.parse(query);
-        Path mediaDirPath = appConfig.getMediaDir();
-        Path pathParam = Path.of(params.getOrDefault("path", mediaDirPath.toAbsolutePath().toString())).normalize();
+        Path mediaDirPath = appConfig.getMediaDir().toAbsolutePath().normalize();
+        String requestedPath = params.get("path");
+        Path pathParam = (requestedPath == null || requestedPath.isBlank())
+                ? mediaDirPath
+                : Path.of(requestedPath);
+        if (!pathParam.isAbsolute()) {
+            pathParam = mediaDirPath.resolve(pathParam);
+        }
+        pathParam = pathParam.toAbsolutePath().normalize();
 
         // If the given path is not within our media dir, ignore it and use mediaDir instead.
-        if (!pathParam.startsWith(mediaDirPath.normalize())) {
+        if (!pathParam.startsWith(mediaDirPath)) {
             log.warning("Received file browser request with path outside media directory: " + pathParam);
             return mediaDirPath.normalize();
         }

--- a/backend/src/main/java/ca/corbett/movienight/api/handler/FileBrowserHandler.java
+++ b/backend/src/main/java/ca/corbett/movienight/api/handler/FileBrowserHandler.java
@@ -62,9 +62,10 @@ public class FileBrowserHandler implements HttpHandler {
         try {
             String method = exchange.getRequestMethod();
             String requestPath = exchange.getRequestURI().getPath();
-            String prefix = appConfig.getApiBasePath() + "files/";
-            if (!requestPath.startsWith(prefix)) {
+            String expectedPath = appConfig.getApiBasePath() + "files";
+            if (!requestPath.equals(expectedPath) && !requestPath.equals(expectedPath + "/")) {
                 throw new IllegalArgumentException("Invalid path: " + requestPath);
+            }
             }
 
             if ("GET".equals(method)) {

--- a/backend/src/main/java/ca/corbett/movienight/api/handler/FileBrowserHandler.java
+++ b/backend/src/main/java/ca/corbett/movienight/api/handler/FileBrowserHandler.java
@@ -193,7 +193,7 @@ public class FileBrowserHandler implements HttpHandler {
     private Map<String, Object> buildResponse(Path currentPath, List<File> files) {
         Map<String, Object> response = new HashMap<>();
         response.put("path", currentPath.toAbsolutePath().toString());
-        if (!currentPath.equals(appConfig.getMediaDir())) {
+        if (!currentPath.toAbsolutePath().normalize().equals(appConfig.getMediaDir().toAbsolutePath().normalize())) {
             response.put("parent", currentPath.getParent().toAbsolutePath().toString());
         }
         List<Map<String, String>> entries = new ArrayList<>();

--- a/backend/src/main/java/ca/corbett/movienight/api/handler/FileBrowserHandler.java
+++ b/backend/src/main/java/ca/corbett/movienight/api/handler/FileBrowserHandler.java
@@ -66,7 +66,6 @@ public class FileBrowserHandler implements HttpHandler {
             if (!requestPath.equals(expectedPath) && !requestPath.equals(expectedPath + "/")) {
                 throw new IllegalArgumentException("Invalid path: " + requestPath);
             }
-            }
 
             if ("GET".equals(method)) {
                 Path targetPath = resolvePathParameter(exchange);

--- a/backend/src/main/java/ca/corbett/movienight/api/handler/FileBrowserHandler.java
+++ b/backend/src/main/java/ca/corbett/movienight/api/handler/FileBrowserHandler.java
@@ -19,6 +19,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.logging.Logger;
 
 /**
@@ -46,6 +47,7 @@ import java.util.logging.Logger;
 public class FileBrowserHandler implements HttpHandler {
 
     private static final Logger log = Logger.getLogger(FileBrowserHandler.class.getName());
+    private static final Set<String> ALLOWED_VIDEO_EXTENSIONS = Set.of("mpg", "mk4", "mp4", "mov", "avi");
 
     private final AppConfig appConfig;
     private final ResponseWriter responseWriter;
@@ -132,10 +134,23 @@ public class FileBrowserHandler implements HttpHandler {
             log.warning("Failed to list files in directory (null returned): " + directory);
             return List.of();
         }
+        children = Arrays.stream(children)
+                .filter(file -> file.isDirectory() || hasAllowedVideoExtension(file))
+                .toArray(File[]::new);
         Arrays.sort(children, Comparator
                 .comparing((File f) -> !f.isDirectory())
                 .thenComparing(f -> f.getName().toLowerCase()));
         return Arrays.asList(children);
+    }
+
+    private boolean hasAllowedVideoExtension(File file) {
+        String fileName = file.getName();
+        int dotIndex = fileName.lastIndexOf('.');
+        if (dotIndex < 0 || dotIndex == fileName.length() - 1) {
+            return false;
+        }
+        String extension = fileName.substring(dotIndex + 1).toLowerCase();
+        return ALLOWED_VIDEO_EXTENSIONS.contains(extension);
     }
 
     /**

--- a/backend/src/main/java/ca/corbett/movienight/api/handler/FileBrowserHandler.java
+++ b/backend/src/main/java/ca/corbett/movienight/api/handler/FileBrowserHandler.java
@@ -47,7 +47,7 @@ import java.util.logging.Logger;
 public class FileBrowserHandler implements HttpHandler {
 
     private static final Logger log = Logger.getLogger(FileBrowserHandler.class.getName());
-    private static final Set<String> ALLOWED_VIDEO_EXTENSIONS = Set.of("mpg", "mk4", "mp4", "mov", "avi");
+    private static final Set<String> ALLOWED_VIDEO_EXTENSIONS = Set.of("mpg", "mkv", "mp4", "mov", "avi");
 
     private final AppConfig appConfig;
     private final ResponseWriter responseWriter;

--- a/backend/src/main/java/ca/corbett/movienight/api/handler/FileBrowserHandler.java
+++ b/backend/src/main/java/ca/corbett/movienight/api/handler/FileBrowserHandler.java
@@ -1,0 +1,195 @@
+package ca.corbett.movienight.api.handler;
+
+
+import ca.corbett.movienight.api.util.ExceptionMapper;
+import ca.corbett.movienight.api.util.QueryParamParser;
+import ca.corbett.movienight.api.util.ResponseWriter;
+import ca.corbett.movienight.config.AppConfig;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+
+/**
+ * Provides a chrooted view of the server's filesystem for browsing the media directory remotely.
+ * Clients can use this to navigate the media directory tree and a media file.
+ * The file browser is "locked" to our configured media directory. The client can't
+ * navigate outside of it.
+ * <p>Routes:</p>
+ * <ul>
+ *     <li>GET /api/files[?path=...]</li>
+ * </ul>
+ * <p>
+ * If path is omitted, we'll list the contents of the media directory. If path is provided, we'll resolve it
+ * relative to the media directory and list its contents. If the resolved path is not a directory
+ * or doesn't exist, we'll fall back to listing the media directory. The response will include the
+ * absolute path of the listed directory, and if it's not the media directory, the absolute path
+ * of its parent directory. This allows the client to implement "up" navigation. The response will also
+ * include a list of entries in the listed directory, where each entry has a name, type (file or directory),
+ * and absolute path. The client can then attach the path of the selected media file to the
+ * media item upsert request when creating or updating a media item.
+ * </p>
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ */
+public class FileBrowserHandler implements HttpHandler {
+
+    private static final Logger log = Logger.getLogger(FileBrowserHandler.class.getName());
+
+    private final AppConfig appConfig;
+    private final ResponseWriter responseWriter;
+
+    public FileBrowserHandler(AppConfig appConfig, ResponseWriter responseWriter) {
+        this.appConfig = appConfig;
+        this.responseWriter = responseWriter;
+    }
+
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+        try {
+            String method = exchange.getRequestMethod();
+            String requestPath = exchange.getRequestURI().getPath();
+            String prefix = appConfig.getApiBasePath() + "files/";
+            if (!requestPath.startsWith(prefix)) {
+                throw new IllegalArgumentException("Invalid path: " + requestPath);
+            }
+
+            if ("GET".equals(method)) {
+                Path targetPath = resolvePathParameter(exchange);
+                List<File> files = listFiles(targetPath);
+                responseWriter.writeJson(exchange, HttpURLConnection.HTTP_OK, buildResponse(targetPath, files));
+            }
+            else {
+                exchange.getResponseHeaders().set("Content-Type", "application/json; charset=utf-8");
+                exchange.sendResponseHeaders(405, 0); // 405 Method Not Allowed
+            }
+        }
+        catch (IOException e) {
+            throw e;
+        }
+        catch (Exception e) {
+            var mapped = ExceptionMapper.map(e);
+            responseWriter.writeJson(exchange, (int)mapped[0], mapped[1]);
+        }
+    }
+
+    /**
+     * Parses our path parameter if one was given, and resolves it to an actual filesystem path
+     * within our media directory. If the given path is outside of our media directory or does
+     * not exist, we will ignore it and return the media directory instead.
+     */
+    private Path resolvePathParameter(HttpExchange exchange) {
+        String query = exchange.getRequestURI().getQuery();
+        Map<String, String> params = QueryParamParser.parse(query);
+        Path mediaDirPath = appConfig.getMediaDir();
+        Path pathParam = Path.of(params.getOrDefault("path", mediaDirPath.toAbsolutePath().toString())).normalize();
+
+        // If the given path is not within our media dir, ignore it and use mediaDir instead.
+        if (!pathParam.startsWith(mediaDirPath.normalize())) {
+            log.warning("Received file browser request with path outside media directory: " + pathParam);
+            return mediaDirPath.normalize();
+        }
+
+        // If the given path does not actually exist, ignore it and use mediaDir instead.
+        if (!Files.exists(pathParam)) {
+            log.warning("Received file browser request with non-existent path: " + pathParam);
+            return mediaDirPath.normalize();
+        }
+
+        // If the given path exists but is a file, that's okay, just use its parent directory instead.
+        // The UI can use this to supply a media file, and we will silently do the right thing.
+        if (Files.isRegularFile(pathParam)) {
+            pathParam = pathParam.getParent();
+        }
+
+        return pathParam;
+    }
+
+    /**
+     * Given a directory, returns a list of its immediate children, sorted with directories first and then files,
+     * and with names sorted alphabetically within those groups. If the given path is not
+     * a directory or doesn't exist, returns an empty list.
+     */
+    private List<File> listFiles(Path directory) {
+        File dirFile = directory.toFile();
+        if (!dirFile.exists() || !dirFile.isDirectory()) {
+            log.warning("Attempted to list files in non-existent or non-directory path: " + directory);
+            return List.of();
+        }
+        File[] children = dirFile.listFiles();
+        if (children == null) {
+            log.warning("Failed to list files in directory (null returned): " + directory);
+            return List.of();
+        }
+        Arrays.sort(children, Comparator
+                .comparing((File f) -> !f.isDirectory())
+                .thenComparing(f -> f.getName().toLowerCase()));
+        return Arrays.asList(children);
+    }
+
+    /**
+     * Builds and returns a Map representing the JSON response for a file listing.
+     * The map will include the absolute path of the current directory, the absolute path
+     * of the parent directory if it's not the media directory, and a list of entries
+     * representing the immediate children of the current directory.
+     * Each entry includes the name, type (file or directory), and absolute path of the child.
+     * <p>
+     *     Sample response:
+     * </p>
+     * <pre>
+     * {
+     *   "path": "/path/to/mediaDir/subdir",
+     *   "parent": "/path/to/mediaDir", // omitted if current directory is media dir
+     *   "entries": [
+     *   {
+     *     "name": "child1",
+     *     "type": "directory",
+     *     "path": "/path/to/mediaDir/subdir/child1"
+     *   },
+     *   {
+     *     "name": "child2.mp4",
+     *     "type": "file",
+     *     "path": "/path/to/mediaDir/subdir/child2.mp4"
+     *   }
+     *   // ... more entries ...
+     *   ]
+     * }
+     * </pre>
+     */
+    private Map<String, Object> buildResponse(Path currentPath, List<File> files) {
+        Map<String, Object> response = new HashMap<>();
+        response.put("path", currentPath.toAbsolutePath().toString());
+        if (!currentPath.equals(appConfig.getMediaDir())) {
+            response.put("parent", currentPath.getParent().toAbsolutePath().toString());
+        }
+        List<Map<String, String>> entries = new ArrayList<>();
+        for (File file : files) {
+            // Skip hidden files:
+            if (file.getName().startsWith(".")) {
+                continue;
+            }
+            // Skip symbolic links to avoid traversal outside the browsed tree
+            if (Files.isSymbolicLink(file.toPath())) {
+                continue;
+            }
+            Map<String, String> entry = new HashMap<>();
+            entry.put("name", file.getName());
+            entry.put("type", file.isDirectory() ? "directory" : "file");
+            entry.put("path", file.getAbsolutePath());
+            entries.add(entry);
+        }
+        response.put("entries", entries);
+        return response;
+    }
+}

--- a/backend/src/main/java/ca/corbett/movienight/api/handler/StreamHandler.java
+++ b/backend/src/main/java/ca/corbett/movienight/api/handler/StreamHandler.java
@@ -74,7 +74,10 @@ public class StreamHandler implements HttpHandler {
             }
         }
         catch (Exception e) {
-            throw new IOException(e);
+            // Getting a lot of these, but they seem harmless.
+            if (!"Connection reset by peer".equals(e.getMessage())) {
+                throw new IOException(e);
+            }
         }
     }
 

--- a/backend/src/main/java/ca/corbett/movienight/service/MediaItemService.java
+++ b/backend/src/main/java/ca/corbett/movienight/service/MediaItemService.java
@@ -3,9 +3,11 @@ package ca.corbett.movienight.service;
 import ca.corbett.movienight.api.dto.MediaItemListResponse;
 import ca.corbett.movienight.api.dto.MediaItemResponse;
 import ca.corbett.movienight.api.dto.MediaItemUpsertRequest;
+import ca.corbett.movienight.config.AppConfig;
 import ca.corbett.movienight.db.Database;
 import ca.corbett.movienight.model.MediaItem;
 
+import java.nio.file.FileSystems;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -22,11 +24,11 @@ import java.util.stream.Collectors;
 public final class MediaItemService {
 
     private final Database database;
-    private final int defaultPageSize;
+    private final AppConfig appConfig;
 
-    public MediaItemService(Database database, int defaultPageSize) {
+    public MediaItemService(Database database, AppConfig appConfig) {
         this.database = database;
-        this.defaultPageSize = defaultPageSize;
+        this.appConfig = appConfig;
     }
 
     /**
@@ -43,7 +45,7 @@ public final class MediaItemService {
         item.setTitle(request.getTitle());
         item.setDescription(request.getDescription());
         item.setLastWatchedDate(request.getLastWatchedDate());
-        item.setMediaFilePath(request.getMediaFilePath());
+        item.setMediaFilePath(convertMediaPathToRelative(request.getMediaFilePath()));
         item.setTags(request.getTags());
 
         database.createMediaItem(item);
@@ -123,7 +125,7 @@ public final class MediaItemService {
         item.setTitle(request.getTitle());
         item.setDescription(request.getDescription());
         item.setLastWatchedDate(request.getLastWatchedDate());
-        item.setMediaFilePath(request.getMediaFilePath());
+        item.setMediaFilePath(convertMediaPathToRelative(request.getMediaFilePath()));
         item.setTags(request.getTags());
 
         try {
@@ -161,9 +163,27 @@ public final class MediaItemService {
                 item.getTitle(),
                 item.getDescription(),
                 item.getLastWatchedDate(),
-                item.getMediaFilePath(),
+                convertMediaPathToRelative(item.getMediaFilePath()),
                 item.getTags(),
                 item.isHasThumbnail()
         );
+    }
+
+    /**
+     * Given any mediaFilePath, will convert it to a relative path if it starts with the media directory base path.
+     * If the path already appears to be relative (does not start with mediaDir), it will be returned as-is.
+     */
+    private String convertMediaPathToRelative(String mediaFilePath) {
+        String basePath = appConfig.getMediaDir().toAbsolutePath().toString();
+        if (mediaFilePath.startsWith(basePath)) {
+            return mediaFilePath.substring(basePath.length());
+        }
+
+        // Strip leading file separator if present
+        if (mediaFilePath.startsWith(FileSystems.getDefault().getSeparator()) && mediaFilePath.length() > 1) {
+            mediaFilePath = mediaFilePath.substring(1);
+        }
+
+        return mediaFilePath; // return as-is if it doesn't start with base path
     }
 }

--- a/backend/src/main/java/ca/corbett/movienight/service/MediaItemService.java
+++ b/backend/src/main/java/ca/corbett/movienight/service/MediaItemService.java
@@ -174,9 +174,10 @@ public final class MediaItemService {
      * If the path already appears to be relative (does not start with mediaDir), it will be returned as-is.
      */
     private String convertMediaPathToRelative(String mediaFilePath) {
-        String basePath = appConfig.getMediaDir().toAbsolutePath().toString();
-        if (mediaFilePath.startsWith(basePath)) {
-            return mediaFilePath.substring(basePath.length());
+        java.nio.file.Path basePath = appConfig.getMediaDir().toAbsolutePath().normalize();
+        java.nio.file.Path candidatePath = java.nio.file.Path.of(mediaFilePath).toAbsolutePath().normalize();
+        if (candidatePath.startsWith(basePath)) {
+            return basePath.relativize(candidatePath).toString();
         }
 
         // Strip leading file separator if present

--- a/backend/src/test/java/ca/corbett/movienight/api/ApiIntegrationTest.java
+++ b/backend/src/test/java/ca/corbett/movienight/api/ApiIntegrationTest.java
@@ -919,6 +919,66 @@ class ApiIntegrationTest {
     }
 
     @Test
+    void createItem_withAbsoluteMediaFilePath_shouldSaveAsRelativePath() throws Exception {
+        // Given an absolute path for our new media item:
+        final String mediaFilePath = tempDir.resolve("subdir1/subdir2/ep1.mkv").toString();
+
+        // WHEN we save it:
+        long groupId = createTestGroup("Group", null);
+        String requestBody = """
+                {
+                    "title": "Episode 1",
+                    "description": "Pilot",
+                    "lastWatchedDate": "2026-05-01",
+                    "mediaFilePath": "%s",
+                    "tags": ["crime", "drama"]
+                }
+                """.formatted(mediaFilePath);
+        HttpResponse<String> response = sendRequest(
+                HttpRequest.newBuilder()
+                           .uri(URI.create(BASE_URL + "/media-groups/" + groupId + "/items"))
+                           .header("Content-Type", "application/json")
+                           .POST(HttpRequest.BodyPublishers.ofString(requestBody))
+                           .build()
+        );
+
+        // THEN the path should have had the media dir stripped off and been saved as a relative path:
+        assertEquals(201, response.statusCode());
+        Map<String, Object> json = parseJson(response.body());
+        assertEquals("subdir1/subdir2/ep1.mkv", json.get("mediaFilePath"));
+    }
+
+    @Test
+    void createItem_withRelativeMediaFilePath_shouldSaveAsIs() throws Exception {
+        // Given a relative path for our new media item:
+        final String mediaFilePath = "subdir1/subdir2/ep1.mkv";
+
+        // WHEN we save it:
+        long groupId = createTestGroup("Group", null);
+        String requestBody = """
+                {
+                    "title": "Episode 1",
+                    "description": "Pilot",
+                    "lastWatchedDate": "2026-05-01",
+                    "mediaFilePath": "%s",
+                    "tags": ["crime", "drama"]
+                }
+                """.formatted(mediaFilePath);
+        HttpResponse<String> response = sendRequest(
+                HttpRequest.newBuilder()
+                           .uri(URI.create(BASE_URL + "/media-groups/" + groupId + "/items"))
+                           .header("Content-Type", "application/json")
+                           .POST(HttpRequest.BodyPublishers.ofString(requestBody))
+                           .build()
+        );
+
+        // THEN the path should be saved as-is:
+        assertEquals(201, response.statusCode());
+        Map<String, Object> json = parseJson(response.body());
+        assertEquals("subdir1/subdir2/ep1.mkv", json.get("mediaFilePath"));
+    }
+
+    @Test
     void updateItem_fullReplacement_returns200() throws Exception {
         long groupId = createTestGroup("Group", null);
         long itemId = createTestItem(groupId, "Original", "/original.mkv");

--- a/frontend/src/admin/features/ItemForm.tsx
+++ b/frontend/src/admin/features/ItemForm.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { z } from 'zod';
 import type { ItemUpsertPayload, MediaGroup } from '../../api/types';
+import { FileBrowserField } from '../../components/shared/FileBrowserField';
 import { Badge } from '../../components/ui/Badge';
 import { Button } from '../../components/ui/Button';
 import { Input } from '../../components/ui/Input';
@@ -85,11 +86,21 @@ export function ItemForm({ groups, initialValues, loading, onSubmit }: ItemFormP
         <FieldError message={form.formState.errors.title?.message} />
       </div>
 
-      <div className="space-y-2">
-        <label className="text-sm font-medium text-content">Media file path</label>
-        <Input error={Boolean(form.formState.errors.mediaFilePath)} {...form.register('mediaFilePath')} />
-        <FieldError message={form.formState.errors.mediaFilePath?.message} />
-      </div>
+      <Controller
+        control={form.control}
+        name="mediaFilePath"
+        render={({ field }) => (
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-content">Media file path</label>
+            <FileBrowserField
+              value={field.value}
+              onChange={field.onChange}
+              error={Boolean(form.formState.errors.mediaFilePath)}
+            />
+            <FieldError message={form.formState.errors.mediaFilePath?.message} />
+          </div>
+        )}
+      />
 
       <div className="space-y-2">
         <label className="text-sm font-medium text-content">Description</label>

--- a/frontend/src/api/files.ts
+++ b/frontend/src/api/files.ts
@@ -1,0 +1,17 @@
+import { apiFetch, buildQueryString } from './client';
+
+export interface FileBrowserEntry {
+  name: string;
+  type: 'file' | 'directory';
+  path: string;
+}
+
+export interface FileBrowserResponse {
+  path: string;
+  parent?: string;
+  entries: FileBrowserEntry[];
+}
+
+export function listFiles(path?: string): Promise<FileBrowserResponse> {
+  return apiFetch<FileBrowserResponse>(`files/${buildQueryString({ path })}`);
+}

--- a/frontend/src/components/shared/FileBrowserField.tsx
+++ b/frontend/src/components/shared/FileBrowserField.tsx
@@ -1,0 +1,170 @@
+import { useQuery } from '@tanstack/react-query';
+import { useState } from 'react';
+import { listFiles } from '../../api/files';
+import type { FileBrowserEntry } from '../../api/files';
+import { cn } from '../../lib/cn';
+import { Button } from '../ui/Button';
+import { Dialog } from '../ui/Dialog';
+
+interface FileBrowserFieldProps {
+  value: string;
+  onChange: (path: string) => void;
+  error?: boolean;
+  disabled?: boolean;
+}
+
+function FolderIcon(): JSX.Element {
+  return (
+    <svg
+      className="h-4 w-4 shrink-0 text-warning"
+      fill="currentColor"
+      viewBox="0 0 20 20"
+      aria-hidden="true"
+    >
+      <path d="M2 6a2 2 0 012-2h4l2 2h6a2 2 0 012 2v6a2 2 0 01-2 2H4a2 2 0 01-2-2V6z" />
+    </svg>
+  );
+}
+
+function FileIcon(): JSX.Element {
+  return (
+    <svg
+      className="h-4 w-4 shrink-0 text-brand"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M3.375 19.5h17.25m-17.25 0a1.125 1.125 0 01-1.125-1.125M3.375 19.5h1.5C5.496 19.5 6 18.996 6 18.375m-3.75.125V14.25m0 5.25V14.25m0 0a1.125 1.125 0 011.125-1.125h9.75a1.125 1.125 0 011.125 1.125M3.375 14.25h17.25M21 12.75a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12V9z"
+      />
+    </svg>
+  );
+}
+
+function UpIcon(): JSX.Element {
+  return (
+    <svg
+      className="h-4 w-4"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={2}
+      viewBox="0 0 24 24"
+      aria-hidden="true"
+    >
+      <path strokeLinecap="round" strokeLinejoin="round" d="M5 10l7-7m0 0l7 7m-7-7v18" />
+    </svg>
+  );
+}
+
+export function FileBrowserField({
+  value,
+  onChange,
+  error,
+  disabled,
+}: FileBrowserFieldProps): JSX.Element {
+  const [open, setOpen] = useState(false);
+  const [browsePath, setBrowsePath] = useState<string | undefined>(undefined);
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['files', browsePath ?? null],
+    queryFn: () => listFiles(browsePath),
+    enabled: open,
+  });
+
+  function handleOpen() {
+    setBrowsePath(value || undefined);
+    setOpen(true);
+  }
+
+  function handleClose() {
+    setOpen(false);
+  }
+
+  function handleEntryClick(entry: FileBrowserEntry) {
+    if (entry.type === 'directory') {
+      setBrowsePath(entry.path);
+    } else {
+      onChange(entry.path);
+      setOpen(false);
+    }
+  }
+
+  return (
+    <>
+      <div className="flex gap-2">
+        <div
+          className={cn(
+            'flex h-10 min-w-0 flex-1 items-center overflow-hidden rounded-md border bg-input-bg px-3 text-sm shadow-sm',
+            error ? 'border-danger' : 'border-input-border',
+            value ? 'text-content' : 'text-content-muted',
+          )}
+        >
+          <span className="truncate">{value || 'No file selected'}</span>
+        </div>
+        <Button type="button" variant="secondary" onClick={handleOpen} disabled={disabled}>
+          Browse…
+        </Button>
+      </div>
+
+      <Dialog open={open} title="Browse for media file" onClose={handleClose} size="md">
+        <div className="space-y-3">
+          <div className="flex min-h-[1.75rem] items-center gap-2">
+            {data?.parent ? (
+              <button
+                type="button"
+                className="inline-flex shrink-0 items-center gap-1 rounded px-2 py-1 text-xs font-medium text-content-secondary transition-colors hover:bg-bg-subtle hover:text-content"
+                onClick={() => setBrowsePath(data.parent)}
+              >
+                <UpIcon />
+                Up
+              </button>
+            ) : null}
+            {data ? (
+              <p className="truncate font-mono text-xs text-content-secondary">{data.path}</p>
+            ) : null}
+          </div>
+
+          <div className="max-h-96 overflow-y-auto rounded-md border border-border-subtle">
+            {isLoading ? (
+              <div className="flex items-center justify-center px-4 py-10 text-sm text-content-muted">
+                Loading…
+              </div>
+            ) : isError ? (
+              <div className="px-4 py-10 text-center text-sm text-danger">
+                Could not load files. Check server connection.
+              </div>
+            ) : data?.entries.length === 0 ? (
+              <div className="px-4 py-10 text-center text-sm text-content-muted">
+                This folder is empty.
+              </div>
+            ) : (
+              <ul role="listbox" aria-label="Files and folders">
+                {data?.entries.map((entry) => (
+                  <li key={entry.path} role="option" aria-selected={false}>
+                    <button
+                      type="button"
+                      className={cn(
+                        'flex w-full items-center gap-3 border-b border-border-subtle px-4 py-2.5 text-left text-sm transition-colors last:border-b-0',
+                        entry.type === 'file'
+                          ? 'hover:bg-bg-subtle text-content font-medium'
+                          : 'hover:bg-bg-subtle text-content-secondary',
+                      )}
+                      onClick={() => handleEntryClick(entry)}
+                    >
+                      {entry.type === 'directory' ? <FolderIcon /> : <FileIcon />}
+                      <span className="truncate">{entry.name}</span>
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+      </Dialog>
+    </>
+  );
+}


### PR DESCRIPTION
This PR addresses issue #86 by introducing a server-side file browser to allow easy selection of media files from within the server's configured media directory. This affected both backend and frontend:

- Backend: add a single `files` endpoint that the UI can use to browse the server's filesystem. The API locks the browser to the configured media directory or any subdirectory. The list of returned files is filtered to only include common video file types. Mofied the item service to accept absolute paths from the frontend and convert them to relative paths before storage. Added unit tests.
- Frontend: added a new file browser component following the pattern of other existing components. This replaces the free-text input field when adding or editing media items. The user can visually select the media file instead of typing its path.
