### PR TITLE
Issue #91 fix playlist download

### DIFF
--- a/backend/src/main/java/ca/corbett/movienight/api/handler/PlaylistHandler.java
+++ b/backend/src/main/java/ca/corbett/movienight/api/handler/PlaylistHandler.java
@@ -226,7 +226,10 @@ public class PlaylistHandler implements HttpHandler {
 
         MediaGroup group = database.getMediaGroupById(groupId);
         if (group == null) {
-            throw new Database.NotFoundException("Media group not found with ID: " + groupId);
+            log.warning("Playlist requested for non-existent media group with ID: " + groupId);
+            String playlist = "#EXTM3U\n"; // empty playlist
+            responseWriter.writePlaylist(exchange, HttpURLConnection.HTTP_OK, playlist, "Empty Playlist");
+            return;
         }
         List<MediaItem> items = database.getMediaItemsByGroupId(groupId);
         String playlist = generatePlaylist(items, appConfig, getServerName(exchange), isLocal);

--- a/backend/src/main/java/ca/corbett/movienight/api/handler/PlaylistHandler.java
+++ b/backend/src/main/java/ca/corbett/movienight/api/handler/PlaylistHandler.java
@@ -6,6 +6,7 @@ import ca.corbett.movienight.api.util.RequestParser;
 import ca.corbett.movienight.api.util.ResponseWriter;
 import ca.corbett.movienight.config.AppConfig;
 import ca.corbett.movienight.db.Database;
+import ca.corbett.movienight.model.MediaGroup;
 import ca.corbett.movienight.model.MediaItem;
 import ca.corbett.movienight.service.MediaGroupService;
 import com.sun.net.httpserver.HttpExchange;
@@ -181,7 +182,7 @@ public class PlaylistHandler implements HttpHandler {
         }
 
         String playlist = generatePlaylist(List.of(item), appConfig, getServerName(exchange), isLocal);
-        responseWriter.writeText(exchange, HttpURLConnection.HTTP_OK, playlist);
+        responseWriter.writePlaylist(exchange, HttpURLConnection.HTTP_OK, playlist, item.getTitle());
     }
 
     private void handleSingleMediaItemPlaylist(HttpExchange exchange, boolean isLocal) throws Exception {
@@ -208,7 +209,7 @@ public class PlaylistHandler implements HttpHandler {
         }
 
         String playlist = generatePlaylist(List.of(item), appConfig, getServerName(exchange), isLocal);
-        responseWriter.writeText(exchange, HttpURLConnection.HTTP_OK, playlist);
+        responseWriter.writePlaylist(exchange, HttpURLConnection.HTTP_OK, playlist, item.getTitle());
     }
 
     private void handleMediaGroupPlaylist(HttpExchange exchange, String groupIdStr, boolean isLocal) throws Exception {
@@ -223,9 +224,13 @@ public class PlaylistHandler implements HttpHandler {
             throw new IllegalArgumentException("Media group ID must be a positive integer: " + groupIdStr);
         }
 
+        MediaGroup group = database.getMediaGroupById(groupId);
+        if (group == null) {
+            throw new Database.NotFoundException("Media group not found with ID: " + groupId);
+        }
         List<MediaItem> items = database.getMediaItemsByGroupId(groupId);
         String playlist = generatePlaylist(items, appConfig, getServerName(exchange), isLocal);
-        responseWriter.writeText(exchange, HttpURLConnection.HTTP_OK, playlist);
+        responseWriter.writePlaylist(exchange, HttpURLConnection.HTTP_OK, playlist, group.getTitle());
     }
 
     private void handleMultiMediaItemPlaylist(HttpExchange exchange, boolean isLocal) throws Exception {
@@ -247,7 +252,7 @@ public class PlaylistHandler implements HttpHandler {
         }
 
         String playlist = generatePlaylist(items, appConfig, getServerName(exchange), isLocal);
-        responseWriter.writeText(exchange, HttpURLConnection.HTTP_OK, playlist);
+        responseWriter.writePlaylist(exchange, HttpURLConnection.HTTP_OK, playlist);
     }
 
     private String getServerName(HttpExchange exchange) {

--- a/backend/src/main/java/ca/corbett/movienight/api/util/ResponseWriter.java
+++ b/backend/src/main/java/ca/corbett/movienight/api/util/ResponseWriter.java
@@ -73,4 +73,35 @@ public final class ResponseWriter {
             os.write(bytes);
         }
     }
