### PR TITLE
Issue #112 - track metadata cache

### DIFF
--- a/backend/src/main/java/ca/corbett/movienight/api/util/TrackMetadataCache.java
+++ b/backend/src/main/java/ca/corbett/movienight/api/util/TrackMetadataCache.java
@@ -1,0 +1,75 @@
+package ca.corbett.movienight.api.util;
+
+import java.io.File;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A package-internal class that manages an in-memory, least-recently-used
+ * cache of a fixed size for TrackMetadata objects. This is used internally
+ * by TrackMetadataUtil to avoid unnecessary I/O and JSON parsing for
+ * frequently accessed media items.
+ * <p>
+ * This cache is thread-safe.
+ * </p>
+ *
+ * @author <a href="https://github.com/scorbo2">scorbo2</a>
+ */
+class TrackMetadataCache {
+
+    private static final int CACHE_SIZE = 1024; // We could add this to AppConfig, but eh....
+
+    private final Set<File> cacheKeys = new LinkedHashSet<>(CACHE_SIZE);
+    private final Map<File, TrackMetadataUtil.MetadataWrapper> cache = new java.util.HashMap<>(CACHE_SIZE);
+
+    public synchronized int size() {
+        return cache.size();
+    }
+
+    public synchronized void clear() {
+        cacheKeys.clear();
+        cache.clear();
+    }
+
+    /**
+     * Returns the TrackMetadata for the given cacheKey if present, or null if not in cache.
+     * If the key is present, it is marked as being recently accessed. This saves it from being
+     * evicted if the cache overflows.
+     */
+    public synchronized TrackMetadataUtil.MetadataWrapper get(File cacheKey) {
+        if (cache.containsKey(cacheKey)) {
+            // Move this key to the end of the access order:
+            cacheKeys.remove(cacheKey);
+            cacheKeys.add(cacheKey);
+            return cache.get(cacheKey);
+        }
+        return null;
+    }
+
+    /**
+     * Adds the given TrackMetadata to the cache, or updates the existing entry if the key is already present.
+     * If this addition would result in the cache overflowing, the least recently used entry is evicted to make room.
+     */
+    public synchronized void put(File cacheKey, TrackMetadataUtil.MetadataWrapper metadata) {
+        // Do we already have this one?
+        // Side effect: if we do, this marks it as recently accessed.
+        if (get(cacheKey) != null) {
+            // Update the existing value and we're done:
+            cache.put(cacheKey, metadata);
+            return;
+        }
+
+        // Check for cache overflow:
+        if (cache.size() >= CACHE_SIZE) {
+            // Evict the least recently used entry:
+            File lruKey = cacheKeys.iterator().next();
+            cacheKeys.remove(lruKey);
+            cache.remove(lruKey);
+        }
+
+        // Now we can add this guy:
+        cacheKeys.add(cacheKey);
+        cache.put(cacheKey, metadata);
+    }
+}

--- a/backend/src/main/java/ca/corbett/movienight/api/util/TrackMetadataUtil.java
+++ b/backend/src/main/java/ca/corbett/movienight/api/util/TrackMetadataUtil.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.File;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
 
@@ -27,6 +28,9 @@ public class TrackMetadataUtil {
      * ObjectMapper is thread-safe and reusable, so we can use a single static instance for the whole class.
      */
     private static final ObjectMapper objectMapper = JsonSupport.getObjectMapper();
+
+    private static final TrackMetadataCache cache = new TrackMetadataCache();
+
     private TrackMetadataUtil() {
     }
 
@@ -46,36 +50,51 @@ public class TrackMetadataUtil {
         }
         File mediaFile = mediaPath.toFile();
 
-        // Then we have to compute the expected sidecar file:
-        File parentDir = mediaFile.getParentFile();
-        if (parentDir == null) {
-            return;
-        }
-        File sidecarFile = new File(parentDir, mediaFile.getName() + ".tracks.json");
+        // If we've already parsed this one, just look it up in cache:
+        MetadataWrapper wrapper = cache.get(mediaFile);
+        if (wrapper == null) {
+            // This one is either new, or it's been evicted from our cache. Okay.
+            // Then we have to compute the expected sidecar file:
+            File parentDir = mediaFile.getParentFile();
+            if (parentDir == null) {
+                return;
+            }
+            File sidecarFile = new File(parentDir, mediaFile.getName() + ".tracks.json");
 
-        // If it doesn't exist, we're done here:
-        if (!sidecarFile.exists()) {
-            return;
+            // If it doesn't exist, we're done here:
+            // This is not an error condition. It just means there's legitimately no track metadata for this item.
+            if (!sidecarFile.exists()) {
+                return;
+            }
+
+            // Otherwise, try to parse it using our expected wrapper format:
+            try {
+                wrapper = objectMapper.readValue(sidecarFile, MetadataWrapper.class);
+            }
+            catch (Exception e) {
+                // If parsing fails for any reason, just log it and move on - we don't want to break
+                // the whole API just because of a bad sidecar file.
+                log.warning("Failed to parse track metadata sidecar file: "
+                                    + sidecarFile.getAbsolutePath() + " - " + e.getMessage());
+                return;
+            }
+
+            // Add this one to our cache so we don't have to load it again next time:
+            cache.put(mediaFile, wrapper);
         }
 
-        // Otherwise, try to parse it using our expected wrapper format:
-        try {
-            MetadataWrapper wrapper = objectMapper.readValue(sidecarFile, MetadataWrapper.class);
-            item.setAudioTracks(wrapper.audioTracks);
-            item.setSubtitleTracks(wrapper.subtitleTracks);
-        } catch (Exception e) {
-            // If parsing fails for any reason, just log it and move on - we don't want to break
-            // the whole API just because of a bad sidecar file.
-            log.warning("Failed to parse track metadata sidecar file: "
-                                + sidecarFile.getAbsolutePath() + " - " + e.getMessage());
-        }
+        // Populate the item with the track metadata:
+        List<TrackMetadata> audioTracks = wrapper.getAudioTracks();
+        List<TrackMetadata> subtitleTracks = wrapper.getSubtitleTracks();
+        item.setAudioTracks(audioTracks == null ? null : new ArrayList<>(audioTracks)); // defensive copy
+        item.setSubtitleTracks(subtitleTracks == null ? null : new ArrayList<>(subtitleTracks)); // defensive copy
     }
 
     /**
      * The expected format of our track metadata sidecar JSON file.
      */
     @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
-    private static class MetadataWrapper {
+    static class MetadataWrapper {
         @JsonProperty("file")
         String filename;
 


### PR DESCRIPTION
This PR addresses issue #112 by adding a simple in-memory LRU cache for track metadata objects, to minimize unnecessary I/O on repeated item retrieval. The cache size is currently not configurable, but could easily be made so in a future ticket.