### PR TITLE
Issue 110 track metadata

### DIFF
--- a/backend/src/main/java/ca/corbett/movienight/api/dto/MediaItemResponse.java
+++ b/backend/src/main/java/ca/corbett/movienight/api/dto/MediaItemResponse.java
@@ -1,6 +1,9 @@
 package ca.corbett.movienight.api.dto;
 
+import ca.corbett.movienight.model.TrackMetadata;
+
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -21,10 +24,13 @@ public final class MediaItemResponse {
     private final List<String> tags;
     private final boolean hasThumbnail;
     private final boolean isRecentlyWatched;
+    private final List<TrackMetadata> audioTracks;
+    private final List<TrackMetadata> subtitleTracks;
 
     public MediaItemResponse(long id, long mediaGroupId, String title, String description,
                              LocalDate lastWatchedDate, String mediaFilePath, List<String> tags,
-                             boolean hasThumbnail, boolean isRecentlyWatched) {
+                             boolean hasThumbnail, boolean isRecentlyWatched,
+                             List<TrackMetadata> audioTracks, List<TrackMetadata> subtitleTracks) {
         this.id = id;
         this.mediaGroupId = mediaGroupId;
         this.title = title;
@@ -34,6 +40,8 @@ public final class MediaItemResponse {
         this.tags = tags;
         this.hasThumbnail = hasThumbnail;
         this.isRecentlyWatched = isRecentlyWatched;
+        this.audioTracks = audioTracks;
+        this.subtitleTracks = subtitleTracks;
     }
 
     public long getId() {
@@ -70,5 +78,13 @@ public final class MediaItemResponse {
 
     public boolean isRecentlyWatched() {
         return isRecentlyWatched;
+    }
+
+    public List<TrackMetadata> getAudioTracks() {
+        return new ArrayList<>(audioTracks);
+    }
+
+    public List<TrackMetadata> getSubtitleTracks() {
+        return new ArrayList<>(subtitleTracks);
     }
 }

--- a/backend/src/main/java/ca/corbett/movienight/api/handler/PlaylistHandler.java
+++ b/backend/src/main/java/ca/corbett/movienight/api/handler/PlaylistHandler.java
@@ -51,6 +51,17 @@ import java.util.logging.Logger;
  *     will be much improved in this case, since there is no http streaming involved. The default is false,
  *     meaning that streaming URLs will be used in the generated playlist.
  * </p>
+ * <p>
+ *     For the single-item endpoint (<code>GET /api/playlist/media-item/{id}</code>), two additional optional
+ *     query parameters are available:
+ *     <ul>
+ *         <li><code>?audioTrackId=N</code> - sets the audio track ID for the media item.
+ *         When set, adds an <code>#EXTVLCOPT:audio-track-id=N</code> line to the playlist.</li>
+ *         <li><code>?subtitleTrackId=N</code> - sets the subtitle track ID for the media item.
+ *         When set, adds an <code>#EXTVLCOPT:sub-track-id=N</code> line to the playlist.</li>
+ *     </ul>
+ *     These are VLC-specific options that allow selecting specific audio or subtitle tracks.
+ * </p>
  *
  * @author <a href="https://github.com/scorbo2">scorbo2</a>
  */
@@ -181,7 +192,12 @@ public class PlaylistHandler implements HttpHandler {
             throw new Database.NotFoundException("Media item not found with ID: " + itemId);
         }
 
-        String playlist = generatePlaylist(List.of(item), appConfig, getServerName(exchange), isLocal);
+        Map<String, String> params = QueryParamParser.parse(exchange.getRequestURI().getQuery());
+        Integer audioTrackId = QueryParamParser.parseIntOptional(params, "audioTrackId").orElse(null);
+        Integer subtitleTrackId = QueryParamParser.parseIntOptional(params, "subtitleTrackId").orElse(null);
+
+        String playlist = generatePlaylist(List.of(item), appConfig, getServerName(exchange), isLocal,
+                audioTrackId, subtitleTrackId);
         responseWriter.writePlaylist(exchange, HttpURLConnection.HTTP_OK, playlist, item.getTitle());
     }
 
@@ -208,7 +224,12 @@ public class PlaylistHandler implements HttpHandler {
             throw new Database.NotFoundException("Media item not found with ID: " + itemId);
         }
 
-        String playlist = generatePlaylist(List.of(item), appConfig, getServerName(exchange), isLocal);
+        Map<String, String> params = QueryParamParser.parse(exchange.getRequestURI().getQuery());
+        Integer audioTrackId = QueryParamParser.parseIntOptional(params, "audioTrackId").orElse(null);
+        Integer subtitleTrackId = QueryParamParser.parseIntOptional(params, "subtitleTrackId").orElse(null);
+
+        String playlist = generatePlaylist(List.of(item), appConfig, getServerName(exchange), isLocal,
+                audioTrackId, subtitleTrackId);
         responseWriter.writePlaylist(exchange, HttpURLConnection.HTTP_OK, playlist, item.getTitle());
     }
 
@@ -232,7 +253,7 @@ public class PlaylistHandler implements HttpHandler {
             return;
         }
         List<MediaItem> items = database.getMediaItemsByGroupId(groupId);
-        String playlist = generatePlaylist(items, appConfig, getServerName(exchange), isLocal);
+        String playlist = generatePlaylist(items, appConfig, getServerName(exchange), isLocal, null, null);
         responseWriter.writePlaylist(exchange, HttpURLConnection.HTTP_OK, playlist, group.getTitle());
     }
 
