### PR TITLE
Issue #108 - adding helper tools

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -24,9 +24,9 @@ the `grab_thumbnail` script on a specific video file, and specify the size and t
 time index to use. For example:
 
 ```shell
-# I don't want to do a whole directory! Let's just do one image.
+# I don't want to do a whole directory! Let's just do one video.
 # Grab the frame at the 77s mark and scale it to 800px wide:
-grab_thumbnail Bladerunner.mkv 800 77
+grab_thumbnail Bladerunner.mkv 77 800
 ```
 
 ### Track metadata extraction

--- a/tools/README.md
+++ b/tools/README.md
@@ -20,8 +20,8 @@ make_thumbnails /path/to/mediaDir
 
 This script is great for processing an entire directory of images in one shot.
 But what if the 3s mark doesn't result in a good thumbnail? Well, you can use
-the `grab_thumbnail` script on a specific video file, and specify the size and the
-time index to use. For example:
+the `grab_thumbnail` script on a specific video file, and specify the time offset and the
+output width to use. For example:
 
 ```shell
 # I don't want to do a whole directory! Let's just do one video.

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,67 @@
+# MovieNight
+
+## Helper tools
+
+The scripts in this directory can be used to help manage video libraries.
+
+### Thumbnail generation
+
+Use `make_thumbnails` to walk a directory looking for video files.
+For each video found, a thumbnail will be extracted from the frame at the 3s mark.
+The frame will be scaled as needed so that it's width is 640 pixels, then it will
+be saved alongside the video file. For example, given `Bladerunner.mkv`, running
+the script in that directory will generate a `Bladerunner.jpg` (if it does not
+already exist):
+
+```shell
+# Scans the given directory and all subdirectories in one shot:
+make_thumbnails /path/to/mediaDir
+```
+
+This script is great for processing an entire directory of images in one shot.
+But what if the 3s mark doesn't result in a good thumbnail? Well, you can use
+the `grab_thumbnail` script on a specific video file, and specify the size and the
+time index to use. For example:
+
+```shell
+# I don't want to do a whole directory! Let's just do one image.
+# Grab the frame at the 77s mark and scale it to 800px wide:
+grab_thumbnail Bladerunner.mkv 800 77
+```
+
+### Track metadata extraction
+
+MovieNight has the ability to start video playback with a specific audio track
+and/or subtitle track, other than the defaults. To do this, you must first run
+the `extract_track_json.py` script in your media directory. This script walks the
+directory looking for video files, and will extract track metadata into a
+sidecar json file. For example, given `Bladerunner.mkv`, you will end up
+with `Bladerunner.mkv.tracks.json`:
+
+```shell
+# Scans the given directory and all subdirectories in one shot:
+extract_track_json.py /path/to/mediaDir
+```
+
+## What do I have to do after running these scripts?
+
+Nothing! MovieNight will detect the sidecar files and pass the information on
+to the UI automatically. The thumbnail you generated will be used in browse
+and search modes (hit "refresh" in your browser if you already had it open). 
+The track JSON you generated will cause extra choosers
+for "audio track" and "subtitles" to appear on the item detail page.
+
+Note that audio/subtitle track selection only work with the "Watch in VLC" action.
+The inline HTML 5 video player does not support multiple tracks :(
+
+## What if I add new media after running these scripts?
+
+No worries. The scripts will not overwrite sidecar files if they already exist.
+(Actually, the `extract_track_json.py` script will overwrite if you use the `--force` option, but not by default).
+So, you can just re-run the same command on your media directory, and any new files will be detected
+and processed, while existing sidecar files will be left alone.
+
+## What if I'm not running on Linux?
+
+The python script should work on any platform, as long as you have `ffmpeg` installed.
+The bash scripts are Linux-specific. No Windows PowerShell version is available at this time (PRs welcome!).

--- a/tools/README.md
+++ b/tools/README.md
@@ -8,7 +8,7 @@ The scripts in this directory can be used to help manage video libraries.
 
 Use `make_thumbnails` to walk a directory looking for video files.
 For each video found, a thumbnail will be extracted from the frame at the 3s mark.
-The frame will be scaled as needed so that it's width is 640 pixels, then it will
+The frame will be scaled as needed so that its width is 640 pixels, then it will
 be saved alongside the video file. For example, given `Bladerunner.mkv`, running
 the script in that directory will generate a `Bladerunner.jpg` (if it does not
 already exist):

--- a/tools/extract_track_json.py
+++ b/tools/extract_track_json.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""
+extract_track_json.py
+
+Walks a directory tree, finds all video files, extracts per-track
+language metadata using ffprobe, and writes a sidecar .tracks.json file
+next to each media file. This sidecar file describes the available
+audio and subtitle tracks that were found in the video file.
+
+Requirements: 
+    ffprobe (comes with ffmpeg)
+
+Usage:
+    python3 extract_track_json.py /path/to/your/media [--dry-run] [--force]
+
+Sidecar file format example (e.g. "Movie.mkv.tracks.json"):
+{
+  "file": "Movie.mkv",
+  "audio": [
+    {"index": 1, "language": "eng", "language_name": "English", "codec": "aac", "title": ""},
+    {"index": 2, "language": "deu", "language_name": "German",  "codec": "aac", "title": ""},
+    {"index": 3, "language": "fra", "language_name": "French",  "codec": "aac", "title": ""}
+  ],
+  "subtitle": [
+    {"index": 4, "language": "eng", "language_name": "English", "codec": "dvd_subtitle", "title": ""},
+    {"index": 5, "language": "deu", "language_name": "German",  "codec": "dvd_subtitle", "title": ""},
+    {"index": 6, "language": "fra", "language_name": "French",  "codec": "dvd_subtitle", "title": ""}
+  ]
+}
+
+Note that the "index" mentioned above is the unique numeric 0-based track id. This can be used
+with "audio-track-id" and "subtitle-track-id" when generating VLC playlist files. Be careful
+not to confuse this with "audio-track" and "subtitle-track"! They are different concepts in VLC.
+In the example above, track id 2 points to the German audio track, and track id 5 points to the 
+German subtitle track. But "audio-track" would be "1" for German audio, and "subtitle-track"
+would also be "1" for German subtitles. (0=English, 1=German, 2=French, for both audio tracks
+and subtitle tracks in this example). 
+
+Think of it like absolute paths (the track-id) versus relative paths (the track number).
+In this script, we only care about the absolute path.
+
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+# ISO 639-2/B and 639-1 codes → human-readable names.
+# This covers the most common cases. VLC uses these same codes internally.
+LANGUAGE_NAMES = {
+    # 3-letter ISO 639-2 codes
+    "eng": "English",
+    "fra": "French",
+    "fre": "French",
+    "deu": "German",
+    "ger": "German",
+    "spa": "Spanish",
+    "ita": "Italian",
+    "jpn": "Japanese",
+    "zho": "Chinese",
+    "chi": "Chinese",
+    "kor": "Korean",
+    "por": "Portuguese",
+    "rus": "Russian",
+    "ara": "Arabic",
+    "hin": "Hindi",
+    "pol": "Polish",
+    "nld": "Dutch",
+    "dut": "Dutch",
+    "swe": "Swedish",
+    "nor": "Norwegian",
+    "dan": "Danish",
+    "fin": "Finnish",
+    "ces": "Czech",
+    "cze": "Czech",
+    "hun": "Hungarian",
+    "rum": "Romanian",
+    "ron": "Romanian",
+    "tur": "Turkish",
+    "heb": "Hebrew",
+    "tha": "Thai",
+    "vie": "Vietnamese",
+    "ind": "Indonesian",
+    "msa": "Malay",
+    "may": "Malay",
+    "ukr": "Ukrainian",
+    "cat": "Catalan",
+    "hrv": "Croatian",
+    "slk": "Slovak",
+    "slo": "Slovak",
+    "slv": "Slovenian",
+    "bul": "Bulgarian",
+    "ell": "Greek",
+    "gre": "Greek",
+    "lit": "Lithuanian",
+    "lav": "Latvian",
+    "est": "Estonian",
+    "srp": "Serbian",
+    "bos": "Bosnian",
+    "glg": "Galician",
+    "eus": "Basque",
+    "lat": "Latin",
+    "und": "Undetermined",
+    # 2-letter ISO 639-1 codes (some video files use these instead)
+    "en": "English",
+    "fr": "French",
+    "de": "German",
+    "es": "Spanish",
+    "it": "Italian",
+    "ja": "Japanese",
+    "zh": "Chinese",
+    "ko": "Korean",
+    "pt": "Portuguese",
+    "ru": "Russian",
+    "ar": "Arabic",
+    "hi": "Hindi",
+    "pl": "Polish",
+    "nl": "Dutch",
+    "sv": "Swedish",
+    "no": "Norwegian",
+    "da": "Danish",
+    "fi": "Finnish",
+    "cs": "Czech",
+    "hu": "Hungarian",
+    "ro": "Romanian",
+    "tr": "Turkish",
+    "he": "Hebrew",
+    "th": "Thai",
+    "vi": "Vietnamese",
+    "id": "Indonesian",
+    "ms": "Malay",
+    "uk": "Ukrainian",
+}
+
+# ffprobe abstracts away the details of pulling out track info for us.
+# It should work with any of these extensions, but it really depends
+# on how the video file was created. No guarantees that any given file
+# will have good metadata.
+MEDIA_EXTENSIONS = {".mkv", ".mp4", ".avi", ".mov", ".m4v", ".ts", ".m2ts"}
+
+
+def language_display_name(code: str) -> str:
+    """Return a human-readable name for an ISO language code, falling back to the raw code."""
+    if not code:
+        return "Unknown"
+    normalized = code.lower().strip()
+    return LANGUAGE_NAMES.get(normalized, code.upper())
+
+
+def probe_file(path: Path) -> list[dict]:
+    """
+    Run ffprobe on a file and return a list of stream dicts, each containing:
+      index, codec_type, codec_name, language (raw tag), language_name, title
+    """
+    cmd = [
+        "ffprobe",
+        "-v", "quiet",
+        "-print_format", "json",
+        "-show_streams",
+        str(path),
+    ]
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    except FileNotFoundError:
+        print("ERROR: ffprobe not found. Please install ffmpeg.", file=sys.stderr)
+        sys.exit(1)
+    except subprocess.TimeoutExpired:
+        print(f"  WARNING: ffprobe timed out on {path.name}", file=sys.stderr)
+        return []
+
+    if result.returncode != 0:
+        print(f"  WARNING: ffprobe failed on {path.name}: {result.stderr.strip()}", file=sys.stderr)
+        return []
+
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        print(f"  WARNING: couldn't parse ffprobe JSON for {path.name}", file=sys.stderr)
+        return []
+
+    if not isinstance(data, dict) or "streams" not in data:
+        print(f"  WARNING: ffprobe output missing 'streams' for {path.name}", file=sys.stderr)
+        return []
+
+    streams = []
+    for s in data.get("streams", []):
+        tags = s.get("tags", {})
+        # Language tag can appear as "language", "LANGUAGE", or occasionally "lang"
+        raw_lang = (
+            tags.get("language")
+            or tags.get("LANGUAGE")
+            or tags.get("lang")
+            or ""
+        )
+        streams.append({
+            "index": s.get("index"),
+            "codec_type": s.get("codec_type", "unknown"),
+            "codec": s.get("codec_name", "unknown"),
+            "language": raw_lang,
+            "language_name": language_display_name(raw_lang) if raw_lang else "Unknown",
+            "title": tags.get("title") or tags.get("TITLE") or "",
+        })
+    return streams
+
+
+def build_sidecar(file_path: Path, streams: list[dict]) -> dict:
+    """Organise stream data into the sidecar structure grouped by type."""
+    result: dict[str, list] = {"file": file_path.name, "audio": [], "subtitle": []}
+    for s in streams:
+        if s["codec_type"] not in ("audio", "subtitle"):
+            continue
+        track = {
+            "index": s["index"],
+            "language": s["language"],
+            "language_name": s["language_name"],
+            "codec": s["codec"],
+            "title": s["title"],
+        }
+        bucket = s["codec_type"]
+        if bucket not in result:
+            result[bucket] = []
+        result[bucket].append(track)
+    return result
+
+
+def sidecar_path(media_path: Path) -> Path:
+    return media_path.parent / (media_path.name + ".tracks.json")
+
+
+def process_file(media_path: Path, dry_run: bool, force: bool) -> bool:
+    """Process one media file. Returns True if a sidecar was written (or would be)."""
+    out = sidecar_path(media_path)
+    if out.exists() and not force:
+        print(f"  SKIP (sidecar exists, use --force to overwrite): {media_path.name}")
+        return False
+
+    streams = probe_file(media_path)
+    if not streams:
+        print(f"  SKIP (no streams found): {media_path.name}")
+        return False
+
+    sidecar = build_sidecar(media_path, streams)
+
+    audio_summary = ", ".join(
+        t["language_name"] + (f" [{t['title']}]" if t["title"] else "")
+        for t in sidecar.get("audio", [])
+    ) or "(none)"
+    sub_summary = ", ".join(
+        t["language_name"] + (f" [{t['title']}]" if t["title"] else "")
+        for t in sidecar.get("subtitle", [])
+    ) or "(none)"
+    print(f"  {'[DRY RUN] ' if dry_run else ''}{'writing' if not dry_run else 'would write'}: {out.name}")
+    print(f"    audio:    {audio_summary}")
+    print(f"    subtitle: {sub_summary}")
+
+    if not dry_run:
+        out.write_text(json.dumps(sidecar, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    return True
+
+
+def walk_directory(root: Path, dry_run: bool, force: bool):
+    media_files = sorted(
+        p for p in root.rglob("*") if p.is_file() and p.suffix.lower() in MEDIA_EXTENSIONS
+    )
+    if not media_files:
+        print(f"No media files found under {root}")
+        return
+
+    print(f"Found {len(media_files)} media file(s) under {root}\n")
+    written = 0
+    for mf in media_files:
+        print(f"{mf.relative_to(root)}")
+        if process_file(mf, dry_run=dry_run, force=force):
+            written += 1
+
+    noun = "sidecar" if written == 1 else "sidecars"
+    action = "would write" if dry_run else "wrote"
+    print(f"\nDone. {action} {written} {noun}.")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Extract per-track language metadata from media files and write .tracks.json sidecars."
+    )
+    parser.add_argument("directory", help="Root directory to walk")
+    parser.add_argument("--dry-run", action="store_true", help="Print what would be done without writing anything")
+    parser.add_argument("--force", action="store_true", help="Overwrite existing sidecar files")
+    args = parser.parse_args()
+
+    root = Path(args.directory).expanduser().resolve()
+    if not root.is_dir():
+        print(f"ERROR: not a directory: {root}", file=sys.stderr)
+        sys.exit(1)
+
+    walk_directory(root, dry_run=args.dry_run, force=args.force)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tools/grab_thumbnail
+++ b/tools/grab_thumbnail
@@ -54,7 +54,7 @@ if [[ -f "$THUMB" ]]; then
 fi
 
 # 4. Extract frame
-if ffmpeg -nostdin -ss "$OFFSET" -i "$VIDEO" -vframes 1 -q:v 2 -vf "scale=${WIDTH}:-1" "$THUMB" -y -loglevel error 2>/dev/null; then
+if ffmpeg -nostdin -y -loglevel error -ss "$OFFSET" -i "$VIDEO" -vframes 1 -q:v 2 -vf "scale=${WIDTH}:-1" "$THUMB"; then
     echo "Created: $THUMB"
 else
     echo "Failed to extract frame from '$VIDEO'." >&2

--- a/tools/grab_thumbnail
+++ b/tools/grab_thumbnail
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Grabs a single frame at the specified offset from the 
+# given video file using ffmpeg, and saves it as a sidecar
+# file alongside the video. Does nothing if the target
+# thumbnail file already exists.
+#
+# USAGE: grab_thumbnail <video.mkv> <offsetSeconds> <thumbWidth>
+# REQUIREMENTS: ffmpeg
+
+
+# 1. Verify ffmpeg is installed
+if ! command -v ffmpeg &>/dev/null; then
+    echo "Error: ffmpeg is not installed." >&2
+    exit 1
+fi
+
+# 2. Validate arguments
+if [[ $# -lt 3 ]]; then
+    echo "Usage: $0 <video_file> <time_offset_seconds> <thumb_width_pixels>" >&2
+    exit 1
+fi
+
+VIDEO="$1"
+OFFSET="$2"
+WIDTH="$3"
+
+# Validate video file exists
+if [[ ! -f "$VIDEO" ]]; then
+    echo "Error: '$VIDEO' is not a valid file." >&2
+    exit 1
+fi
+
+# Validate offset is a number
+if ! [[ "$OFFSET" =~ ^[0-9]+(\.[0-9]+)?$ ]]; then
+    echo "Error: Time offset must be a valid number (e.g., 1.5)." >&2
+    exit 1
+fi
+
+# Validate thumb width is a whole number
+if ! [[ "$WIDTH" =~ ^[0-9]+$ ]]; then
+    echo "Error: Thumbnail width must be a whole number (e.g. 640)." >&2
+    exit 1
+fi
+
+# 3. Generate sidecar path
+THUMB="${VIDEO%.*}.jpg"
+
+# Skip if thumbnail already exists
+if [[ -f "$THUMB" ]]; then
+    echo "Skipping: $THUMB (already exists)"
+    exit 0
+fi
+
+# 4. Extract frame
+if ffmpeg -nostdin -ss "$OFFSET" -i "$VIDEO" -vframes 1 -q:v 2 -vf "scale=${WIDTH}:-1" "$THUMB" -y -loglevel error 2>/dev/null; then
+    echo "Created: $THUMB"
+else
+    echo "Failed to extract frame from '$VIDEO'." >&2
+    exit 1
+fi

--- a/tools/make_thumbnails
+++ b/tools/make_thumbnails
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Goes through a given target directory looking for video files.
+# We consider *.mkv and *.mp4 files.
+# For each one found, we generate a thumbnail image for it
+# by grabbing a screenshot from a fixed time offset.
+# The thumbnail is saved alongside the video as a sidecar.
+# If the target thumbnail already exists, that file is skipped.
+# The target_dir is scanned recursively! Add -maxdepth 1
+# to the find command to skip subdirectories.
+#
+# USAGE: make_thumbnails [target_dir]
+# REQUIREMENTS: ffmpeg, grab_thumbnail
+
+
+# Modify this value (in seconds) to change where we grab a frame:
+TIME_INDEX=3
+
+# Scale thumbnails to this width (pixels):
+THUMB_WIDTH=640
+
+# Make sure grab_thumbnail is on our path:
+if ! command -v grab_thumbnail &>/dev/null; then
+    echo "Error: grab_thumbnail not found." >&2
+    exit 1
+fi
+
+# 1. Handle directory argument (defaults to current directory)
+TARGET_DIR="${1:-.}"
+
+if [[ ! -d "$TARGET_DIR" ]]; then
+    echo "Error: '$TARGET_DIR' is not a valid directory." >&2
+    exit 1
+fi
+
+video_count=0
+
+# We can delegate to our grab_thumbnail script to avoid duplication of code:
+while IFS= read -r -d '' video; do
+    grab_thumbnail "$video" "$TIME_INDEX" "$THUMB_WIDTH"
+    video_count=$((video_count + 1))
+done < <(find "$TARGET_DIR" -type f \( -iname "*.mkv" -o -iname "*.mp4" -o -iname "*.wmv" -o -iname "*.avi" \) -print0 | LC_ALL=C sort -z)
+
+# Handle no videos found
+if [[ $video_count -eq 0 ]]; then
+    echo "No video files found in '$TARGET_DIR'." >&2
+    exit 1
+fi

--- a/tools/make_thumbnails
+++ b/tools/make_thumbnails
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # Goes through a given target directory looking for video files.
-# We consider *.mkv and *.mp4 files.
+# We consider common video file extensions (e.g., *.mkv, *.mp4, *.wmv, *.avi).
 # For each one found, we generate a thumbnail image for it
 # by grabbing a screenshot from a fixed time offset.
 # The thumbnail is saved alongside the video as a sidecar.


### PR DESCRIPTION
This PR addresses issue #108 by adding some command-line helper tools that can be useful in managing a large media library. These tools are optional, and are never invoked by the application itself - users can use these tools manually if needed, or ignore them. A readme is provided for basic guidance.