+
+    public void writePlaylist(HttpExchange exchange, int statusCode, String playlist) throws Exception {
+        writePlaylist(exchange, statusCode, playlist, "playlist");
+    }
+
+    /**
+     * Writes an M3U playlist response body with the given status code.
+     * Sets {@code Content-Type: audio/x-mpegurl} and a
+     * {@code Content-Disposition: attachment; filename="playlist.m3u"} header so that
+     * browsers download the file with the correct {@code .m3u} extension rather than
+     * sniffing the {@code #EXTM3U} header and mis-classifying the response as an HLS
+     * ({@code .m3u8}) stream.
+     *
+     * @param exchange   the HTTP exchange
+     * @param statusCode the HTTP status code
+     * @param playlist   the M3U playlist content
+     * @param filename   the filename to suggest in the Content-Disposition header (without extension)
+     * @throws IOException if writing fails
+     */
+    public void writePlaylist(HttpExchange exchange, int statusCode, String playlist, String filename)
+            throws IOException {
+        byte[] bytes = playlist.getBytes(StandardCharsets.UTF_8);
+
+        exchange.getResponseHeaders().set("Content-Type", "audio/x-mpegurl; charset=utf-8");
+        exchange.getResponseHeaders().set("Content-Disposition", "attachment; filename=\"" + filename + ".m3u\"");
+        exchange.sendResponseHeaders(statusCode, bytes.length);
+
+        try (OutputStream os = exchange.getResponseBody()) {
+            os.write(bytes);
+        }
+    }
 }

--- a/backend/src/main/java/ca/corbett/movienight/api/util/ResponseWriter.java
+++ b/backend/src/main/java/ca/corbett/movienight/api/util/ResponseWriter.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.nio.charset.StandardCharsets;
+import java.util.regex.Pattern;
 
 /**
  * Utility for writing HTTP responses.
@@ -19,6 +20,12 @@ import java.nio.charset.StandardCharsets;
 public final class ResponseWriter {
 
     private static final String CONTENT_TYPE = "application/json; charset=utf-8";
+    private static final Pattern INVALID_CHARS = Pattern.compile("[^a-zA-Z0-9.-]");
+    private static final Pattern LEADING_DOTS = Pattern.compile("^\\.+");
+    private static final Pattern WINDOWS_RESERVED = Pattern.compile(
+            "^(CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])(\\..*)?$",
+            Pattern.CASE_INSENSITIVE
+    );
 
     private final ObjectMapper objectMapper;
 
@@ -74,7 +81,7 @@ public final class ResponseWriter {
         }
     }
 
-    public void writePlaylist(HttpExchange exchange, int statusCode, String playlist) throws Exception {
+    public void writePlaylist(HttpExchange exchange, int statusCode, String playlist) throws IOException {
         writePlaylist(exchange, statusCode, playlist, "playlist");
     }
 
@@ -95,13 +102,47 @@ public final class ResponseWriter {
     public void writePlaylist(HttpExchange exchange, int statusCode, String playlist, String filename)
             throws IOException {
         byte[] bytes = playlist.getBytes(StandardCharsets.UTF_8);
+        String safeFilename = sanitizeFilename(filename, filename);
 
         exchange.getResponseHeaders().set("Content-Type", "audio/x-mpegurl; charset=utf-8");
-        exchange.getResponseHeaders().set("Content-Disposition", "attachment; filename=\"" + filename + ".m3u\"");
+        exchange.getResponseHeaders().set("Content-Disposition", "attachment; filename=\"" + safeFilename + ".m3u\"");
         exchange.sendResponseHeaders(statusCode, bytes.length);
 
         try (OutputStream os = exchange.getResponseBody()) {
             os.write(bytes);
         }
+    }
+
+    /**
+     * Given any arbitrary String, returns a sanitized version that is safe to use as a filename
+     * on any operating system. If the given input is null or empty, or if the resulting sanitized
+     * filename is empty, the given defaultName will be returned.
+     * <p>
+     * The only allowable characters are alphanumeric characters, dots (.), hyphens (-), and underscores (_).
+     * All other characters are replaced with underscores. Leading dots are removed. On Windows,
+     * reserved filenames such as "CON" or "AUX" are prefixed with an underscore. The resulting filename
+     * is truncated to a maximum of 200 characters.
+     * </p>
+     * <p>
+     * Note: copy+pasted from swing-extras 2.9
+     * </p>
+     */
+    public static String sanitizeFilename(String input, String defaultName) {
+        if (input == null || input.trim().isEmpty()) {
+            return defaultName;
+        }
+
+        String sanitized = INVALID_CHARS.matcher(input).replaceAll("_");
+        sanitized = LEADING_DOTS.matcher(sanitized).replaceFirst("");
+
+        if (WINDOWS_RESERVED.matcher(sanitized).matches()) {
+            sanitized = "_" + sanitized;
+        }
+
+        if (sanitized.length() > 200) {
+            sanitized = sanitized.substring(0, 200);
+        }
+
+        return sanitized.isEmpty() ? defaultName : sanitized;
     }
 }

--- a/backend/src/test/java/ca/corbett/movienight/api/ApiIntegrationTest.java
+++ b/backend/src/test/java/ca/corbett/movienight/api/ApiIntegrationTest.java
@@ -1686,6 +1686,32 @@ class ApiIntegrationTest {
     }
 
     @Test