@@ -254,7 +275,7 @@ public class PlaylistHandler implements HttpHandler {
             }
         }
 
-        String playlist = generatePlaylist(items, appConfig, getServerName(exchange), isLocal);
+        String playlist = generatePlaylist(items, appConfig, getServerName(exchange), isLocal, null, null);
         responseWriter.writePlaylist(exchange, HttpURLConnection.HTTP_OK, playlist);
     }
 
@@ -277,13 +298,16 @@ public class PlaylistHandler implements HttpHandler {
      * in the list, in the order they appear in the list. Invalid MediaItems (null, no id, missing media file)
      * will be silently ignored.
      *
-     * @param mediaItems A List of at least one MediaItem to include in the playlist.
-     * @param appConfig  Contains our server port and our data directory.
-     * @param serverName The server name or IP address to use in the streaming URLs in the playlist.
-     * @param isLocal   If true, the playlist will contain direct filesystem paths instead of streaming URLs.
+     * @param mediaItems     A List of at least one MediaItem to include in the playlist.
+     * @param appConfig      Contains our server port and our data directory.
+     * @param serverName     The server name or IP address to use in the streaming URLs in the playlist.
+     * @param isLocal        If true, the playlist will contain direct filesystem paths instead of streaming URLs.
+     * @param audioTrackId   Optional audio track ID. If non-null, adds an #EXTVLCOPT line before each item.
+     * @param subtitleTrackId Optional subtitle track ID. If non-null, adds an #EXTVLCOPT line before each item.
      * @return An m3u playlist as a String. May be empty if mediaItems was empty, or if it contained no valid MediaItems.
      */
-    public static String generatePlaylist(List<MediaItem> mediaItems, AppConfig appConfig, String serverName, boolean isLocal) {
+    public static String generatePlaylist(List<MediaItem> mediaItems, AppConfig appConfig, String serverName,
+            boolean isLocal, Integer audioTrackId, Integer subtitleTrackId) {
         StringBuilder m3u = new StringBuilder();
         m3u.append("#EXTM3U\n");
         for (MediaItem mediaItem : mediaItems) {
@@ -302,6 +326,13 @@ public class PlaylistHandler implements HttpHandler {
                     ? mediaItem.getTitle()
                     : "Untitled Media Item " + mediaItem.getId();
             m3u.append("#EXTINF:-1,").append(itemTitle).append("\n");
+            // Add VLC options for track selection if specified
+            if (audioTrackId != null) {
+                m3u.append("#EXTVLCOPT:audio-track-id=").append(audioTrackId).append("\n");
+            }
+            if (subtitleTrackId != null) {
+                m3u.append("#EXTVLCOPT:sub-track-id=").append(subtitleTrackId).append("\n");
+            }
             if (isLocal) {
                 // Browser is on the same machine or has access to the same shared filesystem:
                 m3u.append(mediaFile.getAbsolutePath());

--- a/backend/src/main/java/ca/corbett/movienight/api/handler/PlaylistHandler.java
+++ b/backend/src/main/java/ca/corbett/movienight/api/handler/PlaylistHandler.java
@@ -54,12 +54,14 @@ import java.util.logging.Logger;
  * <p>
  *     For the single-item endpoint (<code>GET /api/playlist/media-item/{id}</code>), two additional optional
  *     query parameters are available:
- *     <ul>
- *         <li><code>?audioTrackId=N</code> - sets the audio track ID for the media item.
- *         When set, adds an <code>#EXTVLCOPT:audio-track-id=N</code> line to the playlist.</li>
- *         <li><code>?subtitleTrackId=N</code> - sets the subtitle track ID for the media item.
- *         When set, adds an <code>#EXTVLCOPT:sub-track-id=N</code> line to the playlist.</li>
- *     </ul>
+ * </p>
+ * <ul>
+ *     <li><code>?audioTrackId=N</code> - sets the audio track ID for the media item.
+ *     When set, adds an <code>#EXTVLCOPT:audio-track-id=N</code> line to the playlist.</li>
+ *     <li><code>?subtitleTrackId=N</code> - sets the subtitle track ID for the media item.
+ *     When set, adds an <code>#EXTVLCOPT:sub-track-id=N</code> line to the playlist.</li>
+ * </ul>
+ * <p>
  *     These are VLC-specific options that allow selecting specific audio or subtitle tracks.
  * </p>
  *

--- a/backend/src/main/java/ca/corbett/movienight/api/util/TrackMetadataUtil.java
+++ b/backend/src/main/java/ca/corbett/movienight/api/util/TrackMetadataUtil.java
@@ -39,11 +39,20 @@ public class TrackMetadataUtil {
      */
     public static void populateTrackMetadata(MediaItem item, AppConfig appConfig) {
         // We have to resolve the media file within our configured media dir first:
-        Path mediaDir = appConfig.getMediaDir();
-        File mediaFile = mediaDir.resolve(item.getMediaFilePath()).normalize().toFile();
+        Path mediaDir = appConfig.getMediaDir().toAbsolutePath().normalize();
+        Path mediaPath = mediaDir.resolve(item.getMediaFilePath()).normalize();
+        if (!mediaPath.startsWith(mediaDir)) {
+            log.warning("TrackMetadataUtil: mediaFilePath resolved outside mediaDir; skipping: " + item.getMediaFilePath());
+            return;
+        }
+        File mediaFile = mediaPath.toFile();
 
         // Then we have to compute the expected sidecar file:
-        File sidecarFile = new File(mediaFile.getParentFile(), mediaFile.getName() + ".tracks.json");
+        File parentDir = mediaFile.getParentFile();
+        if (parentDir == null) {
+            return;
+        }
+        File sidecarFile = new File(parentDir, mediaFile.getName() + ".tracks.json");
 
         // If it doesn't exist, we're done here:
         if (!sidecarFile.exists()) {

--- a/backend/src/main/java/ca/corbett/movienight/api/util/TrackMetadataUtil.java
+++ b/backend/src/main/java/ca/corbett/movienight/api/util/TrackMetadataUtil.java
@@ -26,8 +26,7 @@ public class TrackMetadataUtil {
     /**
      * ObjectMapper is thread-safe and reusable, so we can use a single static instance for the whole class.
      */
-    private static final ObjectMapper objectMapper = new ObjectMapper();
-
+    private static final ObjectMapper objectMapper = JsonSupport.getObjectMapper();
     private TrackMetadataUtil() {
     }
 

--- a/backend/src/main/java/ca/corbett/movienight/api/util/TrackMetadataUtil.java
+++ b/backend/src/main/java/ca/corbett/movienight/api/util/TrackMetadataUtil.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.Nulls;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import java.io.File;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.logging.Logger;
@@ -37,22 +38,28 @@ public class TrackMetadataUtil {
      * empty track lists in this case.
      */
     public static void populateTrackMetadata(MediaItem item, AppConfig appConfig) {
-        Path sidecar = appConfig.getMediaDir().resolve(item.getMediaFilePath()).resolveSibling(item.getMediaFilePath() + ".tracks.json");
+        // We have to resolve the media file within our configured media dir first:
+        Path mediaDir = appConfig.getMediaDir();
+        File mediaFile = mediaDir.resolve(item.getMediaFilePath()).normalize().toFile();
+
+        // Then we have to compute the expected sidecar file:
+        File sidecarFile = new File(mediaFile.getParentFile(), mediaFile.getName() + ".tracks.json");
 
         // If it doesn't exist, we're done here:
-        if (!sidecar.toFile().exists()) {
+        if (!sidecarFile.exists()) {
             return;
         }
 
         // Otherwise, try to parse it using our expected wrapper format:
         try {
-            MetadataWrapper wrapper = objectMapper.readValue(sidecar.toFile(), MetadataWrapper.class);
+            MetadataWrapper wrapper = objectMapper.readValue(sidecarFile, MetadataWrapper.class);
             item.setAudioTracks(wrapper.audioTracks);
             item.setSubtitleTracks(wrapper.subtitleTracks);
         } catch (Exception e) {
             // If parsing fails for any reason, just log it and move on - we don't want to break
             // the whole API just because of a bad sidecar file.
-            log.warning("Failed to parse track metadata sidecar file: " + sidecar + " - " + e.getMessage());
+            log.warning("Failed to parse track metadata sidecar file: "
+                                + sidecarFile.getAbsolutePath() + " - " + e.getMessage());
         }
     }
 

--- a/backend/src/main/java/ca/corbett/movienight/api/util/TrackMetadataUtil.java
+++ b/backend/src/main/java/ca/corbett/movienight/api/util/TrackMetadataUtil.java
@@ -1,0 +1,87 @@
+package ca.corbett.movienight.api.util;
+
+import ca.corbett.movienight.config.AppConfig;
+import ca.corbett.movienight.model.MediaItem;
+import ca.corbett.movienight.model.TrackMetadata;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.Nulls;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.logging.Logger;
+
+/**
+ * Loads and parses our track metadata sidecar file if present.
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ */
+public class TrackMetadataUtil {
+
+    private static final Logger log = Logger.getLogger(TrackMetadataUtil.class.getName());
+
+    /**
+     * ObjectMapper is thread-safe and reusable, so we can use a single static instance for the whole class.
+     */
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    private TrackMetadataUtil() {
+    }
+
+    /**
+     * Makes a best-effort attempt to load track metadata from a sidecar JSON file and
+     * populate the given MediaItem's audioTracks and subtitleTracks lists.
+     * Exceptions are logged and swallowed - the MediaItem will simply have
+     * empty track lists in this case.
+     */
+    public static void populateTrackMetadata(MediaItem item, AppConfig appConfig) {
+        Path sidecar = appConfig.getMediaDir().resolve(item.getMediaFilePath()).resolveSibling(item.getMediaFilePath() + ".tracks.json");
+
+        // If it doesn't exist, we're done here:
+        if (!sidecar.toFile().exists()) {
+            return;
+        }
+
+        // Otherwise, try to parse it using our expected wrapper format:
+        try {
+            MetadataWrapper wrapper = objectMapper.readValue(sidecar.toFile(), MetadataWrapper.class);
+            item.setAudioTracks(wrapper.audioTracks);
+            item.setSubtitleTracks(wrapper.subtitleTracks);
+        } catch (Exception e) {
+            // If parsing fails for any reason, just log it and move on - we don't want to break
+            // the whole API just because of a bad sidecar file.
+            log.warning("Failed to parse track metadata sidecar file: " + sidecar + " - " + e.getMessage());
+        }
+    }
+
+    /**
+     * The expected format of our track metadata sidecar JSON file.
+     */
+    @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+    private static class MetadataWrapper {
+        @JsonProperty("file")
+        String filename;
+
+        @JsonProperty("audio")
+        @JsonSetter(nulls = Nulls.AS_EMPTY)
+        List<TrackMetadata> audioTracks;
+
+        @JsonProperty("subtitle")
+        @JsonSetter(nulls = Nulls.AS_EMPTY)
+        List<TrackMetadata> subtitleTracks;
+
+        public String getFilename() {
+            return filename;
+        }
+
+        public List<TrackMetadata> getAudioTracks() {
+            return audioTracks;
+        }
+
+        public List<TrackMetadata> getSubtitleTracks() {
+            return subtitleTracks;
+        }
+    }
+}

--- a/backend/src/main/java/ca/corbett/movienight/db/Database.java
+++ b/backend/src/main/java/ca/corbett/movienight/db/Database.java
@@ -1,6 +1,7 @@
 package ca.corbett.movienight.db;
 
 import ca.corbett.movienight.api.util.ThumbnailUtil;
+import ca.corbett.movienight.api.util.TrackMetadataUtil;
 import ca.corbett.movienight.config.AppConfig;
 import ca.corbett.movienight.model.MediaGroup;
 import ca.corbett.movienight.model.MediaItem;
@@ -850,6 +851,8 @@ public class Database {
         item.setHasThumbnail(ThumbnailUtil.hasThumbnail(item, appConfig));
 
         item.setRecentlyWatched(MediaItem.calculateRecentlyWatched(item.getLastWatchedDate(), appConfig));
+
+        TrackMetadataUtil.populateTrackMetadata(item, appConfig);
 
         String tags = rs.getString("tags");
         if (tags == null || tags.isBlank()) {

--- a/backend/src/main/java/ca/corbett/movienight/model/MediaItem.java
+++ b/backend/src/main/java/ca/corbett/movienight/model/MediaItem.java
@@ -66,6 +66,18 @@ public class MediaItem {
     @JsonProperty(value = "isRecentlyWatched", access = JsonProperty.Access.READ_ONLY)
     private boolean isRecentlyWatched = false;
 
+    /**
+     * Not stored in the database - loaded from our tracks JSON sidecar file if present.
+     */
+    @JsonProperty(value = "audioTracks", access = JsonProperty.Access.READ_ONLY)
+    private List<TrackMetadata> audioTracks = new ArrayList<>();
+
+    /**
+     * Not stored in the database - loaded from our tracks JSON sidecar file if present.
+     */
+    @JsonProperty(value = "subtitleTracks", access = JsonProperty.Access.READ_ONLY)
+    private List<TrackMetadata> subtitleTracks = new ArrayList<>();
+
     public long getId() {
         return id;
     }
@@ -128,6 +140,32 @@ public class MediaItem {
 
     public void setMediaFilePath(String mediaFilePath) {
         this.mediaFilePath = mediaFilePath;
+    }
+
+    public List<TrackMetadata> getAudioTracks() {
+        return new ArrayList<>(audioTracks);
+    }
+
+    public List<TrackMetadata> getSubtitleTracks() {
+        return new ArrayList<>(subtitleTracks);
+    }
+
+    public void setAudioTracks(List<TrackMetadata> audioTracks) {
+        if (audioTracks == null) {
+            this.audioTracks = new ArrayList<>();
+        }
+        else {
+            this.audioTracks = new ArrayList<>(audioTracks);
+        }
+    }
+
+    public void setSubtitleTracks(List<TrackMetadata> subtitleTracks) {
+        if (subtitleTracks == null) {
+            this.subtitleTracks = new ArrayList<>();
+        }
+        else {
+            this.subtitleTracks = new ArrayList<>(subtitleTracks);
+        }
     }
 
     /**

--- a/backend/src/main/java/ca/corbett/movienight/model/TrackMetadata.java
+++ b/backend/src/main/java/ca/corbett/movienight/model/TrackMetadata.java
@@ -1,6 +1,6 @@
 package ca.corbett.movienight.model;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonAlias;
 
 /**
  * Represents simple metadata for an audio or a subtitle track within a video file.
@@ -30,7 +30,7 @@ public class TrackMetadata {
      * The user-friendly name of the track's language, derived from the "language" field.
      * This value is not localized.
      */
-    @JsonProperty(value = "language_name", access = JsonProperty.Access.READ_ONLY)
+    @JsonAlias("language_name")
     private String languageName;
 
     /**

--- a/backend/src/main/java/ca/corbett/movienight/model/TrackMetadata.java
+++ b/backend/src/main/java/ca/corbett/movienight/model/TrackMetadata.java
@@ -1,0 +1,86 @@
+package ca.corbett.movienight.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Represents simple metadata for an audio or a subtitle track within a video file.
+ * This is used for videos that have multiple audio tracks (for example, multiple languages),
+ * so that the UI can display the available tracks and allow the user to select which one they
+ * want to use when watching the video. Note that this feature only works with the "Watch in VLC"
+ * option. The inline HTML 5 video player does not support multiple tracks.
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ */
+public class TrackMetadata {
+
+    /**
+     * A unique, 0-based numeric index for this track.
+     * This is used as an identifier when generating VLC playlists.
+     */
+    private int index;
+
+    /**
+     * Either a three-letter ISO 639-2 language code (example: "eng" for English, "spa" for Spanish),
+     * or a two-letter ISO 639-1 language code (example: "en" for English, "es" for Spanish).
+     * (Some video files use ISO 639-2 codes, while others use ISO 639-1 codes, so we need to support both.)
+     */
+    private String language;
+
+    /**
+     * The user-friendly name of the track's language, derived from the "language" field.
+     * This value is not localized.
+     */
+    @JsonProperty(value = "language_name", access = JsonProperty.Access.READ_ONLY)
+    private String languageName;
+
+    /**
+     * We ignore this currently. It may be used in future versions.
+     */
+    private String codec;
+
+    /**
+     * An optional user-friendly title for the track, if it exists.
+     * This is just whatever metadata was in the video file - we don't set this.
+     */
+    private String title;
+
+    public int getIndex() {
+        return index;
+    }
+
+    public void setIndex(int index) {
+        this.index = index;
+    }
+
+    public String getLanguage() {
+        return language;
+    }
+
+    public void setLanguage(String language) {
+        this.language = language;
+    }
+
+    public String getLanguageName() {
+        return languageName;
+    }
+
+    public void setLanguageName(String languageName) {
+        this.languageName = languageName;
+    }
+
+    public String getCodec() {
+        return codec;
+    }
+
+    public void setCodec(String codec) {
+        this.codec = codec;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+}

--- a/backend/src/main/java/ca/corbett/movienight/service/MediaItemService.java
+++ b/backend/src/main/java/ca/corbett/movienight/service/MediaItemService.java
@@ -166,7 +166,9 @@ public final class MediaItemService {
                 convertMediaPathToRelative(item.getMediaFilePath()),
                 item.getTags(),
                 item.isHasThumbnail(),
-                MediaItem.calculateRecentlyWatched(item.getLastWatchedDate(), appConfig)
+                MediaItem.calculateRecentlyWatched(item.getLastWatchedDate(), appConfig),
+                item.getAudioTracks(),
+                item.getSubtitleTracks()
         );
     }
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -13,6 +13,14 @@ export interface MediaGroupListResponse {
   pageSize: number;
 }
 
+export interface TrackMetadata {
+  index: number;
+  language: string;
+  languageName: string;
+  codec: string;
+  title: string | null;
+}
+
 export interface MediaItem {
   id: number;
   mediaGroupId: number;
@@ -23,6 +31,8 @@ export interface MediaItem {
   tags: string[];
   hasThumbnail: boolean;
   recentlyWatched: boolean;
+  audioTracks: TrackMetadata[];
+  subtitleTracks: TrackMetadata[];
 }
 
 export interface MediaItemListResponse {

--- a/frontend/src/browse/pages/ItemDetailPage.tsx
+++ b/frontend/src/browse/pages/ItemDetailPage.tsx
@@ -23,9 +23,10 @@ function languageCodeToCountryCode(languageCode: string): string {
     const SAFE_FALLBACK = 'UN'; // United Nations flag as a generic fallback
     if (!languageCode) return SAFE_FALLBACK;
 
-    // If we get a 2-letter code, we can assume it's ISO 639-1 and use it directly.
+    // If we get a 2-letter code, it's likely ISO 639-1 (language), which doesn't map 1:1 to a country flag.
+    // Use a safe fallback unless we explicitly add a mapping for it.
     if (languageCode.length === 2) {
-        return languageCode.toUpperCase();
+        return SAFE_FALLBACK;
     }
 
     // Otherwise, you might think we could just take the first 2 characters of the language code,

--- a/frontend/src/browse/pages/ItemDetailPage.tsx
+++ b/frontend/src/browse/pages/ItemDetailPage.tsx
@@ -11,13 +11,69 @@ import { TagPills } from '../../components/shared/TagPills';
 import { Thumbnail } from '../../components/shared/Thumbnail';
 import { Button } from '../../components/ui/Button';
 import { Card } from '../../components/ui/Card';
+import { Select } from '../../components/ui/Select';
 import { Skeleton } from '../../components/ui/Skeleton';
-import { addPlaylistLocalQuery } from '../../lib/playlist';
+import { addPlaylistLocalQuery, addPlaylistTrackQuery } from '../../lib/playlist';
+
+/**
+ * We may either receive ISO 639-1 (2-letter) or ISO 639-2 (3-letter) language codes from the backend.
+ * We will do our best to map these to country codes, with a safe fallback for unrecognized codes.
+ */
+function languageCodeToCountryCode(languageCode: string): string {
+    const SAFE_FALLBACK = 'UN'; // United Nations flag as a generic fallback
+    if (!languageCode) return SAFE_FALLBACK;
+
+    // If we get a 2-letter code, we can assume it's ISO 639-1 and use it directly.
+    if (languageCode.length === 2) {
+        return languageCode.toUpperCase();
+    }
+
+    // Otherwise, you might think we could just take the first 2 characters of the language code,
+    // but ISO 639-2 is very weird, and some codes make no sense (like "GER" for Germany).
+    // So, we'll just have a little map of the most likely language codes to their corresponding country codes.
+    const mapping: Record<string, string> = {
+        'eng': 'CA', // English → Canada (because I'm Canadian and we deserve the maple leaf flag 🍁)
+        'ger': 'DE', // German → Germany
+        'deu': 'DE', // German (alternative code) → Germany
+        'fre': 'FR', // French → France
+        'fra': 'FR', // French (alternative code) → France
+        'spa': 'ES', // Spanish → Spain
+        'ita': 'IT', // Italian → Italy
+        'jpn': 'JP', // Japanese → Japan
+        'chi': 'CN', // Chinese → China
+        'rus': 'RU', // Russian → Russia
+        // Add more mappings as needed
+    }
+
+    return mapping[languageCode.toLowerCase()] || SAFE_FALLBACK;
+}
+
+/**
+ * Takes a language code, converts it to a country code, and then converts
+ * that to a flag emoji using Unicode regional indicator symbols.
+ */
+function codeToFlagEmoji(code: string): string {
+  const OFFSET = 0x1F1E6 - 0x41; // maps 'A' → U+1F1E6 (regional indicator)
+  const normalized = languageCodeToCountryCode(code).toUpperCase();
+  if (normalized.length !== 2) return '';
+  const first = String.fromCodePoint(normalized.charCodeAt(0) + OFFSET);
+  const second = String.fromCodePoint(normalized.charCodeAt(1) + OFFSET);
+  return first + second;
+}
+
+/**
+ * Returns a human-readable label for a track, preferring title, then languageName, then index.
+ */
+function getTrackLabel(track: { title: string | null; languageName: string; index: number }): string {
+  return track.title || track.languageName || String(track.index);
+}
 
 export function ItemDetailPage(): JSX.Element {
   const { itemId: itemIdParam } = useParams();
   const navigate = useNavigate();
   const [showPlayer, setShowPlayer] = useState(false);
+  const [selectedAudioTrack, setSelectedAudioTrack] = useState<number | undefined>(undefined);
+  const [selectedSubtitleTrack, setSelectedSubtitleTrack] = useState<number | undefined>(undefined);
   const itemId = Number(itemIdParam);
 
   const itemQuery = useQuery({ queryKey: ['item', itemId], queryFn: () => getItem(itemId) });
@@ -41,6 +97,16 @@ export function ItemDetailPage(): JSX.Element {
   }
 
   const item = itemQuery.data;
+  const showAudioDropdown = item.audioTracks.length > 1;
+  const showSubtitleDropdown = item.subtitleTracks.length > 1;
+
+  const handleWatchInVlc = () => {
+    const audioTrackId = showAudioDropdown ? selectedAudioTrack : undefined;
+    const subtitleTrackId = showSubtitleDropdown ? selectedSubtitleTrack : undefined;
+    const playlistPath = addPlaylistLocalQuery(`playlist/media-item/${item.id}`);
+    const vlcUrl = addPlaylistTrackQuery(playlistPath, audioTrackId, subtitleTrackId);
+    window.location.assign(buildApiUrl(vlcUrl));
+  };
 
   return (
     <div className="space-y-6">
@@ -72,11 +138,55 @@ export function ItemDetailPage(): JSX.Element {
               </div>
             </div>
             <TagPills tags={item.tags} onTagClick={(tag) => navigate(`/browse/search?tagContains=${encodeURIComponent(tag)}`)} />
+
+            {showAudioDropdown || showSubtitleDropdown ? (
+              <div className="grid gap-3 sm:grid-cols-2">
+                {showAudioDropdown ? (
+                  <div className="rounded-lg bg-bg-subtle p-4">
+                    <p className="text-xs uppercase tracking-[0.2em] text-content-muted">Audio Track</p>
+                    <Select
+                      className="mt-2 h-9 w-full"
+                      value={selectedAudioTrack ?? ''}
+                      onChange={(e) => setSelectedAudioTrack(Number(e.target.value))}
+                    >
+                      <option value="" disabled>
+                        Select audio track
+                      </option>
+                      {item.audioTracks.map((track) => (
+                        <option key={track.index} value={track.index}>
+                          {codeToFlagEmoji(track.language)} {getTrackLabel(track)}
+                        </option>
+                      ))}
+                    </Select>
+                  </div>
+                ) : null}
+                {showSubtitleDropdown ? (
+                  <div className="rounded-lg bg-bg-subtle p-4">
+                    <p className="text-xs uppercase tracking-[0.2em] text-content-muted">Subtitle Track</p>
+                    <Select
+                      className="mt-2 h-9 w-full"
+                      value={selectedSubtitleTrack ?? ''}
+                      onChange={(e) => setSelectedSubtitleTrack(Number(e.target.value))}
+                    >
+                      <option value="" disabled>
+                        Select subtitle track
+                      </option>
+                      {item.subtitleTracks.map((track) => (
+                        <option key={track.index} value={track.index}>
+                          {codeToFlagEmoji(track.language)} {getTrackLabel(track)}
+                        </option>
+                      ))}
+                    </Select>
+                  </div>
+                ) : null}
+              </div>
+            ) : null}
+
             <div className="flex flex-wrap gap-3">
               <Button onClick={() => setShowPlayer((current) => !current)}>
                 {showPlayer ? 'Hide player' : 'Watch now'}
               </Button>
-              <Button variant="secondary" onClick={() => window.location.assign(buildApiUrl(addPlaylistLocalQuery(`playlist/media-item/${item.id}`)))}>
+              <Button variant="secondary" onClick={handleWatchInVlc}>
                 Watch in VLC
               </Button>
             </div>

--- a/frontend/src/lib/playlist.ts
+++ b/frontend/src/lib/playlist.ts
@@ -16,3 +16,29 @@ export function addPlaylistLocalQuery(path: string): string {
   return path.includes('?') ? `${path}&local=true` : `${path}?local=true`;
 }
 
+/**
+ * Appends audioTrackId and subtitleTrackId query parameters to a playlist path,
+ * but only when the values are defined (i.e. more than one track is available and the user selected one).
+ */
+export function addPlaylistTrackQuery(
+  path: string,
+  audioTrackId?: number,
+  subtitleTrackId?: number,
+): string {
+  const params = new URLSearchParams();
+
+  if (audioTrackId !== undefined) {
+    params.set('audioTrackId', String(audioTrackId));
+  }
+  if (subtitleTrackId !== undefined) {
+    params.set('subtitleTrackId', String(subtitleTrackId));
+  }
+
+  const queryString = params.toString();
+  if (!queryString) {
+    return path;
+  }
+
+  return path.includes('?') ? `${path}&${queryString}` : `${path}?${queryString}`;
+}
+


### PR DESCRIPTION
This PR addresses issue #110 by adding backend and frontend support for the new audio and subtitle track selection options. If a media file has more than one audio track / subtitle track, new dropdown choosers will be shown on the media item detail page (only when showing a single media item - this option is not yet available on the group page). Users should be able to choose audio track and subtitle track, and these values should be used when generating the VLC playlist for that item.

This feature will only work with the "Watch in VLC" option. The HTML 5 inline video player does not support this ability :(