### PR TITLE
Issue #93 - better config loading with interactive fallback + inject API base path to UI

### DIFF
--- a/backend/src/main/java/ca/corbett/movienight/Main.java
+++ b/backend/src/main/java/ca/corbett/movienight/Main.java
@@ -2,10 +2,12 @@ package ca.corbett.movienight;
 
 import ca.corbett.movienight.api.ApiServer;
 import ca.corbett.movienight.config.AppConfig;
+import ca.corbett.movienight.config.AppConfigInteractiveBuilder;
 import ca.corbett.movienight.db.Database;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.logging.FileHandler;
 import java.util.logging.Formatter;
 import java.util.logging.Handler;
@@ -22,10 +24,9 @@ public class Main {
     private static FileHandler fileHandler = null;
 
     public static void main(String[] args) throws Exception {
-        configureLogging();
+        AppConfig config = loadAppConfig();
+        configureLogging(config.getLogFile());
         Logger log = Logger.getLogger(Main.class.getName());
-
-        AppConfig config = loadAppConfig(log);
         log.info(config.toString());
 
         Database database = new Database(config);
@@ -34,7 +35,8 @@ public class Main {
 
         ApiServer apiServer = ApiServer.create(config, database);
         apiServer.start();
-        log.info("MovieNight started on port " + config.getPort());
+        log.info("MovieNight web UI: http://localhost:" + config.getPort());
+        log.info("MovieNight API: http://localhost:" + config.getPort() + config.getApiBasePath());
 
         // 4. Register shutdown hook for graceful teardown
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
@@ -53,43 +55,90 @@ public class Main {
     }
 
     /**
-     * Checks for MOVIENIGHT_CONFIG_FILE and attempts to load application configuration from
-     * the named file. If the environment variable is not set, or if loading fails, defaults will be used.
-     * Note that some environment variables can override our defaults, or file-based values.
-     * See AppConfig for details on how configuration is loaded and overridden.
+     * Load order for configuration:
+     * <ol>
+     *     <li>If MOVIENIGHT_CONFIG_FILE is set, read the config file from that location.</li>
+     *     <li>If the env var is unspecified, check the current directory for "MovieNight.conf"</li>
+     *     <li>If not found, check for a subdirectory called "config" and look for it there</li>
+     *     <li>If still not found, we will enter interactive mode, prompting the user to enter
+     *         our config values, and then offer to save that config to a file. We will end with
+     *         instructions on how to set MOVIENIGHT_CONFIG_FILE to point to this file for next time.</li>
+     * </ol>
+     * <p>
+     *     Note that even if a config file is found, it's still possible to override certain values
+     *     with special environment variables. This is documented in the AppConfig class.
+     * </p>
      *
-     * @return A populated AppConfig instance, either loaded from file or with defaults.
+     * @return A populated AppConfig instance.
      */
-    public static AppConfig loadAppConfig(Logger log) {
-        AppConfig config = AppConfig.create();
+    public static AppConfig loadAppConfig() {
+        File configFile;
+
+        // Check out env var first:
         String configPath = System.getenv(AppConfig.ENV_VAR_CONFIG);
         if (configPath != null && !configPath.trim().isEmpty()) {
-            File configFile = new File(configPath);
+            configFile = new File(configPath);
+        }
+
+        // If the env var isn't set, check current directory and then config subdirectory:
+        else {
+            configFile = new File(AppConfig.DEFAULT_CONFIG_FILE_NAME);
+            if (!configFile.exists()) {
+                configFile = new File("config/" + AppConfig.DEFAULT_CONFIG_FILE_NAME);
+                if (!configFile.exists()) {
+                    configFile = null;
+                }
+            }
+        }
+
+        // If we got something above, let's check it:
+        if (configFile != null) {
             if (!configFile.exists() || !configFile.isFile() || !configFile.canRead()) {
-                log.severe("Fatal: Invalid config file specified in " + AppConfig.ENV_VAR_CONFIG + ": " + configPath);
+                System.out.println("Fatal: Invalid config file: " + configFile.getAbsolutePath());
                 System.exit(1);
             }
             try {
-                config = AppConfig.fromFile(configFile);
-                log.info("Config loaded from " + configPath);
+                AppConfig config = AppConfig.fromFile(configFile);
+                System.out.println("Config loaded from " + configFile.getAbsolutePath());
+                return config;
             }
             catch (Exception ex) {
-                log.severe("Fatal: Failed to load config from " + configPath + ": " + ex.getMessage());
+                System.out.println(
+                        "Fatal: Failed to load config from " + configFile.getAbsolutePath() + ": " + ex.getMessage());
                 System.exit(1);
             }
         }
-        else {
-            log.info("Hint: set " + AppConfig.ENV_VAR_CONFIG + " to set custom configuration. Using defaults.");
-        }
 
-        return config;
+        // If we get here, no config file was specified or located.
+        // So, let's go into interactive mode to build one:
+        while (true) {
+            try {
+                return AppConfigInteractiveBuilder.build("No configuration file found!");
+            }
+            catch (InterruptedException ie) {
+                // The user most likely hit Ctrl+C. Just exit silently.
+                System.exit(1);
+            }
+            catch (Exception e) {
+                // Special case the "no console" error:
+                if (AppConfigInteractiveBuilder.NO_CONSOLE_ERROR.equals(e.getMessage())) {
+                    System.out.println(e.getMessage());
+                    System.exit(1);
+                }
+
+                // Otherwise, give the user another shot at it, or let them Ctrl+C to kill us:
+                System.out.println("Error during interactive config setup: " + e.getMessage());
+                e.printStackTrace();
+                System.out.println("Let's try again. (Or hit Ctrl+C to exit.)");
+            }
+        }
     }
 
     /**
      * If MOVIENIGHT_LOG_FILE is set to a valid file path, configures java.util.logging to write logs to that
      * file in addition to the console. Otherwise, logging is stdout only.
      */
-    public static void configureLogging() {
+    private static void configureLogging(Path logPath) {
         CustomLogFormatter customFormatter = new CustomLogFormatter();
 
         // Get the root logger (affects all loggers) and add our custom formatter:
@@ -99,8 +148,7 @@ public class Main {
         }
 
         // It's not a fatal error if we were not given a log file. We'll just output a hint and go with console-only.
-        String logFile = System.getenv(AppConfig.ENV_VAR_LOG_FILE);
-        if (logFile == null || logFile.trim().isEmpty()) {
+        if (logPath == null) {
             System.out.println("Hint: You can set "
                                        + AppConfig.ENV_VAR_LOG_FILE
                                        + " environment variable to enable file logging.");
@@ -111,20 +159,20 @@ public class Main {
         // (this is in addition to console logging, not instead of it).
         try {
             // Ensure the parent directory exists
-            File logPath = new File(logFile);
-            File parentDir = logPath.getParentFile();
+            File logFile = logPath.toFile();
+            File parentDir = logFile.getParentFile();
             if (parentDir != null && !parentDir.exists()) {
                 if (!parentDir.mkdirs()) {
                     throw new IOException("Failed to create log directory: " + parentDir.getAbsolutePath());
                 }
             }
 
-            fileHandler = new FileHandler(logFile, true);
+            fileHandler = new FileHandler(logFile.getAbsolutePath(), true);
             fileHandler.setFormatter(customFormatter);
             rootLogger.addHandler(fileHandler);
 
             // Let console users know where they can find the log file:
-            System.out.println("File logging enabled: " + logFile);
+            System.out.println("File logging enabled: " + logFile.getAbsolutePath());
         }
         catch (IOException | SecurityException e) {
             // Again, not fatal if we couldn't get it set up. Just log a warning and move on.
@@ -136,14 +184,13 @@ public class Main {
     /**
      * A custom log formatter that produces more human-friendly log messages.
      */
-    public static class CustomLogFormatter extends Formatter {
+    private static class CustomLogFormatter extends Formatter {
         @Override
         public String format(LogRecord record) {
             String thrown = "";
-            if (record.getThrown() != null) {
-                for (StackTraceElement element : record.getThrown().getStackTrace()) {
-                    thrown += "\n\tat " + element.toString();
-                }
+            Throwable t = record.getThrown();
+            if (t != null) {
+                thrown = formatThrowable(t);
             }
 
             return String.format("%1$tF %1$tr [%2$s] %3$s%4$s%n",
@@ -151,6 +198,26 @@ public class Main {
                                  record.getLevel().getName(),
                                  formatMessage(record),
                                  thrown);
+        }
+
+        private String formatThrowable(Throwable t) {
+            StringBuilder sb = new StringBuilder();
+            Throwable current = t;
+            while (current != null) {
+                sb.append("\n").append(current.getClass().getName());
+                String message = current.getMessage();
+                if (message != null && !message.isEmpty()) {
+                    sb.append(": ").append(message);
+                }
+                for (StackTraceElement element : current.getStackTrace()) {
+                    sb.append("\n\tat ").append(element.toString());
+                }
+                current = current.getCause();
+                if (current != null) {
+                    sb.append("\nCaused by:");
+                }
+            }
+            return sb.toString();
         }
     }
 }

--- a/backend/src/main/java/ca/corbett/movienight/api/ApiServer.java
+++ b/backend/src/main/java/ca/corbett/movienight/api/ApiServer.java
@@ -114,7 +114,7 @@ public final class ApiServer {
         server.createContext(basePath, apiServer::handleAll);
 
         // Mount the static frontend handler at the root path (catch-all for non-API requests)
-        server.createContext("/", new StaticFrontendHandler());
+        server.createContext("/", new StaticFrontendHandler(config));
 
         return apiServer;
     }

--- a/backend/src/main/java/ca/corbett/movienight/api/handler/StaticFrontendHandler.java
+++ b/backend/src/main/java/ca/corbett/movienight/api/handler/StaticFrontendHandler.java
@@ -143,8 +143,12 @@ public final class StaticFrontendHandler implements HttpHandler {
         String html = new String(htmlBytes, StandardCharsets.UTF_8);
         String apiBasePath = config.getApiBasePath();
 
-        // Escape the path for safe JavaScript string literal
-        String escapedPath = apiBasePath.replace("\\", "\\\\").replace("\"", "\\\"");
+        // Escape the path for safe JavaScript string literal (and prevent </script> injection)
+        String escapedPath = apiBasePath.replace("\\", "\\\\")
+                                        .replace("\"", "\\\"")
+                                        .replace("\n", "\\n")
+                                        .replace("\r", "\\r")
+                                        .replace("<", "\\u003c");
         String injection = "<script>window.API_BASE_PATH=\"" + escapedPath + "\";</script>";
 
         // Insert the script right before </head>, if there is a head element. But only do it once!

--- a/backend/src/main/java/ca/corbett/movienight/api/handler/StaticFrontendHandler.java
+++ b/backend/src/main/java/ca/corbett/movienight/api/handler/StaticFrontendHandler.java
@@ -1,8 +1,10 @@
 package ca.corbett.movienight.api.handler;
 
+import ca.corbett.movienight.config.AppConfig;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URLDecoder;
@@ -25,6 +27,7 @@ import java.util.logging.Logger;
  *     <li>Handles index.html as a default file for directory requests</li>
  *     <li>Returns 404 for missing files</li>
  *     <li>Prevents directory traversal attacks</li>
+ *     <li>Injects the runtime-configured API base path into index.html</li>
  * </ul>
  *
  * @author <a href="https://github.com/scorbo2">scorbo2</a>
@@ -36,11 +39,15 @@ public final class StaticFrontendHandler implements HttpHandler {
     private static final String RESOURCE_BASE = "/static/frontend";
     private static final String INDEX_FILE = "index.html";
 
-    public StaticFrontendHandler() {
+    private final AppConfig config;
+
+    public StaticFrontendHandler(AppConfig config) {
+        this.config = config;
     }
 
     @Override
     public void handle(HttpExchange exchange) throws IOException {
+        log.fine("Received request for " + exchange.getRequestURI());
         try {
             String method = exchange.getRequestMethod();
 
@@ -117,6 +124,11 @@ public final class StaticFrontendHandler implements HttpHandler {
             throws IOException {
         byte[] buffer = readAllBytes(resourceStream);
 
+        // Inject runtime API base path into index.html
+        if (mimeType.startsWith("text/html")) {
+            buffer = injectApiBasePath(buffer);
+        }
+
         exchange.getResponseHeaders().set("Content-Type", mimeType);
         exchange.sendResponseHeaders(200, buffer.length);
 
@@ -127,16 +139,30 @@ public final class StaticFrontendHandler implements HttpHandler {
         }
     }
 
-    private byte[] readAllBytes(InputStream stream) throws IOException {
-        byte[] buffer = new byte[8192];
-        int bytesRead;
-        java.io.ByteArrayOutputStream baos = new java.io.ByteArrayOutputStream();
+    private byte[] injectApiBasePath(byte[] htmlBytes) {
+        String html = new String(htmlBytes, StandardCharsets.UTF_8);
+        String apiBasePath = config.getApiBasePath();
 
-        while ((bytesRead = stream.read(buffer)) != -1) {
-            baos.write(buffer, 0, bytesRead);
+        // Escape the path for safe JavaScript string literal
+        String escapedPath = apiBasePath.replace("\\", "\\\\").replace("\"", "\\\"");
+        String injection = "<script>window.API_BASE_PATH=\"" + escapedPath + "\";</script>";
+
+        // Insert the script right before </head>, if there is a head element. But only do it once!
+        String result = html.replaceFirst("</head>", injection + "</head>");
+        if (!result.contains(injection)) {
+            // Fallback if no </head> tag found: insert at the beginning
+            result = injection + html;
         }
 
-        return baos.toByteArray();
+        return result.getBytes(StandardCharsets.UTF_8);
+    }
+
+    private byte[] readAllBytes(InputStream stream) throws IOException {
+        try (stream) {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            stream.transferTo(baos);
+            return baos.toByteArray();
+        }
     }
 
     private String getMimeType(String resourcePath) {

--- a/backend/src/main/java/ca/corbett/movienight/config/AppConfig.java
+++ b/backend/src/main/java/ca/corbett/movienight/config/AppConfig.java
@@ -377,9 +377,9 @@ public final class AppConfig {
             throw new IOException("dbFile path cannot be null");
         }
 
-        // If the file exists, then it must be readable.
-        if (dbFile.toFile().exists() && !dbFile.toFile().canRead()) {
-            throw new IOException("dbFile exists but is not readable: " + dbFile.toAbsolutePath());
+        // If the file exists, then it must be readable and writable.
+        if (dbFile.toFile().exists() && (!dbFile.toFile().canRead() || !dbFile.toFile().canWrite())) {
+            throw new IOException("dbFile exists but is not read/write: " + dbFile.toAbsolutePath());
         }
 
         // If the file doesn't exist, that's fine, but its parent dir must exist and be writable.

--- a/backend/src/main/java/ca/corbett/movienight/config/AppConfig.java
+++ b/backend/src/main/java/ca/corbett/movienight/config/AppConfig.java
@@ -1,6 +1,7 @@
 package ca.corbett.movienight.config;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -73,14 +74,16 @@ public final class AppConfig {
 
     private static final Logger log = Logger.getLogger(AppConfig.class.getName());
 
-    private static final int DEFAULT_PORT = 8080;
-    private static final Path DEFAULT_DB_FILE = Path.of("MovieNight.db");
-    private static final Path DEFAULT_MEDIA_DIR = Path.of(".");
-    private static final Path DEFAULT_THUMBNAIL_DIR = Path.of("thumbnails");
-    private static final int DEFAULT_PAGE_SIZE = 50;
-    private static final String DEFAULT_API_BASE_PATH = "/api/";
-    private static final int DEFAULT_RANGE_LIMIT_MB = 32;
+    public static final String DEFAULT_CONFIG_FILE_NAME = "MovieNight.conf";
+    public static final int DEFAULT_PORT = 8080;
+    public static final Path DEFAULT_DB_FILE = Path.of("MovieNight.db");
+    public static final Path DEFAULT_MEDIA_DIR = Path.of(".");
+    public static final Path DEFAULT_THUMBNAIL_DIR = Path.of("thumbnails");
+    public static final int DEFAULT_PAGE_SIZE = 50;
+    public static final String DEFAULT_API_BASE_PATH = "/api/";
+    public static final int DEFAULT_RANGE_LIMIT_MB = 32;
 
+    private Path logFile;
     private final int port;
     private Path mediaDir;
     private Path thumbnailDir;
@@ -90,7 +93,7 @@ public final class AppConfig {
     private final int rangeLimitMB;
 
     private AppConfig(int port, Path mediaDir, Path thumbnailDir, Path dbFile,
-                      int pageSize, String apiBasePath, int rangeLimitMB) {
+                      int pageSize, String apiBasePath, int rangeLimitMB, Path logFile) {
         this.port = port;
         this.mediaDir = mediaDir;
         this.dbFile = dbFile;
@@ -98,6 +101,7 @@ public final class AppConfig {
         this.pageSize = pageSize;
         this.apiBasePath = apiBasePath;
         this.rangeLimitMB = rangeLimitMB;
+        this.logFile = logFile;
     }
 
     /**
@@ -127,6 +131,7 @@ public final class AppConfig {
         int pageSize = DEFAULT_PAGE_SIZE;
         String apiBasePath = DEFAULT_API_BASE_PATH;
         int rangeLimitMB = DEFAULT_RANGE_LIMIT_MB;
+        Path logFile = null;
         Properties props = new Properties();
         try (InputStream in = Files.newInputStream(inFile.toPath())) { props.load(in); }
         if (props.containsKey("port")) {
@@ -144,7 +149,7 @@ public final class AppConfig {
             thumbnailDir = requireValidDirectory(Path.of(props.getProperty("thumbnailDir")));
         }
         if (props.containsKey("dbFile")) {
-            dbFile = requireValidDbFile(Path.of(props.getProperty("dbFile")));
+            dbFile = requireValidWritableFile(Path.of(props.getProperty("dbFile")));
         }
         if (props.containsKey("pageSize")) {
             try {
@@ -178,8 +183,12 @@ public final class AppConfig {
                 log.warning("Invalid rangeLimitMB in config file, using default: " + rangeLimitMB);
             }
         }
+        if (props.containsKey("logFile")) {
+            logFile = requireValidWritableFile(Path.of(props.getProperty("logFile")));
+        }
 
-        AppConfig newConfig = new AppConfig(port, mediaDir, thumbnailDir, dbFile, pageSize, apiBasePath, rangeLimitMB);
+        AppConfig newConfig = new AppConfig(port, mediaDir, thumbnailDir, dbFile, pageSize, apiBasePath, rangeLimitMB,
+                                            logFile);
         newConfig.applyEnvVarOverrides(); // Allow environment vars to override what we just built above
         return newConfig;
     }
@@ -190,7 +199,7 @@ public final class AppConfig {
      */
     public static AppConfig create() {
         AppConfig newConfig = new AppConfig(DEFAULT_PORT, DEFAULT_MEDIA_DIR, DEFAULT_THUMBNAIL_DIR, DEFAULT_DB_FILE,
-                             DEFAULT_PAGE_SIZE, DEFAULT_API_BASE_PATH, DEFAULT_RANGE_LIMIT_MB);
+                                            DEFAULT_PAGE_SIZE, DEFAULT_API_BASE_PATH, DEFAULT_RANGE_LIMIT_MB, null);
         newConfig.applyEnvVarOverrides(); // Allow environment vars to override defaults
         return newConfig;
     }
@@ -203,16 +212,17 @@ public final class AppConfig {
      * </p>
      */
     public static AppConfig of(int port, Path mediaDir, Path thumbnailDir, Path dbFile,
-                               int pageSize, String apiBasePath, int rangeLimitMB)
+                               int pageSize, String apiBasePath, int rangeLimitMB, Path logFile)
             throws IOException {
         return new AppConfig(
                 requireValidPort(port),
                 requireValidDirectory(mediaDir),
                 requireValidDirectory(thumbnailDir),
-                requireValidDbFile(dbFile),
+                requireValidWritableFile(dbFile),
                 requireValidPageSize(pageSize),
                 apiBasePath,
-                requireValidMBValue(rangeLimitMB)
+                requireValidMBValue(rangeLimitMB),
+                logFile
         );
     }
 
@@ -228,9 +238,9 @@ public final class AppConfig {
     public static AppConfig withCustomPaths(Path mediaDir, Path thumbnailDir, Path dbFile) throws IOException {
         Path validMediaDir = requireValidDirectory(mediaDir);
         Path validThumbnailDir = requireValidDirectory(thumbnailDir);
-        Path validDbFile = requireValidDbFile(dbFile);
+        Path validDbFile = requireValidWritableFile(dbFile);
         return new AppConfig(DEFAULT_PORT, validMediaDir, validThumbnailDir, validDbFile,
-                             DEFAULT_PAGE_SIZE, DEFAULT_API_BASE_PATH, DEFAULT_RANGE_LIMIT_MB);
+                             DEFAULT_PAGE_SIZE, DEFAULT_API_BASE_PATH, DEFAULT_RANGE_LIMIT_MB, null);
     }
 
     /**
@@ -280,6 +290,13 @@ public final class AppConfig {
     }
 
     /**
+     * Returns the effective logFile path, which is the path to our log file, or null if no log file is configured.
+     */
+    public Path getLogFile() {
+        return logFile;
+    }
+
+    /**
      * Returns the default page size for paginated API responses, such as GET /api/media-groups.
      * This is the number of items that will be returned in each page of results when the client
      * does not specify a page size.
@@ -315,7 +332,7 @@ public final class AppConfig {
             String envDbFile = System.getenv(ENV_VAR_DB_FILE);
             if (envDbFile != null && !envDbFile.trim().isEmpty()) {
                 log.info("Overriding dbFile from environment variable " + ENV_VAR_DB_FILE);
-                dbFile = requireValidDbFile(Path.of(envDbFile));
+                dbFile = requireValidWritableFile(Path.of(envDbFile));
             }
             String mediaDirEnv = System.getenv(ENV_VAR_MEDIA_DIR);
             if (mediaDirEnv != null && !mediaDirEnv.trim().isEmpty()) {
@@ -326,6 +343,11 @@ public final class AppConfig {
             if (thumbnailDirEnv != null && !thumbnailDirEnv.trim().isEmpty()) {
                 log.info("Overriding thumbnailDir from environment variable " + ENV_VAR_THUMBNAIL_DIR);
                 thumbnailDir = requireValidDirectory(Path.of(thumbnailDirEnv));
+            }
+            String logFileEnv = System.getenv(ENV_VAR_LOG_FILE);
+            if (logFileEnv != null && !logFileEnv.trim().isEmpty()) {
+                log.info("Overriding logFile from environment variable " + ENV_VAR_LOG_FILE);
+                logFile = requireValidWritableFile(Path.of(logFileEnv));
             }
         }
         catch (IOException ioe) {
@@ -350,7 +372,7 @@ public final class AppConfig {
         return dir;
     }
 
-    private static Path requireValidDbFile(Path dbFile) throws IOException {
+    private static Path requireValidWritableFile(Path dbFile) throws IOException {
         if (dbFile == null) {
             throw new IOException("dbFile path cannot be null");
         }
@@ -396,6 +418,35 @@ public final class AppConfig {
                 ",\n  defaultPageSize=" + pageSize +
                 ",\n  apiBasePath='" + apiBasePath + '\'' +
                 ",\n  rangeLimitMB=" + rangeLimitMB +
+                ",\n  logFile=" + (logFile != null ? logFile.toAbsolutePath() : "null") +
                 "\n}";
+    }
+
+    /**
+     * Writes all configuration properties to the given file as a Java properties file
+     * (simple name=value format). Overwrites the file if it already exists.
+     * <p>
+     * Properties written: port, mediaDir, dbFile, thumbnailDir, pageSize, apiBasePath,
+     * rangeLimitMB, and logFile (if non-null).
+     * </p>
+     *
+     * @param destination the file to write to; created or overwritten
+     * @throws IOException if the file cannot be written
+     */
+    public void writeToFile(File destination) throws IOException {
+        Properties props = new Properties();
+        props.setProperty("port", String.valueOf(port));
+        props.setProperty("mediaDir", mediaDir.toString());
+        props.setProperty("dbFile", dbFile.toString());
+        props.setProperty("thumbnailDir", thumbnailDir.toString());
+        props.setProperty("pageSize", String.valueOf(pageSize));
+        props.setProperty("apiBasePath", apiBasePath);
+        props.setProperty("rangeLimitMB", String.valueOf(rangeLimitMB));
+        if (logFile != null) {
+            props.setProperty("logFile", logFile.toString());
+        }
+        try (FileOutputStream out = new FileOutputStream(destination)) {
+            props.store(out, "MovieNight configuration");
+        }
     }
 }

--- a/backend/src/main/java/ca/corbett/movienight/config/AppConfigInteractiveBuilder.java
+++ b/backend/src/main/java/ca/corbett/movienight/config/AppConfigInteractiveBuilder.java
@@ -1,0 +1,181 @@
+package ca.corbett.movienight.config;
+
+import java.io.File;
+import java.util.Locale;
+
+/**
+ * This class uses stdin/stdout to interrogate the user for configuration values,
+ * and then builds and returns an AppConfig instance representing those values.
+ * An option will be presented to save the config to a file for future use,
+ * and instructions are provided on how to set MOVIENIGHT_CONFIG_FILE to load it.
+ * <p>
+ * This is just a fallback in the case where we are launched with no configuration.
+ * Rather than guessing defaults, we'll ask the user for it.
+ * </p>
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ */
+public class AppConfigInteractiveBuilder {
+
+    public static final String NO_CONSOLE_ERROR = "Interactive mode requires a terminal. Set "
+            + AppConfig.ENV_VAR_CONFIG + " to use a config file instead.";
+
+    private AppConfigInteractiveBuilder() {
+    }
+
+    /**
+     * Starts the process of building out an AppConfig instance interactively.
+     * You can specify an optional banner message to be displayed before we begin.
+     *
+     * @param bannerMsg Optional display message. If non-null and not blank, will be output before we begin.
+     * @return A populated AppConfig instance.
+     * @throws Exception on certain validation errors. We try to pre-validate before creating AppConfig.
+     */
+    public static AppConfig build(String bannerMsg) throws Exception {
+        if (bannerMsg != null && !bannerMsg.trim().isEmpty()) {
+            System.out.println(bannerMsg);
+            System.out.println();
+        }
+
+        // Make sure we have access to a console. This is not guaranteed.
+        // We may be running as a systemd service, or someone may have redirected stdin/stdout, etc.
+        if (System.console() == null) {
+            throw new Exception(NO_CONSOLE_ERROR);
+        }
+
+        // We'll ask for the important ones:
+        int port = askInt("What port shall we listen on?", AppConfig.DEFAULT_PORT, 1, 65535);
+        File mediaDir = askExistingDir("Where are our media files?",
+                                       AppConfig.DEFAULT_MEDIA_DIR.toAbsolutePath().toString());
+        File thumbDir = askExistingDir("Where are our thumbnails?",
+                                       AppConfig.DEFAULT_THUMBNAIL_DIR.toAbsolutePath().toString());
+        File dbFile = askWritableFile("Where is our database file?",
+                                      AppConfig.DEFAULT_DB_FILE.toAbsolutePath().toString());
+        if (!dbFile.exists()) {
+            System.out.println("Database file does not exist. Will be created.");
+        }
+
+        // The less important ones, eh, we'll supply defaults.
+        // This shouldn't feel like a drawn-out interrogation.
+        int pageSize = AppConfig.DEFAULT_PAGE_SIZE;
+        int rangeLimitMB = AppConfig.DEFAULT_RANGE_LIMIT_MB;
+        String apiBasePath = AppConfig.DEFAULT_API_BASE_PATH;
+        System.setProperty("VITE_API_BASE_PATH",
+                           apiBasePath); // This is for the frontend, which needs it at build time.
+
+        // We can optionally enable file logging:
+        File logFile = null;
+        if (askYesNo("Enable file-based logging?", false)) {
+            File defaultLogFile = new File("MovieNight.log").getAbsoluteFile();
+            logFile = askWritableFile("Where should we write logs?", defaultLogFile.getAbsolutePath());
+        }
+
+        AppConfig config = AppConfig.of(port,
+                                        mediaDir.toPath(),
+                                        thumbDir.toPath(),
+                                        dbFile.toPath(),
+                                        pageSize,
+                                        apiBasePath,
+                                        rangeLimitMB,
+                                        logFile == null ? null : logFile.toPath());
+
+        if (askYesNo("Would you like to save this config?", true)) {
+            File defaultConfigFile = new File(AppConfig.DEFAULT_CONFIG_FILE_NAME).getAbsoluteFile();
+            File configFile = askWritableFile("Where should we save the config?", defaultConfigFile.getAbsolutePath());
+            config.writeToFile(configFile);
+            System.out.println("Config saved to " + configFile.getAbsolutePath());
+            System.out.println(
+                    "Next time, you can set the environment variable " + AppConfig.ENV_VAR_CONFIG + " to point to this file.");
+        }
+        else {
+            System.out.println("Config not saved. You will need to re-enter these values next time.");
+        }
+
+        return config;
+    }
+
+
+    private static boolean askYesNo(String question, boolean defaultAnswer) {
+        String defaultStr = defaultAnswer ? "Y/n" : "y/N";
+        while (true) {
+            System.out.print(question + " [" + defaultStr + "]: ");
+            String input = System.console().readLine().trim().toLowerCase(Locale.ROOT);
+            if (input.isEmpty()) {
+                return defaultAnswer;
+            }
+            if (input.equals("y") || input.equals("yes") || input.equals("true") || input.equals("on")) {
+                return true;
+            }
+            if (input.equals("n") || input.equals("no") || input.equals("false") || input.equals("off")) {
+                return false;
+            }
+            System.out.println("Please enter 'y' or 'n'.");
+        }
+    }
+
+    private static File askExistingDir(String question, String defaultPath) {
+        while (true) {
+            System.out.print(question + " [" + defaultPath + "]: ");
+            String input = System.console().readLine().trim();
+            if (input.isEmpty()) {
+                input = defaultPath;
+            }
+            File dir = new File(input);
+            if (!dir.exists() || !dir.isDirectory() || !dir.canRead()) {
+                System.out.println("Please enter a valid directory path.");
+                continue;
+            }
+            return dir;
+        }
+    }
+
+    /**
+     * Ask the user for the location of a file that we can write to.
+     * It's perfectly fine if the file doesn't exist yet - we'll create it,
+     * but the parent directory must exist and be writable, and if the file does exist, it must be writable as well.
+     */
+    private static File askWritableFile(String question, String defaultPath) {
+        while (true) {
+            System.out.print(question + " [" + defaultPath + "]: ");
+            String input = System.console().readLine().trim();
+            if (input.isEmpty()) {
+                input = defaultPath;
+            }
+            File file = new File(input);
+            if (file.exists() && (!file.isFile() || !file.canWrite())) {
+                System.out.println("That file exists, but is not writable. Please enter a different file path.");
+                continue;
+            }
+            if (!file.exists()) {
+                File parentDir = file.getAbsoluteFile().getParentFile();
+                if (parentDir == null || !parentDir.exists() || !parentDir.isDirectory() || !parentDir.canWrite()) {
+                    System.out.println(
+                            "That file is not in a valid writable directory. Please enter a different file path.");
+                    continue;
+                }
+            }
+            return file;
+        }
+    }
+
+    private static int askInt(String question, int defaultAnswer, int min, int max) {
+        while (true) {
+            System.out.print(question + " [" + defaultAnswer + "]: ");
+            String input = System.console().readLine().trim();
+            if (input.isEmpty()) {
+                return defaultAnswer;
+            }
+            try {
+                int answer = Integer.parseInt(input);
+                if (answer < min || answer > max) {
+                    System.out.println("Please enter a number between " + min + " and " + max + ".");
+                    continue;
+                }
+                return answer;
+            }
+            catch (NumberFormatException ex) {
+                System.out.println("Please enter a valid integer.");
+            }
+        }
+    }
+}

--- a/backend/src/main/java/ca/corbett/movienight/config/AppConfigInteractiveBuilder.java
+++ b/backend/src/main/java/ca/corbett/movienight/config/AppConfigInteractiveBuilder.java
@@ -60,6 +60,7 @@ public class AppConfigInteractiveBuilder {
         int pageSize = AppConfig.DEFAULT_PAGE_SIZE;
         int rangeLimitMB = AppConfig.DEFAULT_RANGE_LIMIT_MB;
         String apiBasePath = AppConfig.DEFAULT_API_BASE_PATH;
+
         // We can optionally enable file logging:
         File logFile = null;
         if (askYesNo("Enable file-based logging?", false)) {
@@ -81,8 +82,8 @@ public class AppConfigInteractiveBuilder {
             File configFile = askWritableFile("Where should we save the config?", defaultConfigFile.getAbsolutePath());
             config.writeToFile(configFile);
             System.out.println("Config saved to " + configFile.getAbsolutePath());
-            System.out.println(
-                    "Next time, you can set the environment variable " + AppConfig.ENV_VAR_CONFIG + " to point to this file.");
+            System.out.println("Next time, you can set the environment variable "
+                                       + AppConfig.ENV_VAR_CONFIG + " to point to this file.");
         }
         else {
             System.out.println("Config not saved. You will need to re-enter these values next time.");

--- a/backend/src/main/java/ca/corbett/movienight/config/AppConfigInteractiveBuilder.java
+++ b/backend/src/main/java/ca/corbett/movienight/config/AppConfigInteractiveBuilder.java
@@ -60,9 +60,6 @@ public class AppConfigInteractiveBuilder {
         int pageSize = AppConfig.DEFAULT_PAGE_SIZE;
         int rangeLimitMB = AppConfig.DEFAULT_RANGE_LIMIT_MB;
         String apiBasePath = AppConfig.DEFAULT_API_BASE_PATH;
-        System.setProperty("VITE_API_BASE_PATH",
-                           apiBasePath); // This is for the frontend, which needs it at build time.
-
         // We can optionally enable file logging:
         File logFile = null;
         if (askYesNo("Enable file-based logging?", false)) {

--- a/backend/src/test/java/ca/corbett/movienight/api/ApiIntegrationTest.java
+++ b/backend/src/test/java/ca/corbett/movienight/api/ApiIntegrationTest.java
@@ -64,7 +64,7 @@ class ApiIntegrationTest {
         }
         File dbFile = tempDir.resolve("test.db").toFile();
         final int port = 0; // 0 == ephemeral random port
-        AppConfig appConfig = AppConfig.of(port, tempDir, thumbDir.toPath(), dbFile.toPath(), 10, "/api/", 32);
+        AppConfig appConfig = AppConfig.of(port, tempDir, thumbDir.toPath(), dbFile.toPath(), 10, "/api/", 32, null);
         System.out.println("ApiIntegrationTest using AppConfig: " + appConfig);
         database = new Database(appConfig);
         database.open();

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,4 +1,4 @@
-const rawBase = import.meta.env.VITE_API_BASE_PATH ?? '/MovieNight/';
+const rawBase = ((typeof window !== 'undefined' && (window as Window & { API_BASE_PATH?: string }).API_BASE_PATH) || import.meta.env.VITE_API_BASE_PATH) ?? '/MovieNight/';
 export const API_BASE = rawBase.endsWith('/') ? rawBase : `${rawBase}/`;
 
 function normalizePath(path: string): string {


### PR DESCRIPTION
This PR addresses issue #93 by improving config file load order on startup, and by adding a new, interactive "interrogation" mode, where the user is asked questions to build out an AppConfig instance.

While testing this change, found a bug where the API base path was effectively hard-coded in the UI code (only changeable at build time... unacceptable. We need to change it at runtime). Fixed this by modifying the `StaticFrontEndHandler` to dynamically inject the correct path when serving html files. Quick test of this looks good - API base path can be modified between application runs, and the UI picks up the correct value dynamically.
