### PR TITLE
Issue #93 - better color themes

### DIFF
--- a/frontend/src/admin/AdminTopBar.tsx
+++ b/frontend/src/admin/AdminTopBar.tsx
@@ -1,10 +1,7 @@
 import { Link } from 'react-router-dom';
-import { Button } from '../components/ui/Button';
-import { useTheme } from '../theme/ThemeProvider';
+import { ThemeDropdown } from '../components/ui/ThemeDropdown';
 
 export function AdminTopBar(): JSX.Element {
-  const { theme, toggleTheme } = useTheme();
-
   return (
     <header className="sticky top-0 z-30 border-b border-border-subtle bg-header-bg/95 backdrop-blur">
       <div className="mx-auto flex max-w-screen-2xl items-center justify-between gap-2 px-2 py-2 sm:px-4 lg:px-6">
@@ -16,9 +13,7 @@ export function AdminTopBar(): JSX.Element {
           <Link to="/browse" className="text-sm font-medium text-content-secondary">
             Browse app
           </Link>
-          <Button variant="secondary" size="sm" onClick={toggleTheme}>
-            {theme === 'light' ? 'Dark mode' : 'Light mode'}
-          </Button>
+          <ThemeDropdown />
         </div>
       </div>
     </header>

--- a/frontend/src/browse/BrowseHeader.tsx
+++ b/frontend/src/browse/BrowseHeader.tsx
@@ -1,18 +1,7 @@
 import { useState } from 'react';
 import { Link, NavLink } from 'react-router-dom';
-import { Button } from '../components/ui/Button';
 import { getPlaylistLocalPreference, setPlaylistLocalPreference } from '../lib/playlist';
-import { useTheme } from '../theme/ThemeProvider';
-
-function ThemeToggle(): JSX.Element {
-  const { theme, toggleTheme } = useTheme();
-
-  return (
-    <Button variant="secondary" size="sm" onClick={toggleTheme}>
-      {theme === 'light' ? 'Dark mode' : 'Light mode'}
-    </Button>
-  );
-}
+import { ThemeDropdown } from '../components/ui/ThemeDropdown';
 
 function PlaylistLocalToggle(): JSX.Element {
   const [isLocal, setIsLocal] = useState<boolean>(() => getPlaylistLocalPreference());
@@ -57,7 +46,7 @@ export function BrowseHeader(): JSX.Element {
         </div>
         <div className="flex items-center gap-3">
           <PlaylistLocalToggle />
-          <ThemeToggle />
+          <ThemeDropdown />
         </div>
       </div>
     </header>

--- a/frontend/src/components/shared/RecentlyWatchedBadge.tsx
+++ b/frontend/src/components/shared/RecentlyWatchedBadge.tsx
@@ -1,6 +1,6 @@
 export function RecentlyWatchedBadge(): JSX.Element {
   return (
-    <span className="absolute left-2 top-2 inline-flex items-center rounded-full bg-green-500/50 px-2.5 py-1 text-xs font-semibold text-white shadow-sm">
+    <span className="absolute left-2 top-2 inline-flex items-center rounded-full bg-success/50 px-2.5 py-1 text-xs font-semibold text-content shadow-sm">
       Recently Watched
     </span>
   );

--- a/frontend/src/components/ui/ThemeDropdown.tsx
+++ b/frontend/src/components/ui/ThemeDropdown.tsx
@@ -1,21 +1,22 @@
 import { useTheme } from '../../theme/ThemeProvider';
 import { themeList } from '../../theme/themes';
+import { Select } from './Select';
 
 export function ThemeDropdown(): JSX.Element {
   const { theme, setTheme } = useTheme();
 
   return (
-    <select
+    <Select
       value={theme}
       aria-label="Select color theme"
       onChange={(event) => setTheme(event.target.value as typeof theme)}
-      className="h-9 rounded-md border border-input-border bg-input-bg px-2 text-sm text-content shadow-sm transition-colors focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand/40"
+      className="h-9 w-auto px-2"
     >
       {themeList.map((t) => (
         <option key={t.id} value={t.id}>
           {t.label}
         </option>
       ))}
-    </select>
+    </Select>
   );
 }

--- a/frontend/src/components/ui/ThemeDropdown.tsx
+++ b/frontend/src/components/ui/ThemeDropdown.tsx
@@ -1,0 +1,21 @@
+import { useTheme } from '../../theme/ThemeProvider';
+import { themeList } from '../../theme/ThemeProvider';
+
+export function ThemeDropdown(): JSX.Element {
+  const { theme, setTheme } = useTheme();
+
+  return (
+    <select
+      value={theme}
+      aria-label="Select color theme"
+      onChange={(event) => setTheme(event.target.value as typeof theme)}
+      className="h-9 rounded-md border border-input-border bg-input-bg px-2 text-sm text-content shadow-sm transition-colors focus:border-brand focus:outline-none focus:ring-2 focus:ring-brand/40"
+    >
+      {themeList.map((t) => (
+        <option key={t.id} value={t.id}>
+          {t.label}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/frontend/src/components/ui/ThemeDropdown.tsx
+++ b/frontend/src/components/ui/ThemeDropdown.tsx
@@ -1,5 +1,5 @@
 import { useTheme } from '../../theme/ThemeProvider';
-import { themeList } from '../../theme/ThemeProvider';
+import { themeList } from '../../theme/themes';
 
 export function ThemeDropdown(): JSX.Element {
   const { theme, setTheme } = useTheme();

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -18,7 +18,7 @@
   }
 
   html[data-theme='medium-gray'] {
-    color-scheme: normal;
+    color-scheme: light;
   }
 
   html[data-theme='deep-blue'] {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -17,6 +17,14 @@
     color-scheme: dark;
   }
 
+  html[data-theme='medium-gray'] {
+    color-scheme: normal;
+  }
+
+  html[data-theme='deep-blue'] {
+    color-scheme: dark;
+  }
+
   body {
     @apply bg-bg-app text-content antialiased;
     font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;

--- a/frontend/src/theme/ThemeProvider.tsx
+++ b/frontend/src/theme/ThemeProvider.tsx
@@ -1,20 +1,19 @@
 import { createContext, useContext, useEffect, useMemo, useState, type PropsWithChildren } from 'react';
-import type { ThemeName } from './themes';
+import { themeList, type ThemeName } from './themes';
 
 const STORAGE_KEY = 'movienight-theme';
 
 interface ThemeContextValue {
   theme: ThemeName;
   setTheme: (theme: ThemeName) => void;
-  toggleTheme: () => void;
 }
 
 const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
 
 function getInitialTheme(): ThemeName {
   const stored = window.localStorage.getItem(STORAGE_KEY);
-  if (stored === 'light' || stored === 'dark') {
-    return stored;
+  if (stored === 'light' || stored === 'dark' || stored === 'medium-gray' || stored === 'deep-blue') {
+    return stored as ThemeName;
   }
 
   return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
@@ -32,7 +31,6 @@ export function ThemeProvider({ children }: PropsWithChildren): JSX.Element {
     () => ({
       theme,
       setTheme,
-      toggleTheme: () => setTheme((current) => (current === 'light' ? 'dark' : 'light')),
     }),
     [theme],
   );
@@ -48,3 +46,4 @@ export function useTheme(): ThemeContextValue {
 
   return context;
 }
+export { themeList };

--- a/frontend/src/theme/themes.ts
+++ b/frontend/src/theme/themes.ts
@@ -17,6 +17,6 @@ export const themes = {
   },
 } as const;
 
-export type ThemeName = keyof typeof themes;
+export type ThemeName = (typeof themes)[keyof typeof themes]['id'];
 
 export const themeList = Object.values(themes);

--- a/frontend/src/theme/themes.ts
+++ b/frontend/src/theme/themes.ts
@@ -7,6 +7,14 @@ export const themes = {
     id: 'dark',
     label: 'Dark',
   },
+  mediumGray: {
+    id: 'medium-gray',
+    label: 'Medium Gray',
+  },
+  deepBlue: {
+    id: 'deep-blue',
+    label: 'Deep Blue',
+  },
 } as const;
 
 export type ThemeName = keyof typeof themes;

--- a/frontend/src/theme/tokens.css
+++ b/frontend/src/theme/tokens.css
@@ -62,3 +62,71 @@
   --color-table-row-hover: 30 41 59;
   --color-thumbnail-placeholder-bg: 30 41 59;
 }
+
+[data-theme='medium-gray'] {
+  --color-bg-app: 156 163 175;
+  --color-bg-subtle: 178 188 200;
+  --color-surface: 209 217 227;
+  --color-surface-elevated: 226 232 240;
+  --color-text-primary: 17 24 39;
+  --color-text-secondary: 55 65 81;
+  --color-text-muted: 107 114 128;
+  --color-text-inverse: 243 244 246;
+  --color-border-default: 160 174 192;
+  --color-border-subtle: 197 205 217;
+  --color-border-strong: 75 85 99;
+  --color-brand: 100 116 139;
+  --color-brand-hover: 75 85 99;
+  --color-brand-active: 55 65 81;
+  --color-focus-ring: 100 116 139;
+  --color-card-bg: 209 217 227;
+  --color-card-border: 160 174 192;
+  --color-input-bg: 226 232 240;
+  --color-input-border: 160 174 192;
+  --color-input-placeholder: 107 114 128;
+  --color-sidebar-bg: 156 163 175;
+  --color-header-bg: 209 217 227;
+  --color-table-row-hover: 178 188 200;
+  --color-thumbnail-placeholder-bg: 197 205 217;
+  --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1);
+  --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1);
+  --radius-sm: 0.25rem;
+  --radius-md: 0.375rem;
+  --radius-lg: 0.5rem;
+  --radius-xl: 0.75rem;
+}
+
+[data-theme='deep-blue'] {
+  --color-bg-app: 7 17 44;
+  --color-bg-subtle: 15 32 74;
+  --color-surface: 20 41 88;
+  --color-surface-elevated: 30 58 120;
+  --color-text-primary: 224 236 255;
+  --color-text-secondary: 176 196 230;
+  --color-text-muted: 132 157 201;
+  --color-text-inverse: 10 23 54;
+  --color-border-default: 66 94 150;
+  --color-border-subtle: 44 72 128;
+  --color-border-strong: 147 176 230;
+  --color-brand: 129 186 255;
+  --color-brand-hover: 167 212 255;
+  --color-brand-active: 79 148 255;
+  --color-focus-ring: 129 186 255;
+  --color-card-bg: 20 41 88;
+  --color-card-border: 66 94 150;
+  --color-input-bg: 30 58 120;
+  --color-input-border: 66 94 150;
+  --color-input-placeholder: 132 157 201;
+  --color-sidebar-bg: 7 17 44;
+  --color-header-bg: 15 32 74;
+  --color-table-row-hover: 30 58 120;
+  --color-thumbnail-placeholder-bg: 30 58 120;
+  --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.1);
+  --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.15);
+  --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.2);
+  --radius-sm: 0.25rem;
+  --radius-md: 0.375rem;
+  --radius-lg: 0.5rem;
+  --radius-xl: 0.75rem;
+}


### PR DESCRIPTION
This PR addresses issue #103 by improving our color theme selector:

- remove the old Light/Dark toggle button
- add a proper theme selector (dropdown control)
- add a new "Medium Gray" theme
- add a new "Deep Blue" theme with good color contrast
- deliberately did not override important semantic colors (success, warning, danger, etc) per-theme, so that these colors are always consistent (better UX in my opinion)

