### PR TITLE
Issue #105 - wire up pageSize to the UI

### DIFF
--- a/backend/src/main/java/ca/corbett/movienight/api/handler/StaticFrontendHandler.java
+++ b/backend/src/main/java/ca/corbett/movienight/api/handler/StaticFrontendHandler.java
@@ -27,7 +27,7 @@ import java.util.logging.Logger;
  *     <li>Handles index.html as a default file for directory requests</li>
  *     <li>Returns 404 for missing files</li>
  *     <li>Prevents directory traversal attacks</li>
- *     <li>Injects the runtime-configured API base path into index.html</li>
+ *     <li>Injects runtime-configured values (API base path, page size, etc.) into index.html</li>
  * </ul>
  *
  * @author <a href="https://github.com/scorbo2">scorbo2</a>
@@ -124,9 +124,9 @@ public final class StaticFrontendHandler implements HttpHandler {
             throws IOException {
         byte[] buffer = readAllBytes(resourceStream);
 
-        // Inject runtime API base path into index.html
+        // Inject runtime-configured values into index.html
         if (mimeType.startsWith("text/html")) {
-            buffer = injectApiBasePath(buffer);
+            buffer = injectConfigValues(buffer);
         }
 
         exchange.getResponseHeaders().set("Content-Type", mimeType);
@@ -139,17 +139,24 @@ public final class StaticFrontendHandler implements HttpHandler {
         }
     }
 
-    private byte[] injectApiBasePath(byte[] htmlBytes) {
+    /**
+     * Certain values that are configurable on the backend need to be pushed to the UI
+     * somehow. We use injection for that purpose, so that the UI code can reference them
+     * as global variables without needing to make an API call first.
+     */
+    private byte[] injectConfigValues(byte[] htmlBytes) {
         String html = new String(htmlBytes, StandardCharsets.UTF_8);
         String apiBasePath = config.getApiBasePath();
+        int pageSize = config.getPageSize();
 
-        // Escape the path for safe JavaScript string literal (and prevent </script> injection)
+        // Escape the API base path for safe JavaScript string literal (and prevent </script> injection)
         String escapedPath = apiBasePath.replace("\\", "\\\\")
                                         .replace("\"", "\\\"")
                                         .replace("\n", "\\n")
                                         .replace("\r", "\\r")
                                         .replace("<", "\\u003c");
-        String injection = "<script>window.API_BASE_PATH=\"" + escapedPath + "\";</script>";
+        String injection = "<script>window.MOVIENIGHT_CONFIG = { API_BASE_PATH: \"" + escapedPath
+                + "\", PAGE_SIZE: " + pageSize + " };</script>";
 
         // Insert the script right before </head>, if there is a head element. But only do it once!
         String result = html.replaceFirst("</head>", injection + "</head>");

--- a/backend/src/main/java/ca/corbett/movienight/config/AppConfig.java
+++ b/backend/src/main/java/ca/corbett/movienight/config/AppConfig.java
@@ -81,7 +81,7 @@ public final class AppConfig {
     public static final Path DEFAULT_DB_FILE = Path.of("MovieNight.db");
     public static final Path DEFAULT_MEDIA_DIR = Path.of(".");
     public static final Path DEFAULT_THUMBNAIL_DIR = Path.of("thumbnails");
-    public static final int DEFAULT_PAGE_SIZE = 50;
+    public static final int DEFAULT_PAGE_SIZE = 10;
     public static final String DEFAULT_API_BASE_PATH = "/api/";
     public static final int DEFAULT_RANGE_LIMIT_MB = 32;
     public static final int DEFAULT_RECENTLY_WATCHED_DAYS = 3;

--- a/frontend/src/admin/features/ItemForm.tsx
+++ b/frontend/src/admin/features/ItemForm.tsx
@@ -137,6 +137,7 @@ export function ItemForm({ groups, initialValues, loading, onSubmit, onSaveAndAd
                 }}
               />
               <Button
+                className="whitespace-nowrap"
                 type="button"
                 variant="secondary"
                 onClick={() => {

--- a/frontend/src/admin/pages/AdminGroupsPage.tsx
+++ b/frontend/src/admin/pages/AdminGroupsPage.tsx
@@ -13,12 +13,13 @@ import { Skeleton } from '../../components/ui/Skeleton';
 import { Table, TableBody, TableHead, TableRow, TableWrapper, Td, Th } from '../../components/ui/Table';
 import { getNullableStringParam, getPositiveIntParam, setParam } from '../../lib/url';
 import { GroupDeleteDialog } from '../features/GroupDeleteDialog';
+import { getRuntimePageSize } from '../../lib/runtimeConfig';
 
 export function AdminGroupsPage(): JSX.Element {
   const [searchParams, setSearchParams] = useSearchParams();
   const [deleteTarget, setDeleteTarget] = useState<MediaGroup | null>(null);
   const pageNumber = getPositiveIntParam(searchParams.get('pageNumber'), 1);
-  const pageSize = getPositiveIntParam(searchParams.get('pageSize'), 10);
+  const pageSize = getRuntimePageSize(searchParams.get('pageSize'));
   const filters = {
     pageNumber,
     pageSize,

--- a/frontend/src/admin/pages/AdminItemsPage.tsx
+++ b/frontend/src/admin/pages/AdminItemsPage.tsx
@@ -16,6 +16,7 @@ import { Skeleton } from '../../components/ui/Skeleton';
 import { Table, TableBody, TableHead, TableRow, TableWrapper, Td, Th } from '../../components/ui/Table';
 import { getNullableStringParam, getPositiveIntParam, setParam } from '../../lib/url';
 import { ItemDeleteDialog } from '../features/ItemDeleteDialog';
+import { getRuntimePageSize } from '../../lib/runtimeConfig';
 
 export function AdminItemsPage(): JSX.Element {
   const [searchParams, setSearchParams] = useSearchParams();
@@ -23,7 +24,7 @@ export function AdminItemsPage(): JSX.Element {
   const groupId = searchParams.get('groupId') ? Number(searchParams.get('groupId')) : NaN;
   const hasGroup = Number.isInteger(groupId) && groupId > 0;
   const pageNumber = getPositiveIntParam(searchParams.get('pageNumber'), 1);
-  const pageSize = getPositiveIntParam(searchParams.get('pageSize'), 10);
+  const pageSize = getRuntimePageSize(searchParams.get('pageSize'));
   const filters = {
     pageNumber,
     pageSize,

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,5 +1,5 @@
-const rawBase = ((typeof window !== 'undefined' && (window as Window & { API_BASE_PATH?: string }).API_BASE_PATH) || import.meta.env.VITE_API_BASE_PATH) ?? '/MovieNight/';
-export const API_BASE = rawBase.endsWith('/') ? rawBase : `${rawBase}/`;
+import { getRuntimeApiBasePath } from '../lib/runtimeConfig';
+export const API_BASE = getRuntimeApiBasePath();
 
 function normalizePath(path: string): string {
   return path.replace(/^\//, '');

--- a/frontend/src/browse/pages/BrowseHomePage.tsx
+++ b/frontend/src/browse/pages/BrowseHomePage.tsx
@@ -9,11 +9,12 @@ import { Thumbnail } from '../../components/shared/Thumbnail';
 import { Card } from '../../components/ui/Card';
 import { Skeleton } from '../../components/ui/Skeleton';
 import { getNullableStringParam, getPositiveIntParam } from '../../lib/url';
+import { getRuntimePageSize } from '../../lib/runtimeConfig';
 
 export function BrowseHomePage(): JSX.Element {
   const [searchParams, setSearchParams] = useSearchParams();
   const pageNumber = getPositiveIntParam(searchParams.get('pageNumber'), 1);
-  const pageSize = getPositiveIntParam(searchParams.get('pageSize'), 12);
+  const pageSize = getRuntimePageSize(searchParams.get('pageSize'));
   const filters = {
     pageNumber,
     pageSize,

--- a/frontend/src/browse/pages/GroupDetailPage.tsx
+++ b/frontend/src/browse/pages/GroupDetailPage.tsx
@@ -17,6 +17,7 @@ import { Card } from '../../components/ui/Card';
 import { Skeleton } from '../../components/ui/Skeleton';
 import { addPlaylistLocalQuery } from '../../lib/playlist';
 import { getNullableStringParam, getPositiveIntParam, setParam } from '../../lib/url';
+import { getRuntimePageSize } from '../../lib/runtimeConfig';
 
 export function GroupDetailPage(): JSX.Element {
   const { groupId: groupIdParam } = useParams();
@@ -24,9 +25,9 @@ export function GroupDetailPage(): JSX.Element {
   const [searchParams, setSearchParams] = useSearchParams();
   const groupId = Number(groupIdParam);
   const childPage = getPositiveIntParam(searchParams.get('childPage'), 1);
-  const childPageSize = getPositiveIntParam(searchParams.get('childPageSize'), 12);
+  const childPageSize = getRuntimePageSize(searchParams.get('childPageSize'));
   const itemPage = getPositiveIntParam(searchParams.get('itemPage'), 1);
-  const itemPageSize = getPositiveIntParam(searchParams.get('itemPageSize'), 12);
+  const itemPageSize = getRuntimePageSize(searchParams.get('itemPageSize'));
   const childFilters = {
     pageNumber: childPage,
     pageSize: childPageSize,

--- a/frontend/src/browse/pages/SearchResultsPage.tsx
+++ b/frontend/src/browse/pages/SearchResultsPage.tsx
@@ -12,12 +12,13 @@ import { Thumbnail } from '../../components/shared/Thumbnail';
 import { Card } from '../../components/ui/Card';
 import { Skeleton } from '../../components/ui/Skeleton';
 import { getNullableStringParam, getPositiveIntParam, setParam } from '../../lib/url';
+import { getRuntimePageSize } from '../../lib/runtimeConfig';
 
 export function SearchResultsPage(): JSX.Element {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const pageNumber = getPositiveIntParam(searchParams.get('pageNumber'), 1);
-  const pageSize = getPositiveIntParam(searchParams.get('pageSize'), 12);
+  const pageSize = getRuntimePageSize(searchParams.get('pageSize'));
   const filters = {
     pageNumber,
     pageSize,

--- a/frontend/src/components/shared/PaginationControls.tsx
+++ b/frontend/src/components/shared/PaginationControls.tsx
@@ -18,13 +18,15 @@ export function PaginationControls({
   onPageChange,
   onPageSizeChange,
 }: PaginationControlsProps): JSX.Element {
+  const pageSizeOptions = [...new Set([...PAGE_SIZES, pageSize])].sort((first, second) => first - second);
+
   return (
     <div className="flex flex-col gap-4 rounded-lg border border-border-subtle bg-surface p-4">
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-3 text-sm text-content-secondary">
           <span className="whitespace-nowrap">Results per page</span>
           <Select value={pageSize} className="w-28" onChange={(event) => onPageSizeChange(Number(event.target.value))}>
-            {PAGE_SIZES.map((option) => (
+            {pageSizeOptions.map((option) => (
               <option key={option} value={option}>
                 {option}
               </option>

--- a/frontend/src/components/shared/PaginationControls.tsx
+++ b/frontend/src/components/shared/PaginationControls.tsx
@@ -22,7 +22,7 @@ export function PaginationControls({
     <div className="flex flex-col gap-4 rounded-lg border border-border-subtle bg-surface p-4">
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-3 text-sm text-content-secondary">
-          <span>Results per page</span>
+          <span className="whitespace-nowrap">Results per page</span>
           <Select value={pageSize} className="w-28" onChange={(event) => onPageSizeChange(Number(event.target.value))}>
             {PAGE_SIZES.map((option) => (
               <option key={option} value={option}>

--- a/frontend/src/lib/runtimeConfig.d.ts
+++ b/frontend/src/lib/runtimeConfig.d.ts
@@ -1,0 +1,12 @@
+export {};
+
+declare global {
+  interface MovieNightConfig {
+    API_BASE_PATH: string;
+    PAGE_SIZE: number;
+  }
+
+  interface Window {
+    MOVIENIGHT_CONFIG?: MovieNightConfig;
+  }
+}

--- a/frontend/src/lib/runtimeConfig.ts
+++ b/frontend/src/lib/runtimeConfig.ts
@@ -1,0 +1,12 @@
+/// <reference path="./runtimeConfig.d.ts" />
+import { getPositiveIntParam } from './url'
+
+export function getRuntimePageSize(value: string | null) {
+  const runtimeDefaultPageSize = window?.MOVIENIGHT_CONFIG?.PAGE_SIZE ?? 10;
+  return getPositiveIntParam(value, runtimeDefaultPageSize);
+}
+
+export function getRuntimeApiBasePath() {
+  const rawBase = ((typeof window !== 'undefined' && window?.MOVIENIGHT_CONFIG?.API_BASE_PATH) || import.meta.env.VITE_API_BASE_PATH) ?? '/MovieNight/';
+  return rawBase.endsWith('/') ? rawBase : `${rawBase}/`;
+}

--- a/frontend/src/lib/runtimeConfig.ts
+++ b/frontend/src/lib/runtimeConfig.ts
@@ -2,7 +2,7 @@
 import { getPositiveIntParam } from './url'
 
 export function getRuntimePageSize(value: string | null) {
-  const runtimeDefaultPageSize = window?.MOVIENIGHT_CONFIG?.PAGE_SIZE ?? 10;
+  const runtimeDefaultPageSize = (typeof window !== 'undefined' && window?.MOVIENIGHT_CONFIG?.PAGE_SIZE) || 10;
   return getPositiveIntParam(value, runtimeDefaultPageSize);
 }
 


### PR DESCRIPTION
This PR addresses #105 by adding an additional configuration property to the front-end injection scheme, and generifying the approach to this to make it easier to inject additional properties in future.

The back-end now injects a `MOVIENIGHT_CONFIG` object onto the window, so the front end can read `pageSize` as well as `apiBasePath`. Now, when the user modifies these properties in the config file and restarts the server, the UI will be informed of the new value and can use it, instead of using its own hard-coded default. Added a new `runtimeConfig` module in the front-end code to centralize access to these config values.

Also harmonized the defaults for `pageSize`: the back-end used to have `50` as a default, and the front-end used to default to `12`. Both now default to `10`. 

Unrelated to this PR, found and fixed a couple of minor line-wrapping issues in the UI.