### PR TITLE
Issue #95 recently watched

### DIFF
--- a/backend/src/main/java/ca/corbett/movienight/api/dto/MediaItemResponse.java
+++ b/backend/src/main/java/ca/corbett/movienight/api/dto/MediaItemResponse.java
@@ -20,10 +20,11 @@ public final class MediaItemResponse {
     private final String mediaFilePath;
     private final List<String> tags;
     private final boolean hasThumbnail;
+    private final boolean isRecentlyWatched;
 
     public MediaItemResponse(long id, long mediaGroupId, String title, String description,
                              LocalDate lastWatchedDate, String mediaFilePath, List<String> tags,
-                             boolean hasThumbnail) {
+                             boolean hasThumbnail, boolean isRecentlyWatched) {
         this.id = id;
         this.mediaGroupId = mediaGroupId;
         this.title = title;
@@ -32,6 +33,7 @@ public final class MediaItemResponse {
         this.mediaFilePath = mediaFilePath;
         this.tags = tags;
         this.hasThumbnail = hasThumbnail;
+        this.isRecentlyWatched = isRecentlyWatched;
     }
 
     public long getId() {
@@ -64,5 +66,9 @@ public final class MediaItemResponse {
 
     public boolean isHasThumbnail() {
         return hasThumbnail;
+    }
+
+    public boolean isRecentlyWatched() {
+        return isRecentlyWatched;
     }
 }

--- a/backend/src/main/java/ca/corbett/movienight/config/AppConfig.java
+++ b/backend/src/main/java/ca/corbett/movienight/config/AppConfig.java
@@ -32,6 +32,7 @@ import java.util.logging.Logger;
  *         (e.g. for GET /api/media/groups)</li>
  *     <li><b>apiBasePath</b>: the base path for all API endpoints (default: "/api/")</li>
  *     <li><b>rangeLimitMB</b>: the maximum length of an HTTP Range request in megabytes (default: 32)</li>
+ *     <li><b>logFile</b>: an optional file for file-based logging. Can be null.</li>
  * </ul>
  * <p>
  *     <b>IMPORTANT ENVIRONMENT VARIABLES:</b>
@@ -82,6 +83,7 @@ public final class AppConfig {
     public static final int DEFAULT_PAGE_SIZE = 50;
     public static final String DEFAULT_API_BASE_PATH = "/api/";
     public static final int DEFAULT_RANGE_LIMIT_MB = 32;
+    public static final int DEFAULT_RECENTLY_WATCHED_DAYS = 3;
 
     private Path logFile;
     private final int port;
@@ -91,9 +93,11 @@ public final class AppConfig {
     private final int pageSize;
     private final String apiBasePath;
     private final int rangeLimitMB;
+    private final int recentlyWatchedDays;
 
     private AppConfig(int port, Path mediaDir, Path thumbnailDir, Path dbFile,
-                      int pageSize, String apiBasePath, int rangeLimitMB, Path logFile) {
+                      int pageSize, String apiBasePath, int rangeLimitMB, Path logFile,
+                      int recentlyWatchedDays) {
         this.port = port;
         this.mediaDir = mediaDir;
         this.dbFile = dbFile;
@@ -102,6 +106,7 @@ public final class AppConfig {
         this.apiBasePath = apiBasePath;
         this.rangeLimitMB = rangeLimitMB;
         this.logFile = logFile;
+        this.recentlyWatchedDays = recentlyWatchedDays;
     }
 
     /**
@@ -131,6 +136,7 @@ public final class AppConfig {
         int pageSize = DEFAULT_PAGE_SIZE;
         String apiBasePath = DEFAULT_API_BASE_PATH;
         int rangeLimitMB = DEFAULT_RANGE_LIMIT_MB;
+        int recentlyWatchedDays = DEFAULT_RECENTLY_WATCHED_DAYS;
         Path logFile = null;
         Properties props = new Properties();
         try (InputStream in = Files.newInputStream(inFile.toPath())) { props.load(in); }
@@ -153,7 +159,7 @@ public final class AppConfig {
         }
         if (props.containsKey("pageSize")) {
             try {
-                pageSize = requireValidPageSize(Integer.parseInt(props.getProperty("pageSize")));
+                pageSize = requireInteger(Integer.parseInt(props.getProperty("pageSize")));
             }
             catch (NumberFormatException ignored) {
                 log.warning("Invalid pageSize in config file, using default: " + DEFAULT_PAGE_SIZE);
@@ -186,9 +192,18 @@ public final class AppConfig {
         if (props.containsKey("logFile")) {
             logFile = requireValidWritableFile(Path.of(props.getProperty("logFile")));
         }
+        if (props.containsKey("recentlyWatchedDays")) {
+            try {
+                recentlyWatchedDays = requireInteger(Integer.parseInt(props.getProperty("recentlyWatchedDays")), true);
+            }
+            catch (NumberFormatException ignored) {
+                log.warning("Invalid recentlyWatchedDays in config file, using default: "
+                                    + DEFAULT_RECENTLY_WATCHED_DAYS);
+            }
+        }
 
         AppConfig newConfig = new AppConfig(port, mediaDir, thumbnailDir, dbFile, pageSize, apiBasePath, rangeLimitMB,
-                                            logFile);
+                                            logFile, recentlyWatchedDays);
         newConfig.applyEnvVarOverrides(); // Allow environment vars to override what we just built above
         return newConfig;
     }
@@ -199,7 +214,8 @@ public final class AppConfig {
      */
     public static AppConfig create() {
         AppConfig newConfig = new AppConfig(DEFAULT_PORT, DEFAULT_MEDIA_DIR, DEFAULT_THUMBNAIL_DIR, DEFAULT_DB_FILE,
-                                            DEFAULT_PAGE_SIZE, DEFAULT_API_BASE_PATH, DEFAULT_RANGE_LIMIT_MB, null);
+                                            DEFAULT_PAGE_SIZE, DEFAULT_API_BASE_PATH, DEFAULT_RANGE_LIMIT_MB,
+                                            null, DEFAULT_RECENTLY_WATCHED_DAYS);
         newConfig.applyEnvVarOverrides(); // Allow environment vars to override defaults
         return newConfig;
     }
@@ -212,17 +228,19 @@ public final class AppConfig {
      * </p>
      */
     public static AppConfig of(int port, Path mediaDir, Path thumbnailDir, Path dbFile,
-                               int pageSize, String apiBasePath, int rangeLimitMB, Path logFile)
+                               int pageSize, String apiBasePath, int rangeLimitMB, Path logFile,
+                               int recentlyWatchedDays)
             throws IOException {
         return new AppConfig(
                 requireValidPort(port),
                 requireValidDirectory(mediaDir),
                 requireValidDirectory(thumbnailDir),
                 requireValidWritableFile(dbFile),
-                requireValidPageSize(pageSize),
+                requireInteger(pageSize),
                 apiBasePath,
                 requireValidMBValue(rangeLimitMB),
-                logFile
+                logFile,
+                requireInteger(recentlyWatchedDays, true)
         );
     }
 
@@ -240,7 +258,8 @@ public final class AppConfig {
         Path validThumbnailDir = requireValidDirectory(thumbnailDir);
         Path validDbFile = requireValidWritableFile(dbFile);
         return new AppConfig(DEFAULT_PORT, validMediaDir, validThumbnailDir, validDbFile,
-                             DEFAULT_PAGE_SIZE, DEFAULT_API_BASE_PATH, DEFAULT_RANGE_LIMIT_MB, null);
+                             DEFAULT_PAGE_SIZE, DEFAULT_API_BASE_PATH, DEFAULT_RANGE_LIMIT_MB, null,
+                             DEFAULT_RECENTLY_WATCHED_DAYS);
     }
 
     /**
@@ -324,6 +343,23 @@ public final class AppConfig {
     }
 
     /**
+     * Returns the threshold, in days, for considering a media item as "recently watched".
+     * Media that has been streamed within this threshold will be marked in the UI as "recently watched".
+     * Set to 0 to disable this feature (no media item will be so marked in the UI at all).
+     */
+    public int getRecentlyWatchedDays() {
+        return recentlyWatchedDays;
+    }
+
+    /**
+     * Shorthand for checking if recentlyWatchedDays is greater than zero.
+     * 0 means "turns this feature off entirely".
+     */
+    public boolean isRecentlyWatchedFeatureEnabled() {
+        return recentlyWatchedDays > 0;
+    }
+
+    /**
      * Invoked internally to check for our environment variable overrides,
      * and will update any property that has been overridden.
      */
@@ -394,11 +430,18 @@ public final class AppConfig {
         return dbFile;
     }
 
-    private static int requireValidPageSize(int pageSize) throws NumberFormatException {
-        if (pageSize <= 0) {
-            throw new NumberFormatException("Page size must be a positive integer");
+    private static int requireInteger(int value) throws NumberFormatException {
+        return requireInteger(value, false);
+    }
+
+    private static int requireInteger(int value, boolean allowZero) throws NumberFormatException {
+        if (allowZero && value == 0) {
+            return value;
         }
-        return pageSize;
+        if (value <= 0) {
+            throw new NumberFormatException("Value must be a positive integer");
+        }
+        return value;
     }
 
     private static int requireValidMBValue(int mbValue) throws NumberFormatException {
@@ -419,6 +462,7 @@ public final class AppConfig {
                 ",\n  apiBasePath='" + apiBasePath + '\'' +
                 ",\n  rangeLimitMB=" + rangeLimitMB +
                 ",\n  logFile=" + (logFile != null ? logFile.toAbsolutePath() : "null") +
+                ",\n  recentlyWatchedDays=" + recentlyWatchedDays +
                 "\n}";
     }
 
@@ -427,7 +471,7 @@ public final class AppConfig {
      * (simple name=value format). Overwrites the file if it already exists.
      * <p>
      * Properties written: port, mediaDir, dbFile, thumbnailDir, pageSize, apiBasePath,
-     * rangeLimitMB, and logFile (if non-null).
+     * rangeLimitMB, logFile (if non-null), and recentlyWatchedDays.
      * </p>
      *
      * @param destination the file to write to; created or overwritten
@@ -445,6 +489,7 @@ public final class AppConfig {
         if (logFile != null) {
             props.setProperty("logFile", logFile.toString());
         }
+        props.setProperty("recentlyWatchedDays", String.valueOf(recentlyWatchedDays));
         try (FileOutputStream out = new FileOutputStream(destination)) {
             props.store(out, "MovieNight configuration");
         }

--- a/backend/src/main/java/ca/corbett/movienight/config/AppConfigInteractiveBuilder.java
+++ b/backend/src/main/java/ca/corbett/movienight/config/AppConfigInteractiveBuilder.java
@@ -60,6 +60,7 @@ public class AppConfigInteractiveBuilder {
         int pageSize = AppConfig.DEFAULT_PAGE_SIZE;
         int rangeLimitMB = AppConfig.DEFAULT_RANGE_LIMIT_MB;
         String apiBasePath = AppConfig.DEFAULT_API_BASE_PATH;
+        int recentlyWatchedDays = AppConfig.DEFAULT_RECENTLY_WATCHED_DAYS;
 
         // We can optionally enable file logging:
         File logFile = null;
@@ -75,7 +76,8 @@ public class AppConfigInteractiveBuilder {
                                         pageSize,
                                         apiBasePath,
                                         rangeLimitMB,
-                                        logFile == null ? null : logFile.toPath());
+                                        logFile == null ? null : logFile.toPath(),
+                                        recentlyWatchedDays);
 
         if (askYesNo("Would you like to save this config?", true)) {
             File defaultConfigFile = new File(AppConfig.DEFAULT_CONFIG_FILE_NAME).getAbsoluteFile();

--- a/backend/src/main/java/ca/corbett/movienight/db/Database.java
+++ b/backend/src/main/java/ca/corbett/movienight/db/Database.java
@@ -844,7 +844,7 @@ public class Database {
 
         item.setHasThumbnail(ThumbnailUtil.hasThumbnail(item, appConfig));
 
-        item.setRecentlyWatched(calculateRecentlyWatched(item.getLastWatchedDate(), appConfig));
+        item.setRecentlyWatched(MediaItem.calculateRecentlyWatched(item.getLastWatchedDate(), appConfig));
 
         String tags = rs.getString("tags");
         if (tags == null || tags.isBlank()) {
@@ -931,23 +931,6 @@ public class Database {
         }
 
         log.info("Connected to database at " + dbFile.getAbsolutePath());
-    }
-
-    /**
-     * Returns true if the last watched date is on or after the current date minus
-     * our configured "recently watched" threshold (example: 30 days).
-     * If the last watched date is null (item has never been streamed), returns false.
-     */
-    private boolean calculateRecentlyWatched(LocalDate lastWatchedDate, AppConfig config) {
-        if (lastWatchedDate == null) {
-            return false;
-        }
-        if (config.getRecentlyWatchedDays() == 0) {
-            // A threshold of 0 means "disable recently watched feature", so we will return false for everything:
-            return false;
-        }
-        LocalDate cutoffDate = LocalDate.now().minusDays(config.getRecentlyWatchedDays());
-        return !lastWatchedDate.isBefore(cutoffDate);
     }
 
     @FunctionalInterface

--- a/backend/src/main/java/ca/corbett/movienight/db/Database.java
+++ b/backend/src/main/java/ca/corbett/movienight/db/Database.java
@@ -844,6 +844,8 @@ public class Database {
 
         item.setHasThumbnail(ThumbnailUtil.hasThumbnail(item, appConfig));
 
+        item.setRecentlyWatched(calculateRecentlyWatched(item.getLastWatchedDate(), appConfig));
+
         String tags = rs.getString("tags");
         if (tags == null || tags.isBlank()) {
             item.setTags(List.of());
@@ -929,6 +931,23 @@ public class Database {
         }
 
         log.info("Connected to database at " + dbFile.getAbsolutePath());
+    }
+
+    /**
+     * Returns true if the last watched date is on or after the current date minus
+     * our configured "recently watched" threshold (example: 30 days).
+     * If the last watched date is null (item has never been streamed), returns false.
+     */
+    private boolean calculateRecentlyWatched(LocalDate lastWatchedDate, AppConfig config) {
+        if (lastWatchedDate == null) {
+            return false;
+        }
+        if (config.getRecentlyWatchedDays() == 0) {
+            // A threshold of 0 means "disable recently watched feature", so we will return false for everything:
+            return false;
+        }
+        LocalDate cutoffDate = LocalDate.now().minusDays(config.getRecentlyWatchedDays());
+        return !lastWatchedDate.isBefore(cutoffDate);
     }
 
     @FunctionalInterface

--- a/backend/src/main/java/ca/corbett/movienight/model/MediaItem.java
+++ b/backend/src/main/java/ca/corbett/movienight/model/MediaItem.java
@@ -1,5 +1,6 @@
 package ca.corbett.movienight.model;
 
+import ca.corbett.movienight.config.AppConfig;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.time.LocalDate;
@@ -174,5 +175,22 @@ public class MediaItem {
 
     public void setRecentlyWatched(boolean isRecentlyWatched) {
         this.isRecentlyWatched = isRecentlyWatched;
+    }
+
+    /**
+     * Returns true if the last watched date is on or after the current date minus
+     * our configured "recently watched" threshold (example: 30 days).
+     * If the last watched date is null (item has never been streamed), returns false.
+     */
+    public static boolean calculateRecentlyWatched(LocalDate lastWatchedDate, AppConfig config) {
+        if (lastWatchedDate == null) {
+            return false;
+        }
+        if (config.getRecentlyWatchedDays() == 0) {
+            // A threshold of 0 means "disable recently watched feature", so we will return false for everything:
+            return false;
+        }
+        LocalDate cutoffDate = LocalDate.now().minusDays(config.getRecentlyWatchedDays());
+        return !lastWatchedDate.isBefore(cutoffDate);
     }
 }

--- a/backend/src/main/java/ca/corbett/movienight/model/MediaItem.java
+++ b/backend/src/main/java/ca/corbett/movienight/model/MediaItem.java
@@ -30,6 +30,12 @@ import java.util.stream.Collectors;
  * and filtering media items. Tags are normalized before being stored - they are trimmed, lowercased,
  * and deduplicated. Tags are completely optional.
  * </p>
+ * <p>
+ * <b>Determining "recently watched":</b> rather than exposing the "lastWatchedDate" directly in the UI,
+ * we calculate the amount of time that has elapsed since the last watched date, if it's within
+ * our configured "recently watched" threshold (example: 30 days), then we set "isRecentlyWatched" to true.
+ * The UI can use this simple boolean to mark media items as "recently watched".
+ * </p>
  *
  * @author <a href="https://github.com/scorbo2">scorbo2</a>
  * @since MovieNight 2.0
@@ -52,6 +58,12 @@ public class MediaItem {
      */
     @JsonProperty(value = "hasThumbnail", access = JsonProperty.Access.READ_ONLY)
     private boolean hasThumbnail = false;
+
+    /**
+     * Not stored in the database - populated at runtime as a convenience for the UI.
+     */
+    @JsonProperty(value = "isRecentlyWatched", access = JsonProperty.Access.READ_ONLY)
+    private boolean isRecentlyWatched = false;
 
     public long getId() {
         return id;
@@ -87,6 +99,10 @@ public class MediaItem {
 
     public boolean isHasThumbnail() {
         return hasThumbnail;
+    }
+
+    public boolean isRecentlyWatched() {
+        return isRecentlyWatched;
     }
 
     public void setId(long id) {
@@ -154,5 +170,9 @@ public class MediaItem {
 
     public void setHasThumbnail(boolean hasThumbnail) {
         this.hasThumbnail = hasThumbnail;
+    }
+
+    public void setRecentlyWatched(boolean isRecentlyWatched) {
+        this.isRecentlyWatched = isRecentlyWatched;
     }
 }

--- a/backend/src/main/java/ca/corbett/movienight/service/MediaItemService.java
+++ b/backend/src/main/java/ca/corbett/movienight/service/MediaItemService.java
@@ -165,7 +165,8 @@ public final class MediaItemService {
                 item.getLastWatchedDate(),
                 convertMediaPathToRelative(item.getMediaFilePath()),
                 item.getTags(),
-                item.isHasThumbnail()
+                item.isHasThumbnail(),
+                item.isRecentlyWatched()
         );
     }
 

--- a/backend/src/main/java/ca/corbett/movienight/service/MediaItemService.java
+++ b/backend/src/main/java/ca/corbett/movienight/service/MediaItemService.java
@@ -166,7 +166,7 @@ public final class MediaItemService {
                 convertMediaPathToRelative(item.getMediaFilePath()),
                 item.getTags(),
                 item.isHasThumbnail(),
-                item.isRecentlyWatched()
+                MediaItem.calculateRecentlyWatched(item.getLastWatchedDate(), appConfig)
         );
     }
 

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -23,3 +23,9 @@ apiBasePath=/MovieNight/
 # The maximum size of HTTP range requests when streaming, in Megabytes.
 # Increase this if you have a fast local network and regularly stream very large files.
 rangeLimitMB=32
+
+# The number of days since last watched to consider a media item "recently watched".
+# If an item was streamed within this number of days, it will be marked
+# in the UI as "recently watched".
+# Set this to 0 to disable this feature.
+recentlyWatchedDays=3

--- a/backend/src/test/java/ca/corbett/movienight/api/ApiIntegrationTest.java
+++ b/backend/src/test/java/ca/corbett/movienight/api/ApiIntegrationTest.java
@@ -19,6 +19,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.SQLException;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 
@@ -64,7 +65,8 @@ class ApiIntegrationTest {
         }
         File dbFile = tempDir.resolve("test.db").toFile();
         final int port = 0; // 0 == ephemeral random port
-        AppConfig appConfig = AppConfig.of(port, tempDir, thumbDir.toPath(), dbFile.toPath(), 10, "/api/", 32, null);
+        AppConfig appConfig = AppConfig.of(port, tempDir, thumbDir.toPath(), dbFile.toPath(),
+                                           10, "/api/", 32, null, 3);
         System.out.println("ApiIntegrationTest using AppConfig: " + appConfig);
         database = new Database(appConfig);
         database.open();
@@ -1118,6 +1120,71 @@ class ApiIntegrationTest {
         assertEquals(404, itemGet.statusCode());
     }
 
+    @Test
+    void recentlyWatched_withNullLastWatchedDate_shouldBeFalse() throws Exception {
+        // Given an item that has never been streamed (lastWatchedDate is null):
+        long groupId = createTestGroup("Group", null);
+        long itemId = createTestItem(groupId, "Episode 1", "/ep1.mkv");
+
+        // WHEN we retrieve this item:
+        HttpResponse<String> response = sendRequest(
+                HttpRequest.newBuilder()
+                           .uri(URI.create(BASE_URL + "/media-items/" + itemId))
+                           .GET()
+                           .build()
+        );
+
+        // THEN it should not be marked as recently watched:
+        assertEquals(200, response.statusCode());
+        Map<String, Object> json = parseJson(response.body());
+        assertEquals(itemId, ((Number)json.get("id")).longValue());
+        assertEquals("false", json.get("recentlyWatched").toString());
+    }
+
+    @Test
+    void recentlyWatched_withOldLastWatchedDate_shouldBeFalse() throws Exception {
+        // Given an item that hasn't been streamed in a long time (lastWatchedDate is old):
+        LocalDate oldDate = LocalDate.now().minusMonths(6);
+        long groupId = createTestGroup("Group", null);
+        long itemId = createTestItem(groupId, "Episode 1", "/ep1.mkv", oldDate);
+
+        // WHEN we retrieve this item:
+        HttpResponse<String> response = sendRequest(
+                HttpRequest.newBuilder()
+                           .uri(URI.create(BASE_URL + "/media-items/" + itemId))
+                           .GET()
+                           .build()
+        );
+
+        // THEN it should not be marked as recently watched:
+        assertEquals(200, response.statusCode());
+        Map<String, Object> json = parseJson(response.body());
+        assertEquals(itemId, ((Number)json.get("id")).longValue());
+        assertEquals("false", json.get("recentlyWatched").toString());
+    }
+
+    @Test
+    void recentlyWatched_withRecentLastWatchedDate_shouldBeTrue() throws Exception {
+        // Given an item that was streamed just yesterday:
+        LocalDate recentDate = LocalDate.now().minusDays(1);
+        long groupId = createTestGroup("Group", null);
+        long itemId = createTestItem(groupId, "Episode 1", "/ep1.mkv", recentDate);
+
+        // WHEN we retrieve this item:
+        HttpResponse<String> response = sendRequest(
+                HttpRequest.newBuilder()
+                           .uri(URI.create(BASE_URL + "/media-items/" + itemId))
+                           .GET()
+                           .build()
+        );
+
+        // THEN it should be marked as recently watched:
+        assertEquals(200, response.statusCode());
+        Map<String, Object> json = parseJson(response.body());
+        assertEquals(itemId, ((Number)json.get("id")).longValue());
+        assertEquals("true", json.get("recentlyWatched").toString());
+    }
+
     // ========================================================================
     // Error Mapping
     // ========================================================================
@@ -2091,13 +2158,19 @@ class ApiIntegrationTest {
     }
 
     private long createTestItem(long groupId, String title, String filePath) throws Exception {
+        return createTestItem(groupId, title, filePath, null);
+    }
+
+    private long createTestItem(long groupId, String title, String filePath, LocalDate lastWatched) throws Exception {
+        String body = lastWatched == null
+                ? "{\"title\":\"" + title + "\",\"mediaFilePath\":\"" + filePath + "\"}"
+                : "{\"title\":\"" + title + "\",\"mediaFilePath\":\"" + filePath + "\",\"lastWatchedDate\":\"" + lastWatched.toString() + "\"}";
+
         HttpResponse<String> response = sendRequest(
                 HttpRequest.newBuilder()
                            .uri(URI.create(BASE_URL + "/media-groups/" + groupId + "/items"))
                            .header("Content-Type", "application/json")
-                           .POST(HttpRequest.BodyPublishers.ofString(
-                                   "{\"title\":\"" + title + "\",\"mediaFilePath\":\"" + filePath + "\"}"
-                           ))
+                           .POST(HttpRequest.BodyPublishers.ofString(body))
                            .build()
         );
         assertEquals(201, response.statusCode());

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -22,6 +22,7 @@ export interface MediaItem {
   mediaFilePath: string;
   tags: string[];
   hasThumbnail: boolean;
+  recentlyWatched: boolean;
 }
 
 export interface MediaItemListResponse {

--- a/frontend/src/browse/pages/GroupDetailPage.tsx
+++ b/frontend/src/browse/pages/GroupDetailPage.tsx
@@ -9,6 +9,7 @@ import { EmptyState } from '../../components/shared/EmptyState';
 import { ErrorState } from '../../components/shared/ErrorState';
 import { PaginationControls } from '../../components/shared/PaginationControls';
 import { SearchBar } from '../../components/shared/SearchBar';
+import { RecentlyWatchedBadge } from '../../components/shared/RecentlyWatchedBadge';
 import { TagPills } from '../../components/shared/TagPills';
 import { Thumbnail } from '../../components/shared/Thumbnail';
 import { Button } from '../../components/ui/Button';
@@ -196,7 +197,10 @@ export function GroupDetailPage(): JSX.Element {
               {itemsQuery.data.items.map((item) => (
                 <Link to={`/browse/items/${item.id}`} key={item.id} className="block no-underline">
                   <Card clickable className="space-y-4">
-                    <Thumbnail alt={item.title} src={item.hasThumbnail ? getThumbnailUrl('media-items', item.id) : undefined} />
+                    <div className="relative">
+                      <Thumbnail alt={item.title} src={item.hasThumbnail ? getThumbnailUrl('media-items', item.id) : undefined} />
+                      {item.recentlyWatched && <RecentlyWatchedBadge />}
+                    </div>
                     <div>
                       <h3 className="text-lg font-semibold text-content">
                         {item.title}

--- a/frontend/src/browse/pages/SearchResultsPage.tsx
+++ b/frontend/src/browse/pages/SearchResultsPage.tsx
@@ -6,6 +6,7 @@ import { EmptyState } from '../../components/shared/EmptyState';
 import { ErrorState } from '../../components/shared/ErrorState';
 import { PaginationControls } from '../../components/shared/PaginationControls';
 import { SearchBar } from '../../components/shared/SearchBar';
+import { RecentlyWatchedBadge } from '../../components/shared/RecentlyWatchedBadge';
 import { TagPills } from '../../components/shared/TagPills';
 import { Thumbnail } from '../../components/shared/Thumbnail';
 import { Card } from '../../components/ui/Card';
@@ -65,7 +66,10 @@ export function SearchResultsPage(): JSX.Element {
           <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
             {itemsQuery.data.items.map((item) => (
               <Card key={item.id} className="space-y-4">
-                <Thumbnail alt={item.title} src={item.hasThumbnail ? getThumbnailUrl('media-items', item.id) : undefined} />
+                <div className="relative">
+                  <Thumbnail alt={item.title} src={item.hasThumbnail ? getThumbnailUrl('media-items', item.id) : undefined} />
+                  {item.recentlyWatched && <RecentlyWatchedBadge />}
+                </div>
                 <div>
                   <h2 className="text-lg font-semibold text-content">{item.title}</h2>
                   <p className="mt-2 text-sm text-content-secondary">{item.description ?? 'No description available.'}</p>

--- a/frontend/src/components/shared/RecentlyWatchedBadge.tsx
+++ b/frontend/src/components/shared/RecentlyWatchedBadge.tsx
@@ -1,0 +1,7 @@
+export function RecentlyWatchedBadge(): JSX.Element {
+  return (
+    <span className="absolute left-2 top-2 inline-flex items-center rounded-full bg-green-500/50 px-2.5 py-1 text-xs font-semibold text-white shadow-sm">
+      Recently Watched
+    </span>
+  );
+}


### PR DESCRIPTION
This PR addresses issue #95 by re-introducing the "recently watched" feature that got lost during the version 2 rewrite. This required changes in both back end and front end:

Back end changes:
- add a new config property "recently watched days". Default 3. User can decide how many days ago constitutes a "recent" media item watch. Specifying a value of `0` disables the feature entirely.
- populate a new transient (not stored in the db) flag based on the lastWatchedDate field.
- Add tests to the integration test to cover this new flag.

Front end changes:
- add a new recently watched badge component. We'll add a small "recently watched" badge on top of the thumbnail image at 50% opacity - clear enough to be visible, transparent enough to be subtle. It informs without demanding attention.
- Added a safe fallback for media items that have no thumbnail image.
- ONLY the browse and search result list pages were updated. The media item details page deliberately does not show this badge. Likewise, the entire admin interface ignores this flag. It's only for browse/search screens.