### PR TITLE
Issue #96 - Fix streaming bugs; improve performance

### DIFF
--- a/backend/src/main/java/ca/corbett/movienight/api/ApiServer.java
+++ b/backend/src/main/java/ca/corbett/movienight/api/ApiServer.java
@@ -24,6 +24,7 @@ import com.sun.net.httpserver.HttpServer;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.util.concurrent.Executors;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -71,6 +72,7 @@ public final class ApiServer {
         ObjectMapper objectMapper = JsonSupport.getObjectMapper();
 
         HttpServer server = HttpServer.create(new InetSocketAddress(config.getPort()), 0);
+        server.setExecutor(Executors.newFixedThreadPool(config.getThreadCount()));
 
         ResponseWriter responseWriter = new ResponseWriter(objectMapper);
         Router router = new Router(responseWriter);
@@ -80,7 +82,6 @@ public final class ApiServer {
         MediaItemService mediaItemService = new MediaItemService(database, config);
 
         String basePath = config.getApiBasePath();
-        int defaultPageSize = config.getPageSize();
         ApiServer apiServer = new ApiServer(server, router, responseWriter, requestParser, database, config,
                                             objectMapper);
 

--- a/backend/src/main/java/ca/corbett/movienight/api/handler/StreamHandler.java
+++ b/backend/src/main/java/ca/corbett/movienight/api/handler/StreamHandler.java
@@ -1,20 +1,23 @@
 package ca.corbett.movienight.api.handler;
 
+import ca.corbett.movienight.api.util.ResponseWriter;
 import ca.corbett.movienight.config.AppConfig;
 import ca.corbett.movienight.db.Database;
 import ca.corbett.movienight.model.MediaItem;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 
-import java.io.BufferedInputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.OutputStream;
+import java.io.RandomAccessFile;
+import java.nio.channels.Channels;
 import java.nio.file.Path;
 import java.sql.SQLException;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -73,12 +76,33 @@ public class StreamHandler implements HttpHandler {
                 throw new UnsupportedOperationException("Method " + method + " not supported");
             }
         }
-        catch (Exception e) {
-            // Getting a lot of these, but they seem harmless.
-            if (!"Connection reset by peer".equals(e.getMessage())) {
+        catch (Throwable e) {
+            if (isClientDisconnect(e)) {
+                log.log(Level.FINE, "Client disconnected during streaming - not a big deal.");
+            }
+            else {
                 throw new IOException(e);
             }
         }
+    }
+
+    /**
+     * Certain client disconnects are not a big deal at all, and in fact happen often.
+     * In VLC, if you start streaming a video and then click on the trackbar to seek ahead
+     * by a few minutes, the client disconnects before we've fulfilled the original range
+     * request. This causes our FixedLengthOutputStream to panic and throw an IOException,
+     * because we didn't send as many bytes as we told it we would (via Content-Length).
+     * But, who cares, the client has already started a new range request wherever the
+     * user decided to seek to. It's no big deal and we can largely ignore it.
+     */
+    private boolean isClientDisconnect(Throwable e) {
+        String msg = e.getMessage() != null ? e.getMessage().toLowerCase(Locale.ROOT) : "";
+        return msg.contains("connection reset by peer") ||
+                msg.contains("insufficient bytes written to stream") ||
+                msg.contains("broken pipe") ||
+                msg.contains("closed channel") ||
+                msg.contains("already closed") ||
+                (e.getCause() instanceof Exception cause && isClientDisconnect(cause));
     }
 
     private void handleStream(HttpExchange exchange, String path) throws Exception {
@@ -129,43 +153,37 @@ public class StreamHandler implements HttpHandler {
                 // By default, we'll limit range requests to 32MB, which is good for streaming.
                 long rangeLimit = appConfig.getRangeLimitMB() * 1024 * 1024L; // defaults to 32MB
                 long bytesToRead = Math.min(range.length(), rangeLimit);
-                if (bytesToRead < rangeLimit) {
-                    log.log(Level.INFO, "Client requested {} with offset {} for media id {}. " +
-                                    "Supplying smaller range of {} instead.",
-                            new Object[]{range.length(), range.start, mediaItemId, bytesToRead});
+                if (bytesToRead < range.length()) {
+                    log.log(Level.INFO, "Client requested {0} with offset {1} for media id {2}. " +
+                                    "Supplying smaller range of {3} instead. You can change this in config! " +
+                                    "Adjust the rangeLimitMB setting to allow larger ranges.",
+                            new Object[]{
+                                    ResponseWriter.getPrintableSize(range.length()),
+                                    ResponseWriter.getPrintableSize(range.start),
+                                    mediaItemId,
+                                    ResponseWriter.getPrintableSize(bytesToRead)
+                            });
                 }
 
                 exchange.getResponseHeaders().add("Content-Type", mimeType);
                 exchange.getResponseHeaders().add("Accept-Ranges", "bytes");
-                exchange.getResponseHeaders()
-                        .add("Content-Range",
-                             "bytes " + range.start + "-" + (range.start + bytesToRead - 1) + "/" + mediaFile.length());
-                exchange.sendResponseHeaders(206, Math.min(bytesToRead, mediaFile.length())); // 206 Partial Content
-                try (var output = exchange.getResponseBody();
-                     var input = new java.io.RandomAccessFile(mediaFile, "r")) {
-                    input.seek(range.start);
-                    byte[] buffer = new byte[32 * 1024]; // 32KB buffer for streaming
-                    long bytesToWrite = bytesToRead;
-                    int bytesRead;
-                    while (bytesToWrite > 0 && (bytesRead = input.read(buffer, 0,
-                                                                       (int)Math.min(buffer.length,
-                                                                                     bytesToWrite))) != -1) {
-                        output.write(buffer, 0, bytesRead);
-                        bytesToWrite -= bytesRead;
-                    }
+                exchange.getResponseHeaders().add("Content-Range",
+                                                  "bytes " + range.start + "-" + (range.start + bytesToRead - 1) + "/" + mediaFile.length());
+                exchange.sendResponseHeaders(206, bytesToRead); // 206 partial content
+
+                try (OutputStream output = exchange.getResponseBody();
+                     RandomAccessFile channel = new RandomAccessFile(mediaFile, "r")) {
+                    channel.getChannel().transferTo(range.start, bytesToRead, Channels.newChannel(output));
                 }
             }
             else {
                 exchange.getResponseHeaders().add("Content-Type", mimeType);
                 exchange.getResponseHeaders().add("Accept-Ranges", "bytes");
                 exchange.sendResponseHeaders(200, mediaFile.length());
-                try (var output = exchange.getResponseBody();
-                     var input = new BufferedInputStream(new FileInputStream(mediaFile))) {
-                    byte[] buffer = new byte[32 * 1024]; // 32KB buffer for streaming
-                    int bytesRead;
-                    while ((bytesRead = input.read(buffer)) != -1) {
-                        output.write(buffer, 0, bytesRead);
-                    }
+
+                try (OutputStream output = exchange.getResponseBody();
+                     RandomAccessFile channel = new RandomAccessFile(mediaFile, "r")) {
+                    channel.getChannel().transferTo(0, mediaFile.length(), Channels.newChannel(output));
                 }
             }
         }

--- a/backend/src/main/java/ca/corbett/movienight/api/handler/StreamHandler.java
+++ b/backend/src/main/java/ca/corbett/movienight/api/handler/StreamHandler.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.RandomAccessFile;
 import java.nio.channels.Channels;
+import java.nio.channels.WritableByteChannel;
 import java.nio.file.Path;
 import java.sql.SQLException;
 import java.time.LocalDate;
@@ -221,12 +222,13 @@ public class StreamHandler implements HttpHandler {
             throws Exception {
         try (OutputStream output = exchange.getResponseBody();
              RandomAccessFile file = new RandomAccessFile(mediaFile, "r")) {
+            WritableByteChannel targetChannel = Channels.newChannel(output);
             long bytesTransferred = 0;
             int iterations = 0;
             while (bytesTransferred < bytesToTransfer && iterations < 1000) {
                 long n = file.getChannel().transferTo(offset + bytesTransferred,
                                                       bytesToTransfer - bytesTransferred,
-                                                      Channels.newChannel(output));
+                                                      targetChannel);
                 if (n == 0) {
                     Thread.sleep(10); // Give the socket buffer time to drain
                     iterations++;
@@ -244,6 +246,10 @@ public class StreamHandler implements HttpHandler {
                                 ResponseWriter.getPrintableSize(bytesToTransfer)
                         });
             }
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Streaming interrupted", e);
         }
     }
 

--- a/backend/src/main/java/ca/corbett/movienight/api/handler/StreamHandler.java
+++ b/backend/src/main/java/ca/corbett/movienight/api/handler/StreamHandler.java
@@ -170,21 +170,13 @@ public class StreamHandler implements HttpHandler {
                 exchange.getResponseHeaders().add("Content-Range",
                                                   "bytes " + range.start + "-" + (range.start + bytesToRead - 1) + "/" + mediaFile.length());
                 exchange.sendResponseHeaders(206, bytesToRead); // 206 partial content
-
-                try (OutputStream output = exchange.getResponseBody();
-                     RandomAccessFile channel = new RandomAccessFile(mediaFile, "r")) {
-                    channel.getChannel().transferTo(range.start, bytesToRead, Channels.newChannel(output));
-                }
+                handleStreamTransfer(range.start, bytesToRead, exchange, mediaFile);
             }
             else {
                 exchange.getResponseHeaders().add("Content-Type", mimeType);
                 exchange.getResponseHeaders().add("Accept-Ranges", "bytes");
                 exchange.sendResponseHeaders(200, mediaFile.length());
-
-                try (OutputStream output = exchange.getResponseBody();
-                     RandomAccessFile channel = new RandomAccessFile(mediaFile, "r")) {
-                    channel.getChannel().transferTo(0, mediaFile.length(), Channels.newChannel(output));
-                }
+                handleStreamTransfer(0, mediaFile.length(), exchange, mediaFile);
             }
         }
         finally {
@@ -213,6 +205,46 @@ public class StreamHandler implements HttpHandler {
             case "wav" -> "audio/wav";
             default -> "application/octet-stream"; // fallback for unknown types
         };
+    }
+
+    /**
+     * Uses NIO channels to transfer a byte range from the given media file to the HTTP response output stream,
+     * starting at the specified offset.
+     *
+     * @param offset          The byte offset in the file to start transferring from
+     * @param bytesToTransfer The count of bytes to transfer from the file to the output stream
+     * @param exchange        The HttpExchange representing the client connection, used to get the output stream
+     * @param mediaFile       The media file to read from
+     * @throws Exception if an I/O error occurs during streaming
+     */
+    private void handleStreamTransfer(long offset, long bytesToTransfer, HttpExchange exchange, File mediaFile)
+            throws Exception {
+        try (OutputStream output = exchange.getResponseBody();
+             RandomAccessFile file = new RandomAccessFile(mediaFile, "r")) {
+            long bytesTransferred = 0;
+            int iterations = 0;
+            while (bytesTransferred < bytesToTransfer && iterations < 1000) {
+                long n = file.getChannel().transferTo(offset + bytesTransferred,
+                                                      bytesToTransfer - bytesTransferred,
+                                                      Channels.newChannel(output));
+                if (n == 0) {
+                    Thread.sleep(10); // Give the socket buffer time to drain
+                    iterations++;
+                    continue;
+                }
+                bytesTransferred += n;
+                iterations = 0; // reset if we got something
+            }
+            if (iterations >= 1000) {
+                log.log(Level.WARNING, "Gave up streaming after 1000 iterations without progress. " +
+                                "This likely means the client stopped consuming data. " +
+                                "Successfully transferred {0} out of {1}",
+                        new Object[]{
+                                ResponseWriter.getPrintableSize(bytesTransferred),
+                                ResponseWriter.getPrintableSize(bytesToTransfer)
+                        });
+            }
+        }
     }
 
     /**

--- a/backend/src/main/java/ca/corbett/movienight/api/util/ResponseWriter.java
+++ b/backend/src/main/java/ca/corbett/movienight/api/util/ResponseWriter.java
@@ -145,4 +145,18 @@ public final class ResponseWriter {
 
         return sanitized.isEmpty() ? defaultName : sanitized;
     }
+
+    /**
+     * Given a count of bytes, returns a human-readable String representation of it.
+     */
+    public static String getPrintableSize(long size) {
+        if (size < 1024) { return size + " bytes"; }
+
+        String[] units = {"KB", "MB", "GB", "TB", "PB"};
+        int unitIndex = (int)(Math.log(size) / Math.log(1024)) - 1;
+        unitIndex = Math.min(unitIndex, units.length - 1);
+
+        double value = size / Math.pow(1024, unitIndex + 1);
+        return String.format("%.1f %s", value, units[unitIndex]);
+    }
 }

--- a/backend/src/main/java/ca/corbett/movienight/config/AppConfig.java
+++ b/backend/src/main/java/ca/corbett/movienight/config/AppConfig.java
@@ -33,6 +33,7 @@ import java.util.logging.Logger;
  *     <li><b>apiBasePath</b>: the base path for all API endpoints (default: "/api/")</li>
  *     <li><b>rangeLimitMB</b>: the maximum length of an HTTP Range request in megabytes (default: 32)</li>
  *     <li><b>logFile</b>: an optional file for file-based logging. Can be null.</li>
+ *     <li><b>threadCount</b>: how many threads to allocate for handling HTTP requests (default: 5)</li>
  * </ul>
  * <p>
  *     <b>IMPORTANT ENVIRONMENT VARIABLES:</b>
@@ -84,6 +85,7 @@ public final class AppConfig {
     public static final String DEFAULT_API_BASE_PATH = "/api/";
     public static final int DEFAULT_RANGE_LIMIT_MB = 32;
     public static final int DEFAULT_RECENTLY_WATCHED_DAYS = 3;
+    public static final int DEFAULT_THREAD_COUNT = 5;
 
     private Path logFile;
     private final int port;
@@ -94,10 +96,11 @@ public final class AppConfig {
     private final String apiBasePath;
     private final int rangeLimitMB;
     private final int recentlyWatchedDays;
+    private final int threadCount;
 
     private AppConfig(int port, Path mediaDir, Path thumbnailDir, Path dbFile,
                       int pageSize, String apiBasePath, int rangeLimitMB, Path logFile,
-                      int recentlyWatchedDays) {
+                      int recentlyWatchedDays, int threadCount) {
         this.port = port;
         this.mediaDir = mediaDir;
         this.dbFile = dbFile;
@@ -107,6 +110,7 @@ public final class AppConfig {
         this.rangeLimitMB = rangeLimitMB;
         this.logFile = logFile;
         this.recentlyWatchedDays = recentlyWatchedDays;
+        this.threadCount = threadCount;
     }
 
     /**
@@ -137,6 +141,7 @@ public final class AppConfig {
         String apiBasePath = DEFAULT_API_BASE_PATH;
         int rangeLimitMB = DEFAULT_RANGE_LIMIT_MB;
         int recentlyWatchedDays = DEFAULT_RECENTLY_WATCHED_DAYS;
+        int threadCount = DEFAULT_THREAD_COUNT;
         Path logFile = null;
         Properties props = new Properties();
         try (InputStream in = Files.newInputStream(inFile.toPath())) { props.load(in); }
@@ -201,9 +206,27 @@ public final class AppConfig {
                                     + DEFAULT_RECENTLY_WATCHED_DAYS);
             }
         }
+        if (props.containsKey("threadCount")) {
+            try {
+                threadCount = requireInteger(Integer.parseInt(props.getProperty("threadCount")));
+                if (threadCount <= 2) {
+                    log.warning("threadCount in config file is very low (" + threadCount + ")! " +
+                                        "You may experience performance issues. Consider increasing it.");
+                }
+                int procCount = Runtime.getRuntime().availableProcessors();
+                if (threadCount > procCount * 2) {
+                    log.warning("threadCount in config file is very high (" + threadCount + ")! " +
+                                        "(You only have " + procCount + " CPU cores.) " +
+                                        "You may experience performance issues. Consider decreasing it.");
+                }
+            }
+            catch (NumberFormatException ignored) {
+                log.warning("Invalid threadCount in config file, using default: " + DEFAULT_THREAD_COUNT);
+            }
+        }
 
         AppConfig newConfig = new AppConfig(port, mediaDir, thumbnailDir, dbFile, pageSize, apiBasePath, rangeLimitMB,
-                                            logFile, recentlyWatchedDays);
+                                            logFile, recentlyWatchedDays, threadCount);
         newConfig.applyEnvVarOverrides(); // Allow environment vars to override what we just built above
         return newConfig;
     }
@@ -215,7 +238,7 @@ public final class AppConfig {
     public static AppConfig create() {
         AppConfig newConfig = new AppConfig(DEFAULT_PORT, DEFAULT_MEDIA_DIR, DEFAULT_THUMBNAIL_DIR, DEFAULT_DB_FILE,
                                             DEFAULT_PAGE_SIZE, DEFAULT_API_BASE_PATH, DEFAULT_RANGE_LIMIT_MB,
-                                            null, DEFAULT_RECENTLY_WATCHED_DAYS);
+                                            null, DEFAULT_RECENTLY_WATCHED_DAYS, DEFAULT_THREAD_COUNT);
         newConfig.applyEnvVarOverrides(); // Allow environment vars to override defaults
         return newConfig;
     }
@@ -229,7 +252,7 @@ public final class AppConfig {
      */
     public static AppConfig of(int port, Path mediaDir, Path thumbnailDir, Path dbFile,
                                int pageSize, String apiBasePath, int rangeLimitMB, Path logFile,
-                               int recentlyWatchedDays)
+                               int recentlyWatchedDays, int threadCount)
             throws IOException {
         return new AppConfig(
                 requireValidPort(port),
@@ -240,7 +263,8 @@ public final class AppConfig {
                 apiBasePath,
                 requireValidMBValue(rangeLimitMB),
                 logFile,
-                requireInteger(recentlyWatchedDays, true)
+                requireInteger(recentlyWatchedDays, true),
+                threadCount
         );
     }
 
@@ -259,7 +283,7 @@ public final class AppConfig {
         Path validDbFile = requireValidWritableFile(dbFile);
         return new AppConfig(DEFAULT_PORT, validMediaDir, validThumbnailDir, validDbFile,
                              DEFAULT_PAGE_SIZE, DEFAULT_API_BASE_PATH, DEFAULT_RANGE_LIMIT_MB, null,
-                             DEFAULT_RECENTLY_WATCHED_DAYS);
+                             DEFAULT_RECENTLY_WATCHED_DAYS, DEFAULT_THREAD_COUNT);
     }
 
     /**
@@ -357,6 +381,13 @@ public final class AppConfig {
      */
     public boolean isRecentlyWatchedFeatureEnabled() {
         return recentlyWatchedDays > 0;
+    }
+
+    /**
+     * Returns the configured number of threads to allocate for handling HTTP requests.
+     */
+    public int getThreadCount() {
+        return threadCount;
     }
 
     /**
@@ -463,6 +494,7 @@ public final class AppConfig {
                 ",\n  rangeLimitMB=" + rangeLimitMB +
                 ",\n  logFile=" + (logFile != null ? logFile.toAbsolutePath() : "null") +
                 ",\n  recentlyWatchedDays=" + recentlyWatchedDays +
+                ",\n  threadCount=" + threadCount +
                 "\n}";
     }
 
@@ -490,6 +522,7 @@ public final class AppConfig {
             props.setProperty("logFile", logFile.toString());
         }
         props.setProperty("recentlyWatchedDays", String.valueOf(recentlyWatchedDays));
+        props.setProperty("threadCount", String.valueOf(threadCount));
         try (FileOutputStream out = new FileOutputStream(destination)) {
             props.store(out, "MovieNight configuration");
         }

--- a/backend/src/main/java/ca/corbett/movienight/config/AppConfig.java
+++ b/backend/src/main/java/ca/corbett/movienight/config/AppConfig.java
@@ -264,7 +264,7 @@ public final class AppConfig {
                 requireValidMBValue(rangeLimitMB),
                 logFile,
                 requireInteger(recentlyWatchedDays, true),
-                threadCount
+                requireInteger(threadCount)
         );
     }
 

--- a/backend/src/main/java/ca/corbett/movienight/config/AppConfigInteractiveBuilder.java
+++ b/backend/src/main/java/ca/corbett/movienight/config/AppConfigInteractiveBuilder.java
@@ -61,6 +61,7 @@ public class AppConfigInteractiveBuilder {
         int rangeLimitMB = AppConfig.DEFAULT_RANGE_LIMIT_MB;
         String apiBasePath = AppConfig.DEFAULT_API_BASE_PATH;
         int recentlyWatchedDays = AppConfig.DEFAULT_RECENTLY_WATCHED_DAYS;
+        int threadCount = AppConfig.DEFAULT_THREAD_COUNT;
 
         // We can optionally enable file logging:
         File logFile = null;
@@ -77,7 +78,8 @@ public class AppConfigInteractiveBuilder {
                                         apiBasePath,
                                         rangeLimitMB,
                                         logFile == null ? null : logFile.toPath(),
-                                        recentlyWatchedDays);
+                                        recentlyWatchedDays,
+                                        threadCount);
 
         if (askYesNo("Would you like to save this config?", true)) {
             File defaultConfigFile = new File(AppConfig.DEFAULT_CONFIG_FILE_NAME).getAbsoluteFile();

--- a/backend/src/main/java/ca/corbett/movienight/db/Database.java
+++ b/backend/src/main/java/ca/corbett/movienight/db/Database.java
@@ -127,8 +127,13 @@ public class Database {
     /**
      * Executes the supplied database work inside a transaction. If a transaction is already active,
      * a savepoint is used so nested transactional work can still roll back safely.
+     * <p>
+     * Dev note: this method is synchronized because our HttpServer handles requests in a thread
+     * pool, and it's entirely possible that requests can execute concurrently.
+     * SQLite is a single-writer database anyway, so we don't lose much by serializing access like this.
+     * </p>
      */
-    public <T> T executeInTransaction(TransactionCallback<T> callback) throws SQLException {
+    public synchronized <T> T executeInTransaction(TransactionCallback<T> callback) throws SQLException {
         requireConnected();
         if (callback == null) {
             throw new IllegalArgumentException("callback cannot be null");

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -29,3 +29,7 @@ rangeLimitMB=32
 # in the UI as "recently watched".
 # Set this to 0 to disable this feature.
 recentlyWatchedDays=3
+
+# The number of threads to use in the HTTP server for handling requests.
+# Adjust as needed based on your hardware and the expected number of simultaneous streaming clients.
+threadCount=5

--- a/backend/src/test/java/ca/corbett/movienight/api/ApiIntegrationTest.java
+++ b/backend/src/test/java/ca/corbett/movienight/api/ApiIntegrationTest.java
@@ -66,7 +66,7 @@ class ApiIntegrationTest {
         File dbFile = tempDir.resolve("test.db").toFile();
         final int port = 0; // 0 == ephemeral random port
         AppConfig appConfig = AppConfig.of(port, tempDir, thumbDir.toPath(), dbFile.toPath(),
-                                           10, "/api/", 32, null, 3);
+                                           10, "/api/", 32, null, 3, 5);
         System.out.println("ApiIntegrationTest using AppConfig: " + appConfig);
         database = new Database(appConfig);
         database.open();


### PR DESCRIPTION
This PR addresses issue #96 by improving performance, fixing broken log messaging, and adding more config options related to performance.

There were several problems here:
- The approach to streaming was extremely inefficient and led to stuttering or stalling in VLC client. Improved greatly by relying on OS-level channels instead of manual byte array copying.
- Logging was broken, with incorrect messaging.
- Suppression of normal client disconnect events related to stream seeking was not sufficient. Enhanced it to keep these harmless stack traces from polluting the log.
- Added configuration for controlling the HTTP server's thread count.
- Minor fix in the Database class to avoid `java.sql.SQLException: database in auto-commit mode` when multiple stream handlers attempt to update lastWatchedDate at the same time.