+    void playlist_withWonkyFilename_shouldSanitize() throws Exception {
+        // Given a media item with a title that is not a valid filename:
+        long groupId = createTestGroup("Group", null);
+        long itemId = createTestItem(groupId, "///***InvalidFilename!!!??", "/test-movie.mkv");
+
+        // Create the actual media file on disk
+        Path mediaFile = tempDir.resolve("test-movie.mkv");
+        Files.writeString(mediaFile, "fake video content");
+
+        // When we request a playlist for this item:
+        HttpResponse<String> response = sendRequest(
+                HttpRequest.newBuilder()
+                           .uri(URI.create(BASE_URL + "/playlist/media-item/" + itemId))
+                           .GET()
+                           .build()
+        );
+
+        assertEquals(200, response.statusCode());
+        assertEquals("audio/x-mpegurl; charset=utf-8", response.headers().firstValue("Content-Type").orElse(""));
+        String contentDisposition = response.headers().firstValue("Content-Disposition").orElse(null);
+        assertNotNull(contentDisposition); // should have one
+        assertTrue(contentDisposition.contains("attachment")); // should name an attachment
+        assertTrue(contentDisposition.contains("\"______InvalidFilename_____.m3u\"")); // should sanitize to this
+    }
+
+    @Test
     void playlist_singleMediaItem_nonexistent_returns404() throws Exception {
         HttpResponse<String> response = sendRequest(
                 HttpRequest.newBuilder()

--- a/backend/src/test/java/ca/corbett/movienight/api/ApiIntegrationTest.java
+++ b/backend/src/test/java/ca/corbett/movienight/api/ApiIntegrationTest.java
@@ -1645,6 +1645,11 @@ class ApiIntegrationTest {
 
         assertEquals(200, response.statusCode());
         assertEquals("audio/x-mpegurl; charset=utf-8", response.headers().firstValue("Content-Type").orElse(""));
+        String contentDisposition = response.headers().firstValue("Content-Disposition").orElse(null);
+        assertNotNull(contentDisposition); // should have one
+        assertTrue(contentDisposition.contains("attachment")); // should name an attachment
+        assertTrue(contentDisposition.contains(".m3u")); // extension should be .m3u
+        assertFalse(contentDisposition.contains(".m3u8")); // should NOT be .m3u8
         String body = response.body();
         assertTrue(body.startsWith("#EXTM3U"));
         assertTrue(body.contains("#EXTINF:-1,Test Movie"));
@@ -1669,6 +1674,11 @@ class ApiIntegrationTest {
 
         assertEquals(200, response.statusCode());
         assertEquals("audio/x-mpegurl; charset=utf-8", response.headers().firstValue("Content-Type").orElse(""));
+        String contentDisposition = response.headers().firstValue("Content-Disposition").orElse(null);
+        assertNotNull(contentDisposition); // should have one
+        assertTrue(contentDisposition.contains("attachment")); // should name an attachment
+        assertTrue(contentDisposition.contains(".m3u")); // extension should be .m3u
+        assertFalse(contentDisposition.contains(".m3u8")); // should NOT be .m3u8
         String body = response.body();
         assertTrue(body.startsWith("#EXTM3U"));
         assertTrue(body.contains("#EXTINF:-1,Test Movie"));

--- a/backend/src/test/java/ca/corbett/movienight/api/ApiIntegrationTest.java
+++ b/backend/src/test/java/ca/corbett/movienight/api/ApiIntegrationTest.java
@@ -1644,7 +1644,7 @@ class ApiIntegrationTest {
         );
 
         assertEquals(200, response.statusCode());
-        assertEquals("text/plain; charset=utf-8", response.headers().firstValue("Content-Type").orElse(""));
+        assertEquals("audio/x-mpegurl; charset=utf-8", response.headers().firstValue("Content-Type").orElse(""));
         String body = response.body();
         assertTrue(body.startsWith("#EXTM3U"));
         assertTrue(body.contains("#EXTINF:-1,Test Movie"));
@@ -1668,7 +1668,7 @@ class ApiIntegrationTest {
         );
 
         assertEquals(200, response.statusCode());
-        assertEquals("text/plain; charset=utf-8", response.headers().firstValue("Content-Type").orElse(""));
+        assertEquals("audio/x-mpegurl; charset=utf-8", response.headers().firstValue("Content-Type").orElse(""));
         String body = response.body();
         assertTrue(body.startsWith("#EXTM3U"));
         assertTrue(body.contains("#EXTINF:-1,Test Movie"));


### PR DESCRIPTION
This PR addresses issue #91 by fixing a strange bug in VLC playlist generation.

What happened was the code was setting a `Content-Type` of `text/plain`, and was not setting a `Content-Disposition` at all in the response. This meant that the browser had no idea what kind of file was being downloaded. Apparently, firefox is smart enough to scan the file contents to try to determine a file type, but it was misidentifying the m3u file as a `application/vnd.apple.mpegurl` file, since they both start with the string `#EXTM3U`. 

To fix this, there is now an explicit `writePlaylist` method in `ResponseWriter`. This new method ensures that the response is configured correctly for the browser to understand what type of file is being returned. 

Adjusted affected unit tests as needed. Quick manual test looks much